### PR TITLE
Map claim arrays to API DTOs

### DIFF
--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -1,7 +1,19 @@
 "use client"
 
 import { useState, useCallback } from "react"
-import { apiService, type EventUpsertDto, type EventDto, type ParticipantUpsertDto, type EventListItemDto } from "@/lib/api"
+import {
+  apiService,
+  type EventUpsertDto,
+  type EventDto,
+  type ParticipantUpsertDto,
+  type EventListItemDto,
+  type DamageUpsertDto,
+  type DecisionUpsertDto,
+  type AppealUpsertDto,
+  type ClientClaimUpsertDto,
+  type RecourseUpsertDto,
+  type SettlementUpsertDto,
+} from "@/lib/api"
 import type { Claim, ParticipantInfo, DriverInfo } from "@/types"
 
 const transformApiClaimToFrontend = (apiClaim: EventDto): Claim => {
@@ -37,19 +49,7 @@ const transformApiClaimToFrontend = (apiClaim: EventDto): Claim => {
 }
 
 const transformFrontendClaimToApiPayload = (claimData: Partial<Claim>): EventUpsertDto => {
-  const {
-    id,
-    decisions,
-    appeals,
-    clientClaims,
-    recourses,
-    settlements,
-    damages,
-    injuredParty,
-    perpetrator,
-    servicesCalled,
-    ...rest
-  } = claimData
+  const { id, injuredParty, perpetrator, servicesCalled, ...rest } = claimData
 
   const participants: ParticipantUpsertDto[] = []
 
@@ -97,14 +97,74 @@ const transformFrontendClaimToApiPayload = (claimData: Partial<Claim>): EventUps
     participants.push(mapParticipant(perpetrator, "Sprawca"))
   }
 
+  const mapDate = (date?: string) => (date ? new Date(date).toISOString() : undefined)
+
+  const damagesDto: DamageUpsertDto[] | undefined = rest.damages?.map((d: any) => ({
+    id: d.id ? parseInt(d.id) : undefined,
+    description: d.description,
+    detail: d.detail,
+  }))
+
+  const decisionsDto: DecisionUpsertDto[] | undefined = rest.decisions?.map((d: any) => ({
+    id: d.id ? parseInt(d.id) : undefined,
+    decisionDate: mapDate(d.decisionDate),
+    decisionType: d.decisionType,
+    description: d.description,
+    amount: d.amount,
+    status: d.status,
+  }))
+
+  const appealsDto: AppealUpsertDto[] | undefined = rest.appeals?.map((a: any) => ({
+    id: a.id ? parseInt(a.id) : undefined,
+    appealDate: mapDate(a.appealDate),
+    appealType: a.appealType,
+    description: a.description,
+    status: a.status,
+    amount: a.amount,
+  }))
+
+  const clientClaimsDto: ClientClaimUpsertDto[] | undefined = rest.clientClaims?.map((c: any) => ({
+    id: c.id ? parseInt(c.id) : undefined,
+    claimDate: mapDate(c.claimDate),
+    claimType: c.claimType,
+    description: c.description,
+    amount: c.amount,
+    status: c.status,
+    currency: c.currency,
+  }))
+
+  const recoursesDto: RecourseUpsertDto[] | undefined = rest.recourses?.map((r: any) => ({
+    id: r.id ? parseInt(r.id) : undefined,
+    recourseDate: mapDate(r.recourseDate),
+    recourseType: r.recourseType,
+    description: r.description,
+    amount: r.amount,
+    status: r.status,
+  }))
+
+  const settlementsDto: SettlementUpsertDto[] | undefined = rest.settlements?.map((s: any) => ({
+    id: s.id ? parseInt(s.id) : undefined,
+    settlementDate: mapDate(s.settlementDate),
+    settlementType: s.settlementType,
+    description: s.description,
+    amount: s.amount,
+    status: s.status,
+  }))
+
   return {
     ...rest,
-    damageDate: rest.damageDate ? new Date(rest.damageDate).toISOString() : undefined,
-    reportDate: rest.reportDate ? new Date(rest.reportDate).toISOString() : undefined,
-    reportDateToInsurer: rest.reportDateToInsurer ? new Date(rest.reportDateToInsurer).toISOString() : undefined,
+    damageDate: mapDate(rest.damageDate),
+    reportDate: mapDate(rest.reportDate),
+    reportDateToInsurer: mapDate(rest.reportDateToInsurer),
     eventTime: rest.eventTime,
     servicesCalled: servicesCalled?.join(","),
     participants: participants,
+    damages: damagesDto,
+    decisions: decisionsDto,
+    appeals: appealsDto,
+    clientClaims: clientClaimsDto,
+    recourses: recoursesDto,
+    settlements: settlementsDto,
   }
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -52,6 +52,12 @@ export interface EventUpsertDto {
   payout?: number
   currency?: string
   participants?: ParticipantUpsertDto[]
+  damages?: DamageUpsertDto[]
+  decisions?: DecisionUpsertDto[]
+  appeals?: AppealUpsertDto[]
+  clientClaims?: ClientClaimUpsertDto[]
+  recourses?: RecourseUpsertDto[]
+  settlements?: SettlementUpsertDto[]
 }
 
 export interface ParticipantDto {
@@ -142,6 +148,12 @@ export interface DamageDto {
   status?: string
 }
 
+export interface DamageUpsertDto {
+  id?: number
+  description: string
+  detail?: string
+}
+
 export interface DecisionDto {
   id?: number
   eventId?: number
@@ -151,6 +163,15 @@ export interface DecisionDto {
   amount?: number
 }
 
+export interface DecisionUpsertDto {
+  id?: number
+  decisionDate?: string
+  decisionType?: string
+  description?: string
+  amount?: number
+  status?: string
+}
+
 export interface AppealDto {
   id?: number
   eventId?: number
@@ -158,6 +179,15 @@ export interface AppealDto {
   appealType?: string
   description?: string
   status?: string
+}
+
+export interface AppealUpsertDto {
+  id?: number
+  appealDate?: string
+  appealType?: string
+  description?: string
+  status?: string
+  amount?: number
 }
 
 export interface ClientClaimDto {
@@ -170,6 +200,16 @@ export interface ClientClaimDto {
   status?: string
 }
 
+export interface ClientClaimUpsertDto {
+  id?: number
+  claimDate?: string
+  claimType?: string
+  description?: string
+  amount?: number
+  status?: string
+  currency?: number
+}
+
 export interface RecourseDto {
   id?: number
   eventId?: number
@@ -180,9 +220,27 @@ export interface RecourseDto {
   status?: string
 }
 
+export interface RecourseUpsertDto {
+  id?: number
+  recourseDate?: string
+  recourseType?: string
+  description?: string
+  amount?: number
+  status?: string
+}
+
 export interface SettlementDto {
   id?: number
   eventId?: number
+  settlementDate?: string
+  settlementType?: string
+  description?: string
+  amount?: number
+  status?: string
+}
+
+export interface SettlementUpsertDto {
+  id?: number
   settlementDate?: string
   settlementType?: string
   description?: string


### PR DESCRIPTION
## Summary
- include claim arrays in EventUpsertDto and define *UpsertDto interfaces
- map claim form arrays to API DTOs with date conversions

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6894eeda5ce0832c836f51d4a89fa3ba