### PR TITLE
Add DeleteDocumentAsync overload for path deletion

### DIFF
--- a/backend/Services/IDocumentService.cs
+++ b/backend/Services/IDocumentService.cs
@@ -13,6 +13,7 @@ namespace AutomotiveClaimsApi.Services
         Task<DocumentDto?> GetDocumentByIdAsync(Guid id);
         Task<DocumentDto> UploadAndCreateDocumentAsync(IFormFile file, CreateDocumentDto createDto);
         Task<bool> DeleteDocumentAsync(Guid id);
+        Task<bool> DeleteDocumentAsync(string filePath);
         Task<DocumentDownloadResult?> DownloadDocumentAsync(Guid id);
         Task<(string FilePath, string OriginalFileName)> SaveDocumentAsync(IFormFile file, string category, string? description);
         Task<DocumentDownloadResult?> GetDocumentAsync(string filePath);


### PR DESCRIPTION
## Summary
- add DeleteDocumentAsync(filePath) to IDocumentService
- clarify DocumentService already implements this overload

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689506ce652c832cab59d730470f5a79