### PR TITLE
fix: handle empty case handlers

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -337,7 +337,7 @@ export const ClaimMainContent = ({
       const response = await fetch("/api/dictionaries/case-handlers")
       if (response.ok) {
         const data = await response.json()
-        setCaseHandlers(data)
+        setCaseHandlers(data.items ?? [])
       } else {
         throw new Error(`HTTP error! status: ${response.status}`)
       }


### PR DESCRIPTION
## Summary
- ensure case handler dictionary fetch handles missing items by defaulting to empty array

## Testing
- `pnpm lint` *(fails: prompts for configuration)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68950cc4ec98832cbe90b98147ec5649