### PR TITLE
Fix duplicate properties in event DTOs and model

### DIFF
--- a/backend/DTOs/EventDto.cs
+++ b/backend/DTOs/EventDto.cs
@@ -17,7 +17,6 @@ namespace AutomotiveClaimsApi.DTOs
         public string? InsuranceCompany { get; set; }
         public string? InsuranceCompanyPhone { get; set; }
         public string? InsuranceCompanyEmail { get; set; }
-        public int? InsuranceCompanyId { get; set; }
         public string? PolicyNumber { get; set; }
         public string? Status { get; set; }
         public DateTime? DamageDate { get; set; }
@@ -31,7 +30,6 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Liquidator { get; set; }
         public int? ClientId { get; set; }
         public string? Client { get; set; }
-        public int? ClientId { get; set; }
         public string? ReportingChannel { get; set; }
         public int? LeasingCompanyId { get; set; }
         public string? LeasingCompany { get; set; }
@@ -41,7 +39,6 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Handler { get; set; }
         public string? HandlerEmail { get; set; }
         public string? HandlerPhone { get; set; }
-        public int? HandlerId { get; set; }
         public DateTime? EventTime { get; set; }
         public string? EventLocation { get; set; }
         public string? EventDescription { get; set; }

--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -38,8 +38,6 @@ namespace AutomotiveClaimsApi.DTOs
         [StringLength(200)]
         public string? InsuranceCompanyEmail { get; set; }
 
-        public int? InsuranceCompanyId { get; set; }
-
         [StringLength(100)]
         public string? PolicyNumber { get; set; }
 
@@ -73,8 +71,6 @@ namespace AutomotiveClaimsApi.DTOs
         [StringLength(200)]
         public string? Client { get; set; }
 
-        public int? ClientId { get; set; }
-
         [StringLength(100)]
         public string? ReportingChannel { get; set; }
 
@@ -99,8 +95,6 @@ namespace AutomotiveClaimsApi.DTOs
 
         [StringLength(50)]
         public string? HandlerPhone { get; set; }
-
-        public int? HandlerId { get; set; }
 
         public string? EventTime { get; set; }
 

--- a/backend/Models/Event.cs
+++ b/backend/Models/Event.cs
@@ -43,8 +43,6 @@ namespace AutomotiveClaimsApi.Models
         [MaxLength(200)]
         public string? InsuranceCompanyEmail { get; set; }
 
-        public int? InsuranceCompanyId { get; set; }
-
         [MaxLength(100)]
         public string? PolicyNumber { get; set; }
 
@@ -80,8 +78,6 @@ namespace AutomotiveClaimsApi.Models
         [MaxLength(200)]
         public string? Client { get; set; }
 
-        public int? ClientId { get; set; }
-
         [MaxLength(100)]
         public string? ReportingChannel { get; set; }
 
@@ -106,8 +102,6 @@ namespace AutomotiveClaimsApi.Models
 
         [MaxLength(50)]
         public string? HandlerPhone { get; set; }
-
-        public int? HandlerId { get; set; }
 
         public DateTime? EventTime { get; set; }
 


### PR DESCRIPTION
## Summary
- remove duplicate InsuranceCompanyId, ClientId, and HandlerId fields from `EventUpsertDto`
- clean up duplicate properties in `EventDto` and `Event` model to match

## Testing
- `dotnet build` *(fails: command not found)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689514d87d44832ca236c21922ff20a4