### PR TITLE
Handle missing claim ID when loading decisions

### DIFF
--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -70,6 +70,16 @@ export function DecisionsSection({ claimId }: DecisionsSectionProps) {
   }, [decisions])
 
   const loadDecisions = async () => {
+    if (!claimId) {
+      console.warn("Missing claim ID, skipping decisions fetch")
+      toast({
+        title: "Brak ID roszczenia",
+        description: "Nie można załadować decyzji bez ID roszczenia",
+        variant: "destructive",
+      })
+      return
+    }
+
     setIsLoading(true)
     try {
       const response = await fetch(`/api/decisions?claimId=${claimId}`)


### PR DESCRIPTION
## Summary
- Avoid fetching decisions when `claimId` is absent and warn the user with a toast

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689510cf32d4832ca5753a6b44cd01ac