### PR TITLE
Use server-side backend URL for settlements API

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+# Base URL for backend API, used on the server only
+API_BASE_URL=http://localhost:5200
+
+# Optional: number of times to retry requests to the backend
+# FETCH_RETRY_COUNT=1


### PR DESCRIPTION
## Summary
- use server-only `API_BASE_URL` for settlement routes
- add simple fetch retry with status logging
- document `API_BASE_URL` env variable

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint? Command failed with exit code 1)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68951a8d7820832c934e5a6028657531