### PR TITLE
fix: handle search parameter in vehicle type service

### DIFF
--- a/lib/vehicle-types.ts
+++ b/lib/vehicle-types.ts
@@ -1,14 +1,10 @@
 import type { VehicleType, VehicleTypeResponse } from "@/types/vehicle-type"
-import { API_ENDPOINTS } from "@/lib/constants"
-
 
 const API_BASE_URL = "/api/dictionaries/vehicle-types"
 
-
 export const vehicleTypeService = {
-  async getVehicleTypes(): Promise<VehicleType[]> {
+  async getVehicleTypes(search?: string): Promise<VehicleType[]> {
     try {
-
       const params = new URLSearchParams()
       if (search) {
         params.append("search", search)


### PR DESCRIPTION
## Summary
- accept optional `search` arg in vehicle type service
- remove undefined `search` reference in vehicle types lookup

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68951f63cf00832ca6553ede373445fb