### PR TITLE
feat: add document fields to appeal upsert

### DIFF
--- a/backend/DTOs/AppealUpsertDto.cs
+++ b/backend/DTOs/AppealUpsertDto.cs
@@ -14,5 +14,8 @@ namespace AutomotiveClaimsApi.DTOs
         public decimal? AppealAmount { get; set; }
         public DateTime? DecisionDate { get; set; }
         public string? DecisionReason { get; set; }
+        public string? DocumentPath { get; set; }
+        public string? DocumentName { get; set; }
+        public string? DocumentDescription { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- add document path, name, and description fields to `AppealUpsertDto`

## Testing
- `dotnet build backend/AutomotiveClaimsApi.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894fc17fbbc832c9f7479ac22e89902