### PR TITLE
refactor: keep participant and driver IDs as strings

### DIFF
--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -20,3 +20,17 @@ test('includes dropdown selections in payload', () => {
   assert.equal(payload.clientId, 7)
   assert.equal(payload.handlerId, 9)
 })
+
+test('participant and driver ids remain strings', () => {
+  const payload = transformFrontendClaimToApiPayload({
+    injuredParty: {
+      id: '123',
+      drivers: [{ id: '456' }],
+    },
+  } as any)
+
+  const participant = payload.participants?.[0]
+  const driver = participant?.drivers?.[0]
+  assert.equal(participant?.id, '123')
+  assert.equal(driver?.id, '456')
+})

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -68,7 +68,7 @@ const transformFrontendClaimToApiPayload = (claimData: Partial<Claim>): EventUps
   const participants: ParticipantUpsertDto[] = []
 
   const mapParticipant = (p: ParticipantInfo, role: string): ParticipantUpsertDto => ({
-    id: p.id ? parseInt(p.id) : undefined,
+    id: p.id || undefined,
     role: role,
     name: p.name,
     phone: p.phone,
@@ -88,7 +88,7 @@ const transformFrontendClaimToApiPayload = (claimData: Partial<Claim>): EventUps
     inspectionContactPhone: p.inspectionContactPhone,
     inspectionContactEmail: p.inspectionContactEmail,
     drivers: p.drivers?.map((d: DriverInfo) => ({
-      id: d.id ? parseInt(d.id) : undefined,
+      id: d.id || undefined,
       name: d.name,
       licenseNumber: d.licenseNumber,
       firstName: d.firstName,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -145,7 +145,7 @@ export interface EmailUpsertDto {
 }
 
 export interface ParticipantDto {
-  id?: number
+  id?: string
   role?: string
   name?: string
   phone?: string
@@ -168,7 +168,7 @@ export interface ParticipantDto {
 }
 
 export interface ParticipantUpsertDto {
-  id?: number
+  id?: string
   role?: string
   name?: string
   phone?: string
@@ -191,7 +191,7 @@ export interface ParticipantUpsertDto {
 }
 
 export interface DriverDto {
-  id?: number
+  id?: string
   name?: string
   licenseNumber?: string
   firstName?: string
@@ -207,7 +207,7 @@ export interface DriverDto {
 }
 
 export interface DriverUpsertDto {
-  id?: number
+  id?: string
   name?: string
   licenseNumber?: string
   firstName?: string


### PR DESCRIPTION
## Summary
- avoid parsing participant and driver IDs to numbers before API submission
- update API type definitions to expect string IDs for participants and drivers
- add tests covering string ID handling while preserving numeric payload IDs elsewhere

## Testing
- `npm test` *(0 tests run)*
- `node --test -r tsconfig-paths/register --loader ts-node/esm hooks/__tests__/use-claims.test.ts` *(ERR_REQUIRE_CYCLE_MODULE)*
- `npm run lint` *(interactive prompt, no lint results)*

------
https://chatgpt.com/codex/tasks/task_e_689514d82f24832c9f06de9d9c77320a