### PR TITLE
Use string IDs for participants and drivers

### DIFF
--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -8,6 +8,15 @@ const transformApiClaimToFrontend = (apiClaim: EventDto): Claim => {
   const injuredParty = apiClaim.participants?.find((p: any) => p.role === "Poszkodowany")
   const perpetrator = apiClaim.participants?.find((p: any) => p.role === "Sprawca")
 
+  const mapParticipantDto = (p: any): ParticipantInfo => ({
+    ...p,
+    id: p.id?.toString() || "",
+    drivers: p.drivers?.map((d: any) => ({
+      ...d,
+      id: d.id?.toString() || "",
+    })) || [],
+  })
+
   return {
     ...apiClaim,
     id: apiClaim.id?.toString(),
@@ -25,18 +34,8 @@ const transformApiClaimToFrontend = (apiClaim: EventDto): Claim => {
     clientClaims: apiClaim.clientClaims || [],
     recourses: apiClaim.recourses || [],
     settlements: apiClaim.settlements || [],
-    injuredParty: injuredParty
-      ? {
-          ...injuredParty,
-          drivers: injuredParty.drivers || [],
-        }
-      : undefined,
-    perpetrator: perpetrator
-      ? {
-          ...perpetrator,
-          drivers: perpetrator.drivers || [],
-        }
-      : undefined,
+    injuredParty: injuredParty ? mapParticipantDto(injuredParty) : undefined,
+    perpetrator: perpetrator ? mapParticipantDto(perpetrator) : undefined,
   }
 }
 
@@ -68,8 +67,8 @@ const transformFrontendClaimToApiPayload = (claimData: Partial<Claim>): EventUps
   const participants: ParticipantUpsertDto[] = []
 
   const mapParticipant = (p: ParticipantInfo, role: string): ParticipantUpsertDto => ({
-    id: p.id ? parseInt(p.id) : undefined,
-    role: role,
+    id: p.id ? p.id.toString() : undefined,
+    role,
     name: p.name,
     phone: p.phone,
     email: p.email,
@@ -88,7 +87,7 @@ const transformFrontendClaimToApiPayload = (claimData: Partial<Claim>): EventUps
     inspectionContactPhone: p.inspectionContactPhone,
     inspectionContactEmail: p.inspectionContactEmail,
     drivers: p.drivers?.map((d: DriverInfo) => ({
-      id: d.id ? parseInt(d.id) : undefined,
+      id: d.id ? d.id.toString() : undefined,
       name: d.name,
       licenseNumber: d.licenseNumber,
       firstName: d.firstName,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -168,7 +168,7 @@ export interface ParticipantDto {
 }
 
 export interface ParticipantUpsertDto {
-  id?: number
+  id?: string
   role?: string
   name?: string
   phone?: string
@@ -207,7 +207,7 @@ export interface DriverDto {
 }
 
 export interface DriverUpsertDto {
-  id?: number
+  id?: string
   name?: string
   licenseNumber?: string
   firstName?: string


### PR DESCRIPTION
## Summary
- align ParticipantUpsertDto and DriverUpsertDto IDs with backend by using strings
- ensure participant/driver IDs are converted to strings when building API payloads
- confirmed event creation requests send raw event JSON with the correct headers

## Testing
- `pnpm test`
- `CI=1 pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68951406a15c832ca8068747221429c2