### PR TITLE
Add Note and Email upsert DTOs and event mapping

### DIFF
--- a/backend/Controllers/EventsController.cs
+++ b/backend/Controllers/EventsController.cs
@@ -168,6 +168,22 @@ namespace AutomotiveClaimsApi.Controllers
                     }
                 }
 
+                if (eventDto.Notes != null)
+                {
+                    foreach (var nDto in eventDto.Notes)
+                    {
+                        _context.Notes.Add(MapNoteDtoToModel(nDto, eventEntity.Id));
+                    }
+                }
+
+                if (eventDto.Emails != null)
+                {
+                    foreach (var eDto in eventDto.Emails)
+                    {
+                        _context.Emails.Add(MapEmailDtoToModel(eDto, eventEntity.Id));
+                    }
+                }
+
                 await _context.SaveChangesAsync();
 
                 // Reload the entity with all related data
@@ -216,6 +232,12 @@ namespace AutomotiveClaimsApi.Controllers
                 _context.Drivers.RemoveRange(existingDrivers);
                 _context.Participants.RemoveRange(eventEntity.Participants);
 
+                var existingNotes = await _context.Notes.Where(n => n.EventId == eventEntity.Id).ToListAsync();
+                _context.Notes.RemoveRange(existingNotes);
+
+                var existingEmails = await _context.Emails.Where(e => e.EventId == eventEntity.Id).ToListAsync();
+                _context.Emails.RemoveRange(existingEmails);
+
                 // Add new participants
                 if (eventDto.Participants != null)
                 {
@@ -230,6 +252,22 @@ namespace AutomotiveClaimsApi.Controllers
                                 _context.Drivers.Add(MapDriverDtoToModel(dDto, eventEntity.Id, participant.Id));
                             }
                         }
+                    }
+                }
+
+                if (eventDto.Notes != null)
+                {
+                    foreach (var nDto in eventDto.Notes)
+                    {
+                        _context.Notes.Add(MapNoteDtoToModel(nDto, eventEntity.Id));
+                    }
+                }
+
+                if (eventDto.Emails != null)
+                {
+                    foreach (var eDto in eventDto.Emails)
+                    {
+                        _context.Emails.Add(MapEmailDtoToModel(eDto, eventEntity.Id));
                     }
                 }
 
@@ -381,6 +419,61 @@ namespace AutomotiveClaimsApi.Controllers
                 IsMainDriver = dto.IsMainDriver,
                 UpdatedAt = DateTime.UtcNow,
                 CreatedAt = DateTime.UtcNow // Simplified
+            };
+        }
+
+        private static Note MapNoteDtoToModel(NoteUpsertDto dto, Guid eventId)
+        {
+            return new Note
+            {
+                Id = Guid.NewGuid(),
+                EventId = eventId,
+                Category = dto.Category,
+                Title = dto.Title,
+                Content = dto.Content,
+                CreatedBy = dto.CreatedBy,
+                UpdatedBy = dto.CreatedBy,
+                IsPrivate = dto.IsPrivate,
+                Priority = dto.Priority,
+                Tags = dto.Tags != null ? string.Join(",", dto.Tags) : null,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+        }
+
+        private static Email MapEmailDtoToModel(EmailUpsertDto dto, Guid eventId)
+        {
+            return new Email
+            {
+                Id = Guid.NewGuid(),
+                EventId = eventId,
+                From = dto.From,
+                To = dto.To,
+                Cc = dto.Cc,
+                Bcc = dto.Bcc,
+                Subject = dto.Subject,
+                Body = dto.Body,
+                BodyHtml = dto.BodyHtml,
+                IsHtml = dto.IsHtml,
+                Priority = dto.Priority,
+                Direction = dto.Direction,
+                Status = dto.Status,
+                SentAt = dto.SentAt,
+                ReceivedAt = dto.ReceivedAt,
+                ReadAt = dto.ReadAt,
+                IsRead = dto.IsRead,
+                IsImportant = dto.IsImportant,
+                IsArchived = dto.IsArchived,
+                Tags = dto.Tags,
+                Category = dto.Category,
+                ClaimId = dto.ClaimId,
+                ClaimNumber = dto.ClaimNumber,
+                ThreadId = dto.ThreadId,
+                MessageId = dto.MessageId,
+                InReplyTo = dto.InReplyTo,
+                References = dto.References,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
             };
         }
 

--- a/backend/DTOs/EmailUpsertDto.cs
+++ b/backend/DTOs/EmailUpsertDto.cs
@@ -1,0 +1,52 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class EmailUpsertDto
+    {
+        public Guid? EventId { get; set; }
+
+        [Required]
+        [EmailAddress]
+        public string From { get; set; } = string.Empty;
+
+        [Required]
+        public string To { get; set; } = string.Empty;
+
+        public string? Cc { get; set; }
+        public string? Bcc { get; set; }
+
+        [Required]
+        [StringLength(500)]
+        public string Subject { get; set; } = string.Empty;
+
+        [Required]
+        public string Body { get; set; } = string.Empty;
+
+        public string? BodyHtml { get; set; }
+
+        public bool IsHtml { get; set; } = true;
+
+        public string? Priority { get; set; }
+
+        public string Direction { get; set; } = string.Empty; // Inbound, Outbound
+
+        public string Status { get; set; } = "Draft"; // Draft, Sent, Received, Failed
+
+        public DateTime? SentAt { get; set; }
+        public DateTime? ReceivedAt { get; set; }
+        public DateTime? ReadAt { get; set; }
+        public bool IsRead { get; set; } = false;
+        public bool IsImportant { get; set; } = false;
+        public bool IsArchived { get; set; } = false;
+        public string? Tags { get; set; }
+        public string? Category { get; set; }
+        public string? ClaimId { get; set; }
+        public string? ClaimNumber { get; set; }
+        public string? ThreadId { get; set; }
+        public string? MessageId { get; set; }
+        public string? InReplyTo { get; set; }
+        public string? References { get; set; }
+    }
+}

--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -124,5 +124,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Description { get; set; }
 
         public ICollection<ParticipantUpsertDto>? Participants { get; set; }
+        public ICollection<NoteUpsertDto>? Notes { get; set; }
+        public ICollection<EmailUpsertDto>? Emails { get; set; }
     }
 }

--- a/backend/DTOs/NoteUpsertDto.cs
+++ b/backend/DTOs/NoteUpsertDto.cs
@@ -4,8 +4,7 @@ namespace AutomotiveClaimsApi.DTOs
 {
     public class NoteUpsertDto
     {
-        [Required]
-        public string EventId { get; set; } = string.Empty;
+        public string? EventId { get; set; }
 
         [StringLength(100)]
         public string? Category { get; set; }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -52,6 +52,47 @@ export interface EventUpsertDto {
   payout?: number
   currency?: string
   participants?: ParticipantUpsertDto[]
+  notes?: NoteUpsertDto[]
+  emails?: EmailUpsertDto[]
+}
+
+export interface NoteUpsertDto {
+  eventId?: string
+  category?: string
+  title?: string
+  content: string
+  createdBy?: string
+  isPrivate?: boolean
+  priority?: string
+  tags?: string[]
+}
+
+export interface EmailUpsertDto {
+  from: string
+  to: string
+  cc?: string
+  bcc?: string
+  subject: string
+  body: string
+  bodyHtml?: string
+  isHtml?: boolean
+  priority?: string
+  direction?: string
+  status?: string
+  sentAt?: string
+  receivedAt?: string
+  readAt?: string
+  isRead?: boolean
+  isImportant?: boolean
+  isArchived?: boolean
+  tags?: string
+  category?: string
+  claimId?: string
+  claimNumber?: string
+  threadId?: string
+  messageId?: string
+  inReplyTo?: string
+  references?: string
 }
 
 export interface ParticipantDto {


### PR DESCRIPTION
## Summary
- define NoteUpsertDto and EmailUpsertDto types in frontend API
- include notes and emails collections in EventUpsertDto
- map and persist notes and emails in EventsController

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*
- `pnpm lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6894eedf5518832ca6830a1c41998fec