### PR TITLE
refactor: remove duplicate upsert collections

### DIFF
--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -127,19 +127,6 @@ namespace AutomotiveClaimsApi.DTOs
 
         public ICollection<DocumentDto>? Documents { get; set; }
 
-
-        public ICollection<DamageUpsertDto>? Damages { get; set; }
-
-
-        public ICollection<DamageDto>? Damages { get; set; }
-
-        public ICollection<DecisionDto>? Decisions { get; set; }
-        public ICollection<AppealDto>? Appeals { get; set; }
-        public ICollection<ClientClaimDto>? ClientClaims { get; set; }
-        public ICollection<RecourseDto>? Recourses { get; set; }
-        public ICollection<SettlementDto>? Settlements { get; set; }
-
-
         public ICollection<DamageUpsertDto>? Damages { get; set; }
         public ICollection<DecisionUpsertDto>? Decisions { get; set; }
         public ICollection<AppealUpsertDto>? Appeals { get; set; }


### PR DESCRIPTION
## Summary
- clean EventUpsertDto by removing duplicate collection declarations
- use upsert DTOs for nested collections

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894fc18931c832cb1500cb9c0bb561a