### PR TITLE
Return 404 when no decisions found

### DIFF
--- a/app/api/decisions/route.ts
+++ b/app/api/decisions/route.ts
@@ -44,6 +44,13 @@ export async function GET(request: NextRequest) {
     // Filter decisions by claimId
     const decisions = mockDecisions.filter((d) => d.claimId === claimId)
 
+    if (decisions.length === 0) {
+      return NextResponse.json(
+        { error: "No decisions found" },
+        { status: 404 },
+      )
+    }
+
     return NextResponse.json(decisions)
   } catch (error) {
     console.error("Error fetching decisions:", error)


### PR DESCRIPTION
## Summary
- handle missing claim decisions by returning 404 instead of empty list

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689510d125c0832c9d491cdbd3c65937