### PR TITLE
refactor: represent client claim currency as text

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -141,7 +141,7 @@ export interface Appeal {
 }
 
 export interface ClientClaim {
-  currency: number | undefined;
+  currency?: string;
   id?: string
   eventId?: string
   claimDate: string


### PR DESCRIPTION
## Summary
- treat ClientClaim currency as a string

## Testing
- `pnpm build`
- `pnpm tsc --noEmit` *(fails: "Duplicate identifier 'decisions'." etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6894fbc13e24832cb15e591c257181d7