### PR TITLE
Cleanup duplicate properties in EventUpsertDto

### DIFF
--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -127,19 +127,6 @@ namespace AutomotiveClaimsApi.DTOs
 
         public ICollection<DocumentDto>? Documents { get; set; }
 
-
-        public ICollection<DamageUpsertDto>? Damages { get; set; }
-
-
-        public ICollection<DamageDto>? Damages { get; set; }
-
-        public ICollection<DecisionDto>? Decisions { get; set; }
-        public ICollection<AppealDto>? Appeals { get; set; }
-        public ICollection<ClientClaimDto>? ClientClaims { get; set; }
-        public ICollection<RecourseDto>? Recourses { get; set; }
-        public ICollection<SettlementDto>? Settlements { get; set; }
-
-
         public ICollection<DamageUpsertDto>? Damages { get; set; }
         public ICollection<DecisionUpsertDto>? Decisions { get; set; }
         public ICollection<AppealUpsertDto>? Appeals { get; set; }


### PR DESCRIPTION
## Summary
- consolidate repeated collections in EventUpsertDto so Damages, Decisions, Appeals, ClientClaims, Recourses, and Settlements each appear once and use Upsert DTO types

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894faf3f5c8832c9f18ba060d2ca158