### PR TITLE
Use DocumentPath for deleting appeal documents

### DIFF
--- a/backend/Controllers/AppealsController.cs
+++ b/backend/Controllers/AppealsController.cs
@@ -137,7 +137,7 @@ namespace AutomotiveClaimsApi.Controllers
                 {
                     if (!string.IsNullOrEmpty(appeal.DocumentPath))
                     {
-                        await _documentService.DeleteDocumentAsync(appeal.Id);
+                        await _documentService.DeleteDocumentAsync(appeal.DocumentPath);
                     }
 
                     var documentResult = await _documentService.SaveDocumentAsync(
@@ -179,7 +179,7 @@ namespace AutomotiveClaimsApi.Controllers
 
                 if (!string.IsNullOrEmpty(appeal.DocumentPath))
                 {
-                    await _documentService.DeleteDocumentAsync(appeal.Id);
+                    await _documentService.DeleteDocumentAsync(appeal.DocumentPath);
                 }
 
                 _context.Appeals.Remove(appeal);


### PR DESCRIPTION
## Summary
- Use DocumentPath when deleting appeal documents during update and delete operations

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894fba8a490832c8c8a5f2cf155ebae