### PR TITLE
Use eventId for recourse APIs and totals

### DIFF
--- a/app/api/recourses/[id]/route.ts
+++ b/app/api/recourses/[id]/route.ts
@@ -1,38 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-
-// Mock data for development (same as in route.ts)
-const mockRecourses = [
-  {
-    recourseId: 1,
-    claimId: "1",
-    isJustified: true,
-    filingDate: "2024-01-15T00:00:00Z",
-    insuranceCompany: "PZU SA",
-    obtainDate: "2024-02-20T00:00:00Z",
-    amount: 15000.0,
-    documentPath: "/documents/recourse-1.pdf",
-    documentName: "Pismo w sprawie regresu PZU.pdf",
-    documentDescription: "Oficjalne pismo w sprawie regresu od PZU SA",
-    currencyCode: "PLN",
-    createdDate: "2024-01-15T10:30:00Z",
-    modifiedDate: "2024-02-20T14:15:00Z",
-  },
-  {
-    recourseId: 2,
-    claimId: "1",
-    isJustified: false,
-    filingDate: "2024-01-20T00:00:00Z",
-    insuranceCompany: "Warta SA",
-    obtainDate: null,
-    amount: null,
-    documentPath: "/documents/recourse-2.pdf",
-    documentName: "Odrzucenie regresu Warta.pdf",
-    documentDescription: "Pismo o odrzuceniu wniosku o regres",
-    currencyCode: "PLN",
-    createdDate: "2024-01-20T09:15:00Z",
-    modifiedDate: "2024-01-20T09:15:00Z",
-  },
-]
+import { mockRecourses } from "../route"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {

--- a/app/api/recourses/route.ts
+++ b/app/api/recourses/route.ts
@@ -1,10 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
 
 // Mock data for development
-const mockRecourses = [
+export const mockRecourses = [
   {
     recourseId: 1,
-    claimId: "1",
+    eventId: "1",
     isJustified: true,
     filingDate: "2024-01-15T00:00:00Z",
     insuranceCompany: "PZU SA",
@@ -19,7 +19,7 @@ const mockRecourses = [
   },
   {
     recourseId: 2,
-    claimId: "1",
+    eventId: "1",
     isJustified: false,
     filingDate: "2024-01-20T00:00:00Z",
     insuranceCompany: "Warta SA",
@@ -37,14 +37,14 @@ const mockRecourses = [
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
-    const claimId = searchParams.get("claimId")
+    const eventId = searchParams.get("eventId")
 
-    if (!claimId) {
-      return NextResponse.json({ error: "ClaimId is required" }, { status: 400 })
+    if (!eventId) {
+      return NextResponse.json({ error: "EventId is required" }, { status: 400 })
     }
 
-    // Filter recourses by claimId
-    const filteredRecourses = mockRecourses.filter((r) => r.claimId === claimId)
+    // Filter recourses by eventId
+    const filteredRecourses = mockRecourses.filter((r) => r.eventId === eventId)
 
     return NextResponse.json(filteredRecourses)
   } catch (error) {
@@ -57,7 +57,7 @@ export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData()
 
-    const claimId = formData.get("claimId") as string
+    const eventId = formData.get("eventId") as string
     const isJustified = formData.get("isJustified") === "true"
     const filingDate = formData.get("filingDate") as string
     const insuranceCompany = formData.get("insuranceCompany") as string
@@ -67,14 +67,14 @@ export async function POST(request: NextRequest) {
     const document = formData.get("document") as File
 
     // Validate required fields
-    if (!claimId || !filingDate || !insuranceCompany) {
-      return NextResponse.json({ error: "ClaimId, filingDate, and insuranceCompany are required" }, { status: 400 })
+    if (!eventId || !filingDate || !insuranceCompany) {
+      return NextResponse.json({ error: "EventId, filingDate, and insuranceCompany are required" }, { status: 400 })
     }
 
     // Create new recourse
     const newRecourse = {
       recourseId: Math.max(...mockRecourses.map((r) => r.recourseId)) + 1,
-      claimId,
+      eventId,
       isJustified,
       filingDate: new Date(filingDate).toISOString(),
       insuranceCompany,

--- a/app/api/recourses/total/route.ts
+++ b/app/api/recourses/total/route.ts
@@ -1,0 +1,22 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { mockRecourses } from "../route"
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const eventId = searchParams.get("eventId")
+
+    if (!eventId) {
+      return NextResponse.json({ error: "EventId is required" }, { status: 400 })
+    }
+
+    const total = mockRecourses
+      .filter((r) => r.eventId === eventId)
+      .reduce((sum, r) => sum + (r.amount ?? 0), 0)
+
+    return NextResponse.json(total)
+  } catch (error) {
+    console.error("Error fetching total recourse amount:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/components/claim-form/recourse-section.tsx
+++ b/components/claim-form/recourse-section.tsx
@@ -38,7 +38,7 @@ import {
 
 interface Recourse {
   recourseId: number
-  claimId: string
+  eventId: string
   isJustified: boolean
   filingDate?: string
   insuranceCompany?: string
@@ -234,7 +234,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
     setLoading(true)
     try {
       const submitFormData = new FormData()
-      submitFormData.append("claimId", eventId)
+      submitFormData.append("eventId", eventId)
       submitFormData.append("isJustified", formData.isJustified.toString())
       submitFormData.append("filingDate", formData.filingDate)
       submitFormData.append("insuranceCompany", formData.insuranceCompany)


### PR DESCRIPTION
## Summary
- Switch recourse APIs to accept `eventId` instead of `claimId`
- Add `/api/recourses/total` endpoint to compute total recourse amount
- Update recourse section form to submit `eventId`

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689514d6e688832cbb4fb8eb4cb68c60