### PR TITLE
Add optional IDs to upsert DTOs

### DIFF
--- a/backend/Controllers/DamagesController.cs
+++ b/backend/Controllers/DamagesController.cs
@@ -70,7 +70,7 @@ namespace AutomotiveClaimsApi.Controllers
 
                 var damage = new Damage
                 {
-                    Id = Guid.NewGuid(),
+                    Id = upsertDto.Id ?? Guid.NewGuid(),
                     EventId = upsertDto.EventId.Value,
                     Description = upsertDto.Description,
                     Detail = upsertDto.Detail,

--- a/backend/Controllers/EventsController.cs
+++ b/backend/Controllers/EventsController.cs
@@ -814,7 +814,7 @@ namespace AutomotiveClaimsApi.Controllers
         {
             return new Damage
             {
-                Id = Guid.NewGuid(),
+                Id = dto.Id ?? Guid.NewGuid(),
                 EventId = dto.EventId ?? eventId,
                 Description = dto.Description,
                 Detail = dto.Detail,
@@ -835,7 +835,7 @@ namespace AutomotiveClaimsApi.Controllers
         {
             return new Decision
             {
-                Id = Guid.NewGuid(),
+                Id = dto.Id ?? Guid.NewGuid(),
                 EventId = dto.EventId ?? eventId,
                 DecisionDate = dto.DecisionDate,
                 DecisionType = dto.DecisionType,
@@ -855,7 +855,7 @@ namespace AutomotiveClaimsApi.Controllers
         {
             return new Appeal
             {
-                Id = Guid.NewGuid(),
+                Id = dto.Id ?? Guid.NewGuid(),
                 EventId = dto.EventId ?? eventId,
                 AppealNumber = dto.AppealNumber,
                 SubmissionDate = dto.SubmissionDate ?? DateTime.UtcNow,
@@ -875,7 +875,7 @@ namespace AutomotiveClaimsApi.Controllers
         {
             return new ClientClaim
             {
-                Id = Guid.NewGuid(),
+                Id = dto.Id ?? Guid.NewGuid(),
                 EventId = dto.EventId ?? eventId,
                 ClaimNumber = dto.ClaimNumber,
                 ClaimDate = dto.ClaimDate,
@@ -897,7 +897,7 @@ namespace AutomotiveClaimsApi.Controllers
         {
             return new Recourse
             {
-                Id = Guid.NewGuid(),
+                Id = dto.Id ?? Guid.NewGuid(),
                 EventId = dto.EventId ?? eventId,
                 Status = dto.Status,
                 InitiationDate = dto.InitiationDate,
@@ -914,7 +914,7 @@ namespace AutomotiveClaimsApi.Controllers
         {
             return new Settlement
             {
-                Id = Guid.NewGuid(),
+                Id = dto.Id ?? Guid.NewGuid(),
                 EventId = dto.EventId ?? eventId,
                 SettlementNumber = dto.SettlementNumber,
                 SettlementType = dto.SettlementType,

--- a/backend/DTOs/AppealUpsertDto.cs
+++ b/backend/DTOs/AppealUpsertDto.cs
@@ -4,6 +4,7 @@ namespace AutomotiveClaimsApi.DTOs
 {
     public class AppealUpsertDto
     {
+        public Guid? Id { get; set; }
         public Guid? EventId { get; set; }
         public string? AppealNumber { get; set; }
         public DateTime? SubmissionDate { get; set; }

--- a/backend/DTOs/ClientClaimUpsertDto.cs
+++ b/backend/DTOs/ClientClaimUpsertDto.cs
@@ -4,6 +4,7 @@ namespace AutomotiveClaimsApi.DTOs
 {
     public class ClientClaimUpsertDto
     {
+        public Guid? Id { get; set; }
         public Guid? EventId { get; set; }
         public string? ClaimNumber { get; set; }
         public DateTime? ClaimDate { get; set; }

--- a/backend/DTOs/DamageUpsertDto.cs
+++ b/backend/DTOs/DamageUpsertDto.cs
@@ -5,6 +5,7 @@ namespace AutomotiveClaimsApi.DTOs
 {
     public class DamageUpsertDto
     {
+        public Guid? Id { get; set; }
         public Guid? EventId { get; set; }
 
         [Required]

--- a/backend/DTOs/DecisionUpsertDto.cs
+++ b/backend/DTOs/DecisionUpsertDto.cs
@@ -4,6 +4,7 @@ namespace AutomotiveClaimsApi.DTOs
 {
     public class DecisionUpsertDto
     {
+        public Guid? Id { get; set; }
         public Guid? EventId { get; set; }
         public DateTime? DecisionDate { get; set; }
         public string? DecisionType { get; set; }

--- a/backend/DTOs/RecourseUpsertDto.cs
+++ b/backend/DTOs/RecourseUpsertDto.cs
@@ -4,6 +4,7 @@ namespace AutomotiveClaimsApi.DTOs
 {
     public class RecourseUpsertDto
     {
+        public Guid? Id { get; set; }
         public Guid? EventId { get; set; }
         public string? Status { get; set; }
         public DateTime? InitiationDate { get; set; }

--- a/backend/DTOs/SettlementUpsertDto.cs
+++ b/backend/DTOs/SettlementUpsertDto.cs
@@ -4,6 +4,7 @@ namespace AutomotiveClaimsApi.DTOs
 {
     public class SettlementUpsertDto
     {
+        public Guid? Id { get; set; }
         public Guid? EventId { get; set; }
         public string? SettlementNumber { get; set; }
         public string? SettlementType { get; set; }


### PR DESCRIPTION
## Summary
- allow specifying existing IDs when creating damages, decisions, appeals, client claims, recourses, and settlements
- consume provided IDs when mapping DTOs to entities

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894fc178a0c832c8792e08ef23f20ce