### PR TITLE
feat: connect decisions API to backend

### DIFF
--- a/app/api/decisions/[id]/route.ts
+++ b/app/api/decisions/[id]/route.ts
@@ -1,108 +1,75 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-// Mock data - replace with actual database calls
-const mockDecisions = [
-  {
-    decisionId: 1,
-    claimId: "1",
-    decisionDate: "2024-01-15T00:00:00Z",
-    status: "Wypłata",
-    paymentAmount: 5000.0,
-    currency: "PLN",
-    compensationTitle: "Pojazd - szkoda częściowa",
-    documentPath: "/documents/decision-1.pdf",
-    documentName: "decision-1.pdf",
-    documentDescription: "Decyzja o wypłacie odszkodowania",
-    createdAt: "2024-01-15T10:00:00Z",
-    updatedAt: "2024-01-15T10:00:00Z",
-  },
-]
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const id = params.id
+    const response = await fetch(`${API_BASE_URL}/api/decisions/${params.id}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
 
-    // TODO: Replace with actual database call
-    // const response = await fetch(`${process.env.API_BASE_URL}/api/decisions/${id}`)
-    // const decision = await response.json()
-
-    // Mock data for now
-    const mockDecision = mockDecisions.find((d) => d.decisionId === Number.parseInt(id))
-    if (!mockDecision) {
-      return NextResponse.json({ error: "Decision not found" }, { status: 404 })
+    if (!response.ok) {
+      const errorData = await response.text()
+      return NextResponse.json({ error: "Failed to fetch decision", details: errorData }, { status: response.status })
     }
 
-    return NextResponse.json(mockDecision)
+    const data = await response.json()
+    return NextResponse.json(data)
   } catch (error) {
     console.error("Error fetching decision:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    return NextResponse.json(
+      { error: "Internal server error", details: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 },
+    )
   }
 }
 
 export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const id = params.id
     const formData = await request.formData()
 
-    const claimId = formData.get("claimId") as string
-    const decisionDate = formData.get("decisionDate") as string
-    const status = formData.get("status") as string
-    const paymentAmount = formData.get("paymentAmount") as string
-    const currency = formData.get("currency") as string
-    const compensationTitle = formData.get("compensationTitle") as string
-    const documentDescription = formData.get("documentDescription") as string
-    const document = formData.get("document") as File
+    const response = await fetch(`${API_BASE_URL}/api/decisions/${params.id}`, {
+      method: "PUT",
+      body: formData,
+    })
 
-    if (!claimId || !decisionDate || !status) {
-      return NextResponse.json({ error: "Required fields missing" }, { status: 400 })
+    if (!response.ok) {
+      const errorData = await response.text()
+      return NextResponse.json({ error: "Failed to update decision", details: errorData }, { status: response.status })
     }
 
-    // Find existing decision
-    const decisionIndex = mockDecisions.findIndex((d) => d.decisionId === Number.parseInt(id))
-    if (decisionIndex === -1) {
-      return NextResponse.json({ error: "Decision not found" }, { status: 404 })
-    }
-
-    // Update decision
-    const updatedDecision = {
-      ...mockDecisions[decisionIndex],
-      claimId,
-      decisionDate,
-      status,
-      paymentAmount: paymentAmount ? Number.parseFloat(paymentAmount) : null,
-      currency: currency || "PLN",
-      compensationTitle: compensationTitle || null,
-      documentPath: document ? `/documents/${document.name}` : null,
-      documentName: document ? document.name : null,
-      documentDescription: documentDescription || null,
-      updatedAt: new Date().toISOString(),
-    }
-
-    mockDecisions[decisionIndex] = updatedDecision
-
-    return NextResponse.json(updatedDecision)
+    const data = await response.json()
+    return NextResponse.json(data)
   } catch (error) {
     console.error("Error updating decision:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    return NextResponse.json(
+      { error: "Internal server error", details: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 },
+    )
   }
 }
 
 export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const id = params.id
+    const response = await fetch(`${API_BASE_URL}/api/decisions/${params.id}`, {
+      method: "DELETE",
+    })
 
-    // Find existing decision
-    const decisionIndex = mockDecisions.findIndex((d) => d.decisionId === Number.parseInt(id))
-    if (decisionIndex === -1) {
-      return NextResponse.json({ error: "Decision not found" }, { status: 404 })
+    if (!response.ok) {
+      const errorData = await response.text()
+      return NextResponse.json({ error: "Failed to delete decision", details: errorData }, { status: response.status })
     }
 
-    // Remove decision from array
-    mockDecisions.splice(decisionIndex, 1)
-
-    return NextResponse.json({ message: "Decision deleted successfully" })
+    return NextResponse.json({ success: true })
   } catch (error) {
     console.error("Error deleting decision:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    return NextResponse.json(
+      { error: "Internal server error", details: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 },
+    )
   }
 }
+

--- a/app/api/decisions/route.ts
+++ b/app/api/decisions/route.ts
@@ -1,36 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-// Mock data for development - replace with actual database calls
-const mockDecisions = [
-  {
-    decisionId: 1,
-    claimId: "1",
-    decisionDate: "2024-01-15T00:00:00Z",
-    status: "Wypłata",
-    paymentAmount: 5000.0,
-    currency: "PLN",
-    compensationTitle: "Pojazd - bezsporna",
-    documentPath: "/documents/decision-1.pdf",
-    documentName: "Decyzja_wypłata_001.pdf",
-    documentDescription: "Decyzja o wypłacie odszkodowania",
-    createdAt: "2024-01-15T10:00:00Z",
-    updatedAt: "2024-01-15T10:00:00Z",
-  },
-  {
-    decisionId: 2,
-    claimId: "1",
-    decisionDate: "2024-01-20T00:00:00Z",
-    status: "Odmowa",
-    paymentAmount: 0,
-    currency: "PLN",
-    compensationTitle: "Pojazd zastępczy",
-    documentPath: "/documents/decision-2.pdf",
-    documentName: "Decyzja_odmowa_002.pdf",
-    documentDescription: "Odmowa wypłaty za pojazd zastępczy",
-    createdAt: "2024-01-20T14:30:00Z",
-    updatedAt: "2024-01-20T14:30:00Z",
-  },
-]
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
 
 export async function GET(request: NextRequest) {
   try {
@@ -41,13 +11,31 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "ClaimId is required" }, { status: 400 })
     }
 
-    // Filter decisions by claimId
-    const decisions = mockDecisions.filter((d) => d.claimId === claimId)
+    const url = `${API_BASE_URL}/api/decisions?claimId=${claimId}`
 
-    return NextResponse.json(decisions)
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+
+    if (!response.ok) {
+      const errorData = await response.text()
+      return NextResponse.json(
+        { error: "Failed to fetch decisions", details: errorData },
+        { status: response.status },
+      )
+    }
+
+    const data = await response.json()
+    return NextResponse.json(data)
   } catch (error) {
     console.error("Error fetching decisions:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    return NextResponse.json(
+      { error: "Internal server error", details: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 },
+    )
   }
 }
 
@@ -55,46 +43,27 @@ export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData()
 
-    const claimId = formData.get("claimId") as string
-    const decisionDate = formData.get("decisionDate") as string
-    const status = formData.get("status") as string
-    const paymentAmount = formData.get("paymentAmount") as string
-    const currency = formData.get("currency") as string
-    const compensationTitle = formData.get("compensationTitle") as string
-    const documentDescription = formData.get("documentDescription") as string
-    const document = formData.get("document") as File
+    const response = await fetch(`${API_BASE_URL}/api/decisions`, {
+      method: "POST",
+      body: formData,
+    })
 
-    // Validate required fields
-    if (!claimId || !decisionDate || !status) {
-      return NextResponse.json({ error: "Required fields missing" }, { status: 400 })
+    if (!response.ok) {
+      const errorData = await response.text()
+      return NextResponse.json(
+        { error: "Failed to create decision", details: errorData },
+        { status: response.status },
+      )
     }
 
-    // Create new decision object
-    const newDecision = {
-      decisionId: mockDecisions.length + 1,
-      claimId,
-      decisionDate,
-      status,
-      paymentAmount: paymentAmount ? Number.parseFloat(paymentAmount) : null,
-      currency: currency || "PLN",
-      compensationTitle: compensationTitle || null,
-      documentPath: document ? `/documents/${document.name}` : null,
-      documentName: document ? document.name : null,
-      documentDescription: documentDescription || null,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    }
-
-    // In a real application, you would:
-    // 1. Save the file to storage (filesystem, cloud storage, etc.)
-    // 2. Save the decision to database
-    // 3. Return the created decision
-
-    mockDecisions.push(newDecision)
-
-    return NextResponse.json(newDecision, { status: 201 })
+    const data = await response.json()
+    return NextResponse.json(data, { status: 201 })
   } catch (error) {
     console.error("Error creating decision:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    return NextResponse.json(
+      { error: "Internal server error", details: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 },
+    )
   }
 }
+


### PR DESCRIPTION
## Summary
- Connect decision endpoints to real backend API
- Add error handling and return entities from persistent store

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68951a83c4dc832cb81929ae5528c54e