### PR TITLE
feat: add upsert dtos for secondary claim data

### DIFF
--- a/backend/Controllers/EventsController.cs
+++ b/backend/Controllers/EventsController.cs
@@ -168,6 +168,54 @@ namespace AutomotiveClaimsApi.Controllers
                     }
                 }
 
+                if (eventDto.Damages != null)
+                {
+                    foreach (var dDto in eventDto.Damages)
+                    {
+                        _context.Damages.Add(MapDamageDtoToModel(dDto, eventEntity.Id));
+                    }
+                }
+
+                if (eventDto.Decisions != null)
+                {
+                    foreach (var dDto in eventDto.Decisions)
+                    {
+                        _context.Decisions.Add(MapDecisionDtoToModel(dDto, eventEntity.Id));
+                    }
+                }
+
+                if (eventDto.Appeals != null)
+                {
+                    foreach (var aDto in eventDto.Appeals)
+                    {
+                        _context.Appeals.Add(MapAppealDtoToModel(aDto, eventEntity.Id));
+                    }
+                }
+
+                if (eventDto.ClientClaims != null)
+                {
+                    foreach (var cDto in eventDto.ClientClaims)
+                    {
+                        _context.ClientClaims.Add(MapClientClaimDtoToModel(cDto, eventEntity.Id));
+                    }
+                }
+
+                if (eventDto.Recourses != null)
+                {
+                    foreach (var rDto in eventDto.Recourses)
+                    {
+                        _context.Recourses.Add(MapRecourseDtoToModel(rDto, eventEntity.Id));
+                    }
+                }
+
+                if (eventDto.Settlements != null)
+                {
+                    foreach (var sDto in eventDto.Settlements)
+                    {
+                        _context.Settlements.Add(MapSettlementDtoToModel(sDto, eventEntity.Id));
+                    }
+                }
+
                 await _context.SaveChangesAsync();
 
                 // Reload the entity with all related data
@@ -201,6 +249,12 @@ namespace AutomotiveClaimsApi.Controllers
             {
                 var eventEntity = await _context.Events
                     .Include(e => e.Participants).ThenInclude(p => p.Drivers)
+                    .Include(e => e.Damages)
+                    .Include(e => e.Decisions)
+                    .Include(e => e.Appeals)
+                    .Include(e => e.ClientClaims)
+                    .Include(e => e.Recourses)
+                    .Include(e => e.Settlements)
                     .FirstOrDefaultAsync(e => e.Id == id);
 
                 if (eventEntity == null)
@@ -211,10 +265,16 @@ namespace AutomotiveClaimsApi.Controllers
                 MapUpsertDtoToEvent(eventDto, eventEntity);
                 eventEntity.UpdatedAt = DateTime.UtcNow;
 
-                // Remove existing participants and drivers
+                // Remove existing related entities
                 var existingDrivers = eventEntity.Participants.SelectMany(p => p.Drivers).ToList();
                 _context.Drivers.RemoveRange(existingDrivers);
                 _context.Participants.RemoveRange(eventEntity.Participants);
+                _context.Damages.RemoveRange(eventEntity.Damages);
+                _context.Decisions.RemoveRange(eventEntity.Decisions);
+                _context.Appeals.RemoveRange(eventEntity.Appeals);
+                _context.ClientClaims.RemoveRange(eventEntity.ClientClaims);
+                _context.Recourses.RemoveRange(eventEntity.Recourses);
+                _context.Settlements.RemoveRange(eventEntity.Settlements);
 
                 // Add new participants
                 if (eventDto.Participants != null)
@@ -230,6 +290,54 @@ namespace AutomotiveClaimsApi.Controllers
                                 _context.Drivers.Add(MapDriverDtoToModel(dDto, eventEntity.Id, participant.Id));
                             }
                         }
+                    }
+                }
+
+                if (eventDto.Damages != null)
+                {
+                    foreach (var dDto in eventDto.Damages)
+                    {
+                        _context.Damages.Add(MapDamageDtoToModel(dDto, eventEntity.Id));
+                    }
+                }
+
+                if (eventDto.Decisions != null)
+                {
+                    foreach (var dDto in eventDto.Decisions)
+                    {
+                        _context.Decisions.Add(MapDecisionDtoToModel(dDto, eventEntity.Id));
+                    }
+                }
+
+                if (eventDto.Appeals != null)
+                {
+                    foreach (var aDto in eventDto.Appeals)
+                    {
+                        _context.Appeals.Add(MapAppealDtoToModel(aDto, eventEntity.Id));
+                    }
+                }
+
+                if (eventDto.ClientClaims != null)
+                {
+                    foreach (var cDto in eventDto.ClientClaims)
+                    {
+                        _context.ClientClaims.Add(MapClientClaimDtoToModel(cDto, eventEntity.Id));
+                    }
+                }
+
+                if (eventDto.Recourses != null)
+                {
+                    foreach (var rDto in eventDto.Recourses)
+                    {
+                        _context.Recourses.Add(MapRecourseDtoToModel(rDto, eventEntity.Id));
+                    }
+                }
+
+                if (eventDto.Settlements != null)
+                {
+                    foreach (var sDto in eventDto.Settlements)
+                    {
+                        _context.Settlements.Add(MapSettlementDtoToModel(sDto, eventEntity.Id));
                     }
                 }
 
@@ -381,6 +489,133 @@ namespace AutomotiveClaimsApi.Controllers
                 IsMainDriver = dto.IsMainDriver,
                 UpdatedAt = DateTime.UtcNow,
                 CreatedAt = DateTime.UtcNow // Simplified
+            };
+        }
+
+        private static Damage MapDamageDtoToModel(DamageUpsertDto dto, Guid eventId)
+        {
+            return new Damage
+            {
+                Id = Guid.NewGuid(),
+                EventId = dto.EventId ?? eventId,
+                Description = dto.Description,
+                Detail = dto.Detail,
+                Location = dto.Location,
+                Severity = dto.Severity,
+                EstimatedCost = dto.EstimatedCost,
+                ActualCost = dto.ActualCost,
+                RepairStatus = dto.RepairStatus,
+                RepairDate = dto.RepairDate,
+                RepairShop = dto.RepairShop,
+                Notes = dto.Notes,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+        }
+
+        private static Decision MapDecisionDtoToModel(DecisionUpsertDto dto, Guid eventId)
+        {
+            return new Decision
+            {
+                Id = Guid.NewGuid(),
+                EventId = dto.EventId ?? eventId,
+                DecisionDate = dto.DecisionDate,
+                DecisionType = dto.DecisionType,
+                DecisionDescription = dto.DecisionDescription,
+                DecisionAmount = dto.DecisionAmount,
+                DecisionStatus = dto.DecisionStatus,
+                DecisionNumber = dto.DecisionNumber,
+                Description = dto.Description,
+                Reason = dto.Reason,
+                Notes = dto.Notes,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+        }
+
+        private static Appeal MapAppealDtoToModel(AppealUpsertDto dto, Guid eventId)
+        {
+            return new Appeal
+            {
+                Id = Guid.NewGuid(),
+                EventId = dto.EventId ?? eventId,
+                AppealNumber = dto.AppealNumber,
+                SubmissionDate = dto.SubmissionDate ?? DateTime.UtcNow,
+                Reason = dto.Reason,
+                Status = dto.Status,
+                Notes = dto.Notes,
+                Description = dto.Description,
+                AppealAmount = dto.AppealAmount,
+                DecisionDate = dto.DecisionDate,
+                DecisionReason = dto.DecisionReason,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+        }
+
+        private static ClientClaim MapClientClaimDtoToModel(ClientClaimUpsertDto dto, Guid eventId)
+        {
+            return new ClientClaim
+            {
+                Id = Guid.NewGuid(),
+                EventId = dto.EventId ?? eventId,
+                ClaimNumber = dto.ClaimNumber,
+                ClaimDate = dto.ClaimDate,
+                ClaimType = dto.ClaimType,
+                ClaimAmount = dto.ClaimAmount,
+                Currency = dto.Currency,
+                Status = dto.Status,
+                Description = dto.Description,
+                DocumentPath = dto.DocumentPath,
+                DocumentName = dto.DocumentName,
+                DocumentDescription = dto.DocumentDescription,
+                ClaimNotes = dto.ClaimNotes,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+        }
+
+        private static Recourse MapRecourseDtoToModel(RecourseUpsertDto dto, Guid eventId)
+        {
+            return new Recourse
+            {
+                Id = Guid.NewGuid(),
+                EventId = dto.EventId ?? eventId,
+                Status = dto.Status,
+                InitiationDate = dto.InitiationDate,
+                Description = dto.Description,
+                Notes = dto.Notes,
+                RecourseNumber = dto.RecourseNumber,
+                RecourseAmount = dto.RecourseAmount,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+        }
+
+        private static Settlement MapSettlementDtoToModel(SettlementUpsertDto dto, Guid eventId)
+        {
+            return new Settlement
+            {
+                Id = Guid.NewGuid(),
+                EventId = dto.EventId ?? eventId,
+                SettlementNumber = dto.SettlementNumber,
+                SettlementType = dto.SettlementType,
+                ExternalEntity = dto.ExternalEntity,
+                CustomExternalEntity = dto.CustomExternalEntity,
+                TransferDate = dto.TransferDate,
+                Status = dto.Status,
+                SettlementDate = dto.SettlementDate,
+                Amount = dto.Amount,
+                SettlementAmount = dto.SettlementAmount,
+                Currency = dto.Currency,
+                PaymentMethod = dto.PaymentMethod,
+                Notes = dto.Notes,
+                Description = dto.Description,
+                DocumentPath = dto.DocumentPath,
+                DocumentName = dto.DocumentName,
+                DocumentDescription = dto.DocumentDescription,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
             };
         }
 

--- a/backend/DTOs/AppealUpsertDto.cs
+++ b/backend/DTOs/AppealUpsertDto.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class AppealUpsertDto
+    {
+        public Guid? EventId { get; set; }
+        public string? AppealNumber { get; set; }
+        public DateTime? SubmissionDate { get; set; }
+        public string? Reason { get; set; }
+        public string? Status { get; set; }
+        public string? Notes { get; set; }
+        public string? Description { get; set; }
+        public decimal? AppealAmount { get; set; }
+        public DateTime? DecisionDate { get; set; }
+        public string? DecisionReason { get; set; }
+    }
+}

--- a/backend/DTOs/ClientClaimUpsertDto.cs
+++ b/backend/DTOs/ClientClaimUpsertDto.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class ClientClaimUpsertDto
+    {
+        public Guid? EventId { get; set; }
+        public string? ClaimNumber { get; set; }
+        public DateTime? ClaimDate { get; set; }
+        public string? ClaimType { get; set; }
+        public decimal? ClaimAmount { get; set; }
+        public string? Currency { get; set; }
+        public string? Status { get; set; }
+        public string? Description { get; set; }
+        public string? DocumentPath { get; set; }
+        public string? DocumentName { get; set; }
+        public string? DocumentDescription { get; set; }
+        public string? ClaimNotes { get; set; }
+    }
+}

--- a/backend/DTOs/DecisionUpsertDto.cs
+++ b/backend/DTOs/DecisionUpsertDto.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class DecisionUpsertDto
+    {
+        public Guid? EventId { get; set; }
+        public DateTime? DecisionDate { get; set; }
+        public string? DecisionType { get; set; }
+        public string? DecisionDescription { get; set; }
+        public decimal? DecisionAmount { get; set; }
+        public string? DecisionStatus { get; set; }
+        public string? DecisionNumber { get; set; }
+        public string? Description { get; set; }
+        public string? Reason { get; set; }
+        public string? Notes { get; set; }
+    }
+}

--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -124,5 +124,11 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Description { get; set; }
 
         public ICollection<ParticipantUpsertDto>? Participants { get; set; }
+        public ICollection<DamageUpsertDto>? Damages { get; set; }
+        public ICollection<DecisionUpsertDto>? Decisions { get; set; }
+        public ICollection<AppealUpsertDto>? Appeals { get; set; }
+        public ICollection<ClientClaimUpsertDto>? ClientClaims { get; set; }
+        public ICollection<RecourseUpsertDto>? Recourses { get; set; }
+        public ICollection<SettlementUpsertDto>? Settlements { get; set; }
     }
 }

--- a/backend/DTOs/RecourseUpsertDto.cs
+++ b/backend/DTOs/RecourseUpsertDto.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class RecourseUpsertDto
+    {
+        public Guid? EventId { get; set; }
+        public string? Status { get; set; }
+        public DateTime? InitiationDate { get; set; }
+        public string? Description { get; set; }
+        public string? Notes { get; set; }
+        public string? RecourseNumber { get; set; }
+        public decimal? RecourseAmount { get; set; }
+    }
+}

--- a/backend/DTOs/SettlementUpsertDto.cs
+++ b/backend/DTOs/SettlementUpsertDto.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class SettlementUpsertDto
+    {
+        public Guid? EventId { get; set; }
+        public string? SettlementNumber { get; set; }
+        public string? SettlementType { get; set; }
+        public string? ExternalEntity { get; set; }
+        public string? CustomExternalEntity { get; set; }
+        public DateTime? TransferDate { get; set; }
+        public string? Status { get; set; }
+        public DateTime? SettlementDate { get; set; }
+        public decimal? Amount { get; set; }
+        public decimal? SettlementAmount { get; set; }
+        public string? Currency { get; set; }
+        public string? PaymentMethod { get; set; }
+        public string? Notes { get; set; }
+        public string? Description { get; set; }
+        public string? DocumentPath { get; set; }
+        public string? DocumentName { get; set; }
+        public string? DocumentDescription { get; set; }
+    }
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -52,6 +52,12 @@ export interface EventUpsertDto {
   payout?: number
   currency?: string
   participants?: ParticipantUpsertDto[]
+  damages?: DamageUpsertDto[]
+  decisions?: DecisionUpsertDto[]
+  appeals?: AppealUpsertDto[]
+  clientClaims?: ClientClaimUpsertDto[]
+  recourses?: RecourseUpsertDto[]
+  settlements?: SettlementUpsertDto[]
 }
 
 export interface ParticipantDto {
@@ -142,6 +148,20 @@ export interface DamageDto {
   status?: string
 }
 
+export interface DamageUpsertDto {
+  eventId?: string
+  description?: string
+  detail?: string
+  location?: string
+  severity?: string
+  estimatedCost?: number
+  actualCost?: number
+  repairStatus?: string
+  repairDate?: string
+  repairShop?: string
+  notes?: string
+}
+
 export interface DecisionDto {
   id?: number
   eventId?: number
@@ -151,6 +171,19 @@ export interface DecisionDto {
   amount?: number
 }
 
+export interface DecisionUpsertDto {
+  eventId?: string
+  decisionDate?: string
+  decisionType?: string
+  decisionDescription?: string
+  decisionAmount?: number
+  decisionStatus?: string
+  decisionNumber?: string
+  description?: string
+  reason?: string
+  notes?: string
+}
+
 export interface AppealDto {
   id?: number
   eventId?: number
@@ -158,6 +191,19 @@ export interface AppealDto {
   appealType?: string
   description?: string
   status?: string
+}
+
+export interface AppealUpsertDto {
+  eventId?: string
+  appealNumber?: string
+  submissionDate?: string
+  reason?: string
+  status?: string
+  notes?: string
+  description?: string
+  appealAmount?: number
+  decisionDate?: string
+  decisionReason?: string
 }
 
 export interface ClientClaimDto {
@@ -170,6 +216,21 @@ export interface ClientClaimDto {
   status?: string
 }
 
+export interface ClientClaimUpsertDto {
+  eventId?: string
+  claimNumber?: string
+  claimDate?: string
+  claimType?: string
+  claimAmount?: number
+  currency?: string
+  status?: string
+  description?: string
+  documentPath?: string
+  documentName?: string
+  documentDescription?: string
+  claimNotes?: string
+}
+
 export interface RecourseDto {
   id?: number
   eventId?: number
@@ -180,6 +241,16 @@ export interface RecourseDto {
   status?: string
 }
 
+export interface RecourseUpsertDto {
+  eventId?: string
+  status?: string
+  initiationDate?: string
+  description?: string
+  notes?: string
+  recourseNumber?: string
+  recourseAmount?: number
+}
+
 export interface SettlementDto {
   id?: number
   eventId?: number
@@ -188,6 +259,26 @@ export interface SettlementDto {
   description?: string
   amount?: number
   status?: string
+}
+
+export interface SettlementUpsertDto {
+  eventId?: string
+  settlementNumber?: string
+  settlementType?: string
+  externalEntity?: string
+  customExternalEntity?: string
+  transferDate?: string
+  status?: string
+  settlementDate?: string
+  amount?: number
+  settlementAmount?: number
+  currency?: string
+  paymentMethod?: string
+  notes?: string
+  description?: string
+  documentPath?: string
+  documentName?: string
+  documentDescription?: string
 }
 
 // API Service


### PR DESCRIPTION
## Summary
- add interfaces for damage, decision, appeal, client claim, recourse and settlement upserts
- support the new upsert types in EventUpsertDto and backend mapping
- implement backend upsert DTO classes for related claim entities

## Testing
- `npm test` *(fails: Missing script "test")*
- `dotnet build backend/AutomotiveClaimsApi.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_6894eedc2c70832caeb1e2cc45058692