### PR TITLE
fix: default claim status items

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -303,7 +303,7 @@ export const ClaimMainContent = ({
       const response = await fetch("/api/dictionaries/claim-statuses")
       if (response.ok) {
         const data = await response.json()
-        setClaimStatuses(data)
+        setClaimStatuses(data.items ?? [])
       } else {
         throw new Error(`HTTP error! status: ${response.status}`)
       }


### PR DESCRIPTION
## Summary
- default claim status items to empty list when API response missing items property

## Testing
- `npm test` (fails: Cannot find module 'tsconfig-paths/register')

------
https://chatgpt.com/codex/tasks/task_e_68950cc45a8c832cbb49dd1b6b78f9bf