### PR TITLE
Store uploaded document references in claim payload

### DIFF
--- a/backend/Controllers/EventsController.cs
+++ b/backend/Controllers/EventsController.cs
@@ -152,6 +152,17 @@ namespace AutomotiveClaimsApi.Controllers
 
                 _context.Events.Add(eventEntity);
 
+                if (eventDto.Documents != null && eventDto.Documents.Any())
+                {
+                    var documentIds = eventDto.Documents.Select(d => d.Id).ToList();
+                    var documents = await _context.Documents.Where(d => documentIds.Contains(d.Id)).ToListAsync();
+                    foreach (var doc in documents)
+                    {
+                        doc.EventId = eventEntity.Id;
+                        doc.UpdatedAt = DateTime.UtcNow;
+                    }
+                }
+
                 if (eventDto.Participants != null)
                 {
                     foreach (var pDto in eventDto.Participants)
@@ -230,6 +241,17 @@ namespace AutomotiveClaimsApi.Controllers
                                 _context.Drivers.Add(MapDriverDtoToModel(dDto, eventEntity.Id, participant.Id));
                             }
                         }
+                    }
+                }
+
+                if (eventDto.Documents != null && eventDto.Documents.Any())
+                {
+                    var documentIds = eventDto.Documents.Select(d => d.Id).ToList();
+                    var documents = await _context.Documents.Where(d => documentIds.Contains(d.Id)).ToListAsync();
+                    foreach (var doc in documents)
+                    {
+                        doc.EventId = eventEntity.Id;
+                        doc.UpdatedAt = DateTime.UtcNow;
                     }
                 }
 

--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -124,5 +124,6 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Description { get; set; }
 
         public ICollection<ParticipantUpsertDto>? Participants { get; set; }
+        public ICollection<DocumentDto>? Documents { get; set; }
     }
 }

--- a/components/claim-form/claim-form.tsx
+++ b/components/claim-form/claim-form.tsx
@@ -118,15 +118,17 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    
+
     try {
+      const payload = { ...formData, documents: uploadedFiles }
+
       if (mode === 'create') {
-        const result = await createClaim(formData)
+        const result = await createClaim(payload)
         if (result) {
           router.push(`/claims/${result.id}/view`)
         }
       } else if (mode === 'edit' && formData.id) {
-        const result = await updateClaim(formData.id, formData)
+        const result = await updateClaim(formData.id, payload)
         if (result) {
           router.push(`/claims/${result.id}/view`)
         }

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -10,7 +10,7 @@ import { File, Search, Filter, Eye, Download, Upload, X, Trash2, Grid, List, Wan
 import type { DocumentsSectionProps } from "@/types"
 
 interface Document {
-  id: number
+  id: string
   eventId?: number
   damageId?: number
   fileName: string
@@ -216,6 +216,25 @@ export const DocumentsSection = ({
 
       if (successfulUploads.length > 0) {
         setDocuments((prev) => [...prev, ...successfulUploads])
+        setUploadedFiles((prev) => [
+          ...prev,
+          ...successfulUploads.map((doc) => ({
+            id: doc.id.toString(),
+            name: doc.originalFileName || doc.fileName,
+            size: doc.fileSize,
+            type: doc.contentType.includes("image")
+              ? "image"
+              : doc.contentType.includes("pdf")
+              ? "pdf"
+              : doc.contentType.includes("msword") || doc.contentType.includes("wordprocessingml")
+              ? "doc"
+              : "other",
+            uploadedAt: doc.createdAt,
+            url: doc.filePath,
+            category: doc.documentType,
+            description: doc.description,
+          })),
+        ])
         toast({
           title: "Przesłano pliki",
           description: `Pomyślnie dodano ${successfulUploads.length} plik(ów) do kategorii "${category}".`,

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -48,6 +48,7 @@ const transformFrontendClaimToApiPayload = (claimData: Partial<Claim>): EventUps
     injuredParty,
     perpetrator,
     servicesCalled,
+    documents,
     ...rest
   } = claimData
 
@@ -105,6 +106,7 @@ const transformFrontendClaimToApiPayload = (claimData: Partial<Claim>): EventUps
     eventTime: rest.eventTime,
     servicesCalled: servicesCalled?.join(","),
     participants: participants,
+    documents: documents?.map((d) => ({ id: d.id, filePath: d.url })),
   }
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -33,6 +33,11 @@ export interface EventDto extends EventListItemDto {
   settlements?: SettlementDto[]
 }
 
+export interface DocumentDto {
+  id?: string
+  filePath?: string
+}
+
 export interface EventUpsertDto {
   spartaNumber?: string
   claimNumber?: string
@@ -52,6 +57,7 @@ export interface EventUpsertDto {
   payout?: number
   currency?: string
   participants?: ParticipantUpsertDto[]
+  documents?: DocumentDto[]
 }
 
 export interface ParticipantDto {

--- a/types/index.ts
+++ b/types/index.ts
@@ -55,6 +55,7 @@ export interface Claim {
   vehicleNumber?: string
   location?: string
   description?: string
+  documents?: UploadedFile[]
   documentsSectionProps?: DocumentsSectionProps
 }
 


### PR DESCRIPTION
## Summary
- Track uploaded document IDs/paths in claim form state
- Include documents array when transforming claim data to API payload
- Extend EventUpsertDto with documents and link them in EventsController

## Testing
- `pnpm lint` *(fails: If you set up ESLint yourself, we recommend adding the Next.js ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6894eede9ff4832cb1addcda81bd1db5