### PR TITLE
Add case handler vacation management

### DIFF
--- a/backend/Controllers/CaseHandlerVacationsController.cs
+++ b/backend/Controllers/CaseHandlerVacationsController.cs
@@ -1,0 +1,129 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using AutomotiveClaimsApi.Data;
+using AutomotiveClaimsApi.Models.Dictionary;
+
+namespace AutomotiveClaimsApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CaseHandlerVacationsController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly ILogger<CaseHandlerVacationsController> _logger;
+
+        public CaseHandlerVacationsController(ApplicationDbContext context, ILogger<CaseHandlerVacationsController> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<CaseHandlerVacation>>> GetVacations()
+        {
+            return await _context.CaseHandlerVacations
+                .Include(v => v.CaseHandler)
+                .Include(v => v.SubstituteHandler)
+                .ToListAsync();
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<CaseHandlerVacation>> GetVacation(int id)
+        {
+            var vacation = await _context.CaseHandlerVacations
+                .Include(v => v.CaseHandler)
+                .Include(v => v.SubstituteHandler)
+                .FirstOrDefaultAsync(v => v.Id == id);
+
+            if (vacation == null)
+            {
+                return NotFound();
+            }
+
+            return vacation;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<CaseHandlerVacation>> CreateVacation(CaseHandlerVacation vacation)
+        {
+            if (vacation.StartDate >= vacation.EndDate)
+            {
+                return BadRequest("Start date must be before end date");
+            }
+
+            var overlap = await _context.CaseHandlerVacations
+                .AnyAsync(v => v.CaseHandlerId == vacation.CaseHandlerId &&
+                               v.StartDate < vacation.EndDate &&
+                               vacation.StartDate < v.EndDate);
+
+            if (overlap)
+            {
+                return BadRequest("Vacation period overlaps with existing vacation");
+            }
+
+            vacation.CreatedAt = DateTime.UtcNow;
+            vacation.UpdatedAt = DateTime.UtcNow;
+
+            _context.CaseHandlerVacations.Add(vacation);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction(nameof(GetVacation), new { id = vacation.Id }, vacation);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateVacation(int id, CaseHandlerVacation vacation)
+        {
+            if (id != vacation.Id)
+            {
+                return BadRequest();
+            }
+
+            if (vacation.StartDate >= vacation.EndDate)
+            {
+                return BadRequest("Start date must be before end date");
+            }
+
+            var overlap = await _context.CaseHandlerVacations
+                .AnyAsync(v => v.CaseHandlerId == vacation.CaseHandlerId &&
+                               v.Id != id &&
+                               v.StartDate < vacation.EndDate &&
+                               vacation.StartDate < v.EndDate);
+
+            if (overlap)
+            {
+                return BadRequest("Vacation period overlaps with existing vacation");
+            }
+
+            var existing = await _context.CaseHandlerVacations.FindAsync(id);
+            if (existing == null)
+            {
+                return NotFound();
+            }
+
+            existing.CaseHandlerId = vacation.CaseHandlerId;
+            existing.StartDate = vacation.StartDate;
+            existing.EndDate = vacation.EndDate;
+            existing.SubstituteHandlerId = vacation.SubstituteHandlerId;
+            existing.UpdatedAt = DateTime.UtcNow;
+
+            await _context.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteVacation(int id)
+        {
+            var vacation = await _context.CaseHandlerVacations.FindAsync(id);
+            if (vacation == null)
+            {
+                return NotFound();
+            }
+
+            _context.CaseHandlerVacations.Remove(vacation);
+            await _context.SaveChangesAsync();
+
+            return NoContent();
+        }
+    }
+}

--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -40,6 +40,7 @@ namespace AutomotiveClaimsApi.Data
         public DbSet<PaymentMethod> PaymentMethods { get; set; }
         public DbSet<ContractType> ContractTypes { get; set; }
         public DbSet<DocumentStatus> DocumentStatuses { get; set; }
+        public DbSet<CaseHandlerVacation> CaseHandlerVacations { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/backend/Migrations/20240130000011_AddCaseHandlerVacations.cs
+++ b/backend/Migrations/20240130000011_AddCaseHandlerVacations.cs
@@ -1,0 +1,71 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCaseHandlerVacations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.EnsureSchema(
+                name: "dict");
+
+            migrationBuilder.CreateTable(
+                name: "CaseHandlerVacations",
+                schema: "dict",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    CaseHandlerId = table.Column<int>(type: "integer", nullable: false),
+                    StartDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    EndDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    SubstituteHandlerId = table.Column<int>(type: "integer", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CaseHandlerVacations", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CaseHandlerVacations_CaseHandlers_CaseHandlerId",
+                        column: x => x.CaseHandlerId,
+                        principalSchema: "dict",
+                        principalTable: "CaseHandlers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CaseHandlerVacations_CaseHandlers_SubstituteHandlerId",
+                        column: x => x.SubstituteHandlerId,
+                        principalSchema: "dict",
+                        principalTable: "CaseHandlers",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CaseHandlerVacations_CaseHandlerId",
+                schema: "dict",
+                table: "CaseHandlerVacations",
+                column: "CaseHandlerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CaseHandlerVacations_SubstituteHandlerId",
+                schema: "dict",
+                table: "CaseHandlerVacations",
+                column: "SubstituteHandlerId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CaseHandlerVacations",
+                schema: "dict");
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -990,6 +990,81 @@ namespace AutomotiveClaimsApi.Migrations
                     b.ToTable("Settlements");
                 });
 
+            modelBuilder.Entity("AutomotiveClaimsApi.Models.Dictionary.CaseHandler", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer")
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+                    b.Property<string>("Code")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<bool>("IsActive")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("CaseHandlers", "dict");
+                });
+
+            modelBuilder.Entity("AutomotiveClaimsApi.Models.Dictionary.CaseHandlerVacation", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer")
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+                    b.Property<int>("CaseHandlerId")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<DateTime>("EndDate")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<DateTime>("StartDate")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int?>("SubstituteHandlerId")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTime>("UpdatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CaseHandlerId");
+
+                    b.HasIndex("SubstituteHandlerId");
+
+                    b.ToTable("CaseHandlerVacations", "dict");
+                });
+
+            modelBuilder.Entity("AutomotiveClaimsApi.Models.Dictionary.CaseHandlerVacation", b =>
+                {
+                    b.HasOne("AutomotiveClaimsApi.Models.Dictionary.CaseHandler", "CaseHandler")
+                        .WithMany()
+                        .HasForeignKey("CaseHandlerId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("AutomotiveClaimsApi.Models.Dictionary.CaseHandler", "SubstituteHandler")
+                        .WithMany()
+                        .HasForeignKey("SubstituteHandlerId");
+
+                    b.Navigation("CaseHandler");
+
+                    b.Navigation("SubstituteHandler");
+                });
+
             modelBuilder.Entity("AutomotiveClaimsApi.Models.Appeal", b =>
                 {
                     b.HasOne("AutomotiveClaimsApi.Models.Event", "Event")

--- a/backend/Models/Dictionary/CaseHandlerVacation.cs
+++ b/backend/Models/Dictionary/CaseHandlerVacation.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AutomotiveClaimsApi.Models.Dictionary
+{
+    [Table("CaseHandlerVacations", Schema = "dict")]
+    public class CaseHandlerVacation
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Required]
+        public int CaseHandlerId { get; set; }
+        public CaseHandler? CaseHandler { get; set; }
+
+        [Required]
+        public DateTime StartDate { get; set; }
+
+        [Required]
+        public DateTime EndDate { get; set; }
+
+        public int? SubstituteHandlerId { get; set; }
+        public CaseHandler? SubstituteHandler { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce CaseHandlerVacation entity and DbContext set
- add migration for dict.CaseHandlerVacations with foreign keys to CaseHandlers
- implement CaseHandlerVacationsController with vacation period validation

## Testing
- `pnpm test`
- `dotnet build backend/AutomotiveClaimsApi.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68950e2b1934832c8309c142519c7bb7