### PR TITLE
feat: support pending file uploads before claim creation

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -57,6 +57,7 @@ export interface Claim {
   location?: string
   description?: string
   documents?: UploadedFile[]
+  pendingFiles?: UploadedFile[]
   documentsSectionProps?: DocumentsSectionProps
 }
 
@@ -184,6 +185,7 @@ export interface UploadedFile {
   category?: string
   description?: string
   date?: string
+  file?: File
 }
 
 export interface RequiredDocument {
@@ -200,5 +202,7 @@ export interface DocumentsSectionProps {
   setUploadedFiles: React.Dispatch<React.SetStateAction<UploadedFile[]>>
   requiredDocuments: RequiredDocument[]
   setRequiredDocuments: React.Dispatch<React.SetStateAction<RequiredDocument[]>>
-  eventId?: number
+  eventId?: number | string
+  pendingFiles?: UploadedFile[]
+  setPendingFiles?: React.Dispatch<React.SetStateAction<UploadedFile[]>>
 }


### PR DESCRIPTION
## Summary
- allow storing pending uploaded files and their File objects
- handle uploads without eventId in DocumentsSection and show deletable pending files
- upload pending files after creating a claim and navigate to its view

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6895111cd198832c97e0c43ec080c93d