### PR TITLE
feat: add in-memory repair schedule backend

### DIFF
--- a/backend/Controllers/RepairSchedulesController.cs
+++ b/backend/Controllers/RepairSchedulesController.cs
@@ -1,0 +1,106 @@
+using Microsoft.AspNetCore.Mvc;
+using AutomotiveClaimsApi.Models;
+using AutomotiveClaimsApi.DTOs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AutomotiveClaimsApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class RepairSchedulesController : ControllerBase
+    {
+        private static readonly List<RepairSchedule> _schedules = new();
+
+        [HttpGet]
+        public ActionResult<IEnumerable<RepairScheduleDto>> GetSchedules([FromQuery] Guid? eventId)
+        {
+            var query = _schedules.AsEnumerable();
+            if (eventId.HasValue)
+            {
+                query = query.Where(s => s.EventId == eventId.Value);
+            }
+
+            return Ok(query.Select(RepairScheduleDto.FromModel));
+        }
+
+        [HttpGet("{id}")]
+        public ActionResult<RepairScheduleDto> GetSchedule(Guid id)
+        {
+            var schedule = _schedules.FirstOrDefault(s => s.Id == id);
+            if (schedule == null)
+                return NotFound();
+            return Ok(RepairScheduleDto.FromModel(schedule));
+        }
+
+        [HttpPost]
+        public ActionResult<RepairScheduleDto> CreateSchedule([FromBody] CreateRepairScheduleDto createDto)
+        {
+            var schedule = new RepairSchedule
+            {
+                Id = Guid.NewGuid(),
+                EventId = createDto.EventId,
+                CompanyName = createDto.CompanyName,
+                DamageNumber = createDto.DamageNumber,
+                VehicleFleetNumber = createDto.VehicleFleetNumber,
+                VehicleRegistration = createDto.VehicleRegistration,
+                DamageDate = createDto.DamageDate,
+                DamageTime = createDto.DamageTime,
+                ExpertWaitingDate = createDto.ExpertWaitingDate,
+                AdditionalInspections = createDto.AdditionalInspections,
+                RepairStartDate = createDto.RepairStartDate,
+                RepairEndDate = createDto.RepairEndDate,
+                WhyNotOperational = createDto.WhyNotOperational,
+                AlternativeVehiclesAvailable = createDto.AlternativeVehiclesAvailable,
+                AlternativeVehiclesDescription = createDto.AlternativeVehiclesDescription,
+                ContactDispatcher = createDto.ContactDispatcher,
+                ContactManager = createDto.ContactManager,
+                Status = createDto.Status,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+
+            _schedules.Add(schedule);
+            return CreatedAtAction(nameof(GetSchedule), new { id = schedule.Id }, RepairScheduleDto.FromModel(schedule));
+        }
+
+        [HttpPut("{id}")]
+        public ActionResult<RepairScheduleDto> UpdateSchedule(Guid id, [FromBody] UpdateRepairScheduleDto updateDto)
+        {
+            var schedule = _schedules.FirstOrDefault(s => s.Id == id);
+            if (schedule == null)
+                return NotFound();
+
+            if (updateDto.CompanyName != null) schedule.CompanyName = updateDto.CompanyName;
+            if (updateDto.DamageNumber != null) schedule.DamageNumber = updateDto.DamageNumber;
+            if (updateDto.VehicleFleetNumber != null) schedule.VehicleFleetNumber = updateDto.VehicleFleetNumber;
+            if (updateDto.VehicleRegistration != null) schedule.VehicleRegistration = updateDto.VehicleRegistration;
+            if (updateDto.DamageDate != null) schedule.DamageDate = updateDto.DamageDate;
+            if (updateDto.DamageTime != null) schedule.DamageTime = updateDto.DamageTime;
+            if (updateDto.ExpertWaitingDate != null) schedule.ExpertWaitingDate = updateDto.ExpertWaitingDate;
+            if (updateDto.AdditionalInspections != null) schedule.AdditionalInspections = updateDto.AdditionalInspections;
+            if (updateDto.RepairStartDate != null) schedule.RepairStartDate = updateDto.RepairStartDate;
+            if (updateDto.RepairEndDate != null) schedule.RepairEndDate = updateDto.RepairEndDate;
+            if (updateDto.WhyNotOperational != null) schedule.WhyNotOperational = updateDto.WhyNotOperational;
+            if (updateDto.AlternativeVehiclesAvailable.HasValue) schedule.AlternativeVehiclesAvailable = updateDto.AlternativeVehiclesAvailable.Value;
+            if (updateDto.AlternativeVehiclesDescription != null) schedule.AlternativeVehiclesDescription = updateDto.AlternativeVehiclesDescription;
+            if (updateDto.ContactDispatcher != null) schedule.ContactDispatcher = updateDto.ContactDispatcher;
+            if (updateDto.ContactManager != null) schedule.ContactManager = updateDto.ContactManager;
+            if (updateDto.Status != null) schedule.Status = updateDto.Status;
+
+            schedule.UpdatedAt = DateTime.UtcNow;
+            return Ok(RepairScheduleDto.FromModel(schedule));
+        }
+
+        [HttpDelete("{id}")]
+        public IActionResult DeleteSchedule(Guid id)
+        {
+            var schedule = _schedules.FirstOrDefault(s => s.Id == id);
+            if (schedule == null)
+                return NotFound();
+            _schedules.Remove(schedule);
+            return NoContent();
+        }
+    }
+}

--- a/backend/DTOs/CreateRepairScheduleDto.cs
+++ b/backend/DTOs/CreateRepairScheduleDto.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class CreateRepairScheduleDto
+    {
+        public Guid EventId { get; set; }
+        public string? CompanyName { get; set; }
+        public string? DamageNumber { get; set; }
+        public string? VehicleFleetNumber { get; set; }
+        public string? VehicleRegistration { get; set; }
+        public string? DamageDate { get; set; }
+        public string? DamageTime { get; set; }
+        public string? ExpertWaitingDate { get; set; }
+        public string? AdditionalInspections { get; set; }
+        public string? RepairStartDate { get; set; }
+        public string? RepairEndDate { get; set; }
+        public string? WhyNotOperational { get; set; }
+        public bool AlternativeVehiclesAvailable { get; set; }
+        public string? AlternativeVehiclesDescription { get; set; }
+        public string? ContactDispatcher { get; set; }
+        public string? ContactManager { get; set; }
+        public string? Status { get; set; }
+    }
+}

--- a/backend/DTOs/RepairScheduleDto.cs
+++ b/backend/DTOs/RepairScheduleDto.cs
@@ -1,0 +1,56 @@
+using System;
+using AutomotiveClaimsApi.Models;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class RepairScheduleDto
+    {
+        public Guid Id { get; set; }
+        public Guid EventId { get; set; }
+        public string? CompanyName { get; set; }
+        public string? DamageNumber { get; set; }
+        public string? VehicleFleetNumber { get; set; }
+        public string? VehicleRegistration { get; set; }
+        public string? DamageDate { get; set; }
+        public string? DamageTime { get; set; }
+        public string? ExpertWaitingDate { get; set; }
+        public string? AdditionalInspections { get; set; }
+        public string? RepairStartDate { get; set; }
+        public string? RepairEndDate { get; set; }
+        public string? WhyNotOperational { get; set; }
+        public bool AlternativeVehiclesAvailable { get; set; }
+        public string? AlternativeVehiclesDescription { get; set; }
+        public string? ContactDispatcher { get; set; }
+        public string? ContactManager { get; set; }
+        public string? Status { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+
+        public static RepairScheduleDto FromModel(RepairSchedule schedule)
+        {
+            return new RepairScheduleDto
+            {
+                Id = schedule.Id,
+                EventId = schedule.EventId,
+                CompanyName = schedule.CompanyName,
+                DamageNumber = schedule.DamageNumber,
+                VehicleFleetNumber = schedule.VehicleFleetNumber,
+                VehicleRegistration = schedule.VehicleRegistration,
+                DamageDate = schedule.DamageDate,
+                DamageTime = schedule.DamageTime,
+                ExpertWaitingDate = schedule.ExpertWaitingDate,
+                AdditionalInspections = schedule.AdditionalInspections,
+                RepairStartDate = schedule.RepairStartDate,
+                RepairEndDate = schedule.RepairEndDate,
+                WhyNotOperational = schedule.WhyNotOperational,
+                AlternativeVehiclesAvailable = schedule.AlternativeVehiclesAvailable,
+                AlternativeVehiclesDescription = schedule.AlternativeVehiclesDescription,
+                ContactDispatcher = schedule.ContactDispatcher,
+                ContactManager = schedule.ContactManager,
+                Status = schedule.Status,
+                CreatedAt = schedule.CreatedAt,
+                UpdatedAt = schedule.UpdatedAt
+            };
+        }
+    }
+}

--- a/backend/DTOs/UpdateRepairScheduleDto.cs
+++ b/backend/DTOs/UpdateRepairScheduleDto.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class UpdateRepairScheduleDto
+    {
+        public string? CompanyName { get; set; }
+        public string? DamageNumber { get; set; }
+        public string? VehicleFleetNumber { get; set; }
+        public string? VehicleRegistration { get; set; }
+        public string? DamageDate { get; set; }
+        public string? DamageTime { get; set; }
+        public string? ExpertWaitingDate { get; set; }
+        public string? AdditionalInspections { get; set; }
+        public string? RepairStartDate { get; set; }
+        public string? RepairEndDate { get; set; }
+        public string? WhyNotOperational { get; set; }
+        public bool? AlternativeVehiclesAvailable { get; set; }
+        public string? AlternativeVehiclesDescription { get; set; }
+        public string? ContactDispatcher { get; set; }
+        public string? ContactManager { get; set; }
+        public string? Status { get; set; }
+    }
+}

--- a/backend/Models/RepairSchedule.cs
+++ b/backend/Models/RepairSchedule.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class RepairSchedule
+    {
+        public Guid Id { get; set; }
+        public Guid EventId { get; set; }
+        public string? CompanyName { get; set; }
+        public string? DamageNumber { get; set; }
+        public string? VehicleFleetNumber { get; set; }
+        public string? VehicleRegistration { get; set; }
+        public string? DamageDate { get; set; }
+        public string? DamageTime { get; set; }
+        public string? ExpertWaitingDate { get; set; }
+        public string? AdditionalInspections { get; set; }
+        public string? RepairStartDate { get; set; }
+        public string? RepairEndDate { get; set; }
+        public string? WhyNotOperational { get; set; }
+        public bool AlternativeVehiclesAvailable { get; set; }
+        public string? AlternativeVehiclesDescription { get; set; }
+        public string? ContactDispatcher { get; set; }
+        public string? ContactManager { get; set; }
+        public string? Status { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add RepairSchedule model and DTOs
- implement in-memory RepairSchedulesController

## Testing
- `dotnet build backend/AutomotiveClaimsApi.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894da763690832c8722dd6e4435a55d