### PR TITLE
Wrap claim payload in eventDto

### DIFF
--- a/backend/Controllers/EventsController.cs
+++ b/backend/Controllers/EventsController.cs
@@ -147,10 +147,11 @@ namespace AutomotiveClaimsApi.Controllers
         }
 
         [HttpPost]
-        public async Task<ActionResult<EventDto>> CreateEvent(EventUpsertDto eventDto)
+        public async Task<ActionResult<EventDto>> CreateEvent([FromBody] EventUpsertRequest request)
         {
             try
             {
+                var eventDto = request.EventDto;
                 var eventEntity = new Event
                 {
                     Id = Guid.NewGuid(),
@@ -281,10 +282,11 @@ namespace AutomotiveClaimsApi.Controllers
         }
 
         [HttpPut("{id}")]
-        public async Task<IActionResult> UpdateEvent(Guid id, EventUpsertDto eventDto)
+        public async Task<IActionResult> UpdateEvent(Guid id, [FromBody] EventUpsertRequest request)
         {
             try
             {
+                var eventDto = request.EventDto;
                 var eventEntity = await _context.Events
                     .Include(e => e.Participants).ThenInclude(p => p.Drivers)
                     .Include(e => e.Damages)

--- a/backend/DTOs/EventUpsertRequest.cs
+++ b/backend/DTOs/EventUpsertRequest.cs
@@ -1,0 +1,7 @@
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class EventUpsertRequest
+    {
+        public EventUpsertDto EventDto { get; set; } = new EventUpsertDto();
+    }
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -405,14 +405,14 @@ class ApiService {
   async createClaim(claim: EventUpsertDto): Promise<EventDto> {
     return this.request<EventDto>("/events", {
       method: "POST",
-      body: JSON.stringify(claim),
+      body: JSON.stringify({ eventDto: claim }),
     })
   }
 
   async updateClaim(id: string, claim: EventUpsertDto): Promise<EventDto> {
     return this.request<EventDto>(`/events/${id}`, {
       method: "PUT",
-      body: JSON.stringify(claim),
+      body: JSON.stringify({ eventDto: claim }),
     })
   }
 


### PR DESCRIPTION
## Summary
- Wrap claim bodies in `{ eventDto: claim }` for create and update requests
- Add `EventUpsertRequest` wrapper and adjust `EventsController` endpoints to consume it

## Testing
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `dotnet build backend` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689514d9821c832c804f37a34fd47c1d