### PR TITLE
Restrict document preview to category and show type

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -464,7 +464,9 @@ export const DocumentsSection = ({
   }
 
   const handlePreview = (document: Document, documentsArray?: Document[]) => {
-    const docsToPreview = documentsArray || allDocuments
+    const docsToPreview =
+      documentsArray ||
+      documents.filter((d) => d.documentType === document.documentType)
     const index = docsToPreview.findIndex((d) => d.id === document.id)
 
     setPreviewDocuments(docsToPreview)
@@ -1133,6 +1135,7 @@ export const DocumentsSection = ({
               <div className="flex justify-between items-center p-4 bg-gray-50 border-b">
                 <div className="flex items-center gap-4">
                   <h3 className="text-lg font-semibold truncate max-w-md">{previewDocument.originalFileName}</h3>
+                  <Badge variant="secondary">{previewDocument.documentType}</Badge>
                   <div className="text-sm text-gray-500">
                     {currentPreviewIndex + 1} z {previewDocuments.length}
                   </div>


### PR DESCRIPTION
## Summary
- limit document preview navigation to the current document type
- display document type badge in preview modal header

## Testing
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68951fe98864832cb3dd6e43c48d00ce