### PR TITLE
feat: handle array servicesCalled

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -148,7 +148,9 @@ export default function ClaimPage() {
             inspectionContactEmail: "",
             drivers: [{ id: "", name: "", licenseNumber: "" }],
           },
-          servicesCalled: claimData.servicesCalled?.split(",") || [],
+          servicesCalled: Array.isArray(claimData.servicesCalled)
+            ? claimData.servicesCalled
+            : (claimData.servicesCalled?.split(",") ?? []),
           damages: claimData.damages || [],
           decisions: claimData.decisions || [],
           appeals: claimData.appeals || [],

--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -159,7 +159,9 @@ export default function EditClaimPage() {
             inspectionContactEmail: "",
             drivers: [{ id: "", name: "", licenseNumber: "" }],
           },
-          servicesCalled: claimData.servicesCalled?.split(",") || [],
+          servicesCalled: Array.isArray(claimData.servicesCalled)
+            ? claimData.servicesCalled
+            : (claimData.servicesCalled?.split(",") ?? []),
           damages: claimData.damages || [],
           decisions: claimData.decisions || [],
           appeals: claimData.appeals || [],

--- a/app/claims/[id]/view/page.tsx
+++ b/app/claims/[id]/view/page.tsx
@@ -126,7 +126,9 @@ export default function ViewClaimPage() {
           ...claimData,
           injuredParty: claimData.participants?.find((p: any) => p.role === "Poszkodowany"),
           perpetrator: claimData.participants?.find((p: any) => p.role === "Sprawca"),
-          servicesCalled: claimData.servicesCalled?.split(",") || [],
+          servicesCalled: Array.isArray(claimData.servicesCalled)
+            ? claimData.servicesCalled
+            : (claimData.servicesCalled?.split(",") ?? []),
           damages: claimData.damages || [],
           decisions: claimData.decisions || [],
           appeals: claimData.appeals || [],

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -27,7 +27,9 @@ const transformApiClaimToFrontend = (apiClaim: EventDto): Claim => {
     totalClaim: apiClaim.totalClaim ?? 0,
     payout: apiClaim.payout ?? 0,
     currency: apiClaim.currency ?? "PLN",
-    servicesCalled: apiClaim.servicesCalled?.split(",").filter(Boolean) || [],
+    servicesCalled: Array.isArray(apiClaim.servicesCalled)
+      ? apiClaim.servicesCalled
+      : (apiClaim.servicesCalled?.split(",").filter(Boolean) ?? []),
     damages: apiClaim.damages || [],
     decisions: apiClaim.decisions || [],
     appeals: apiClaim.appeals || [],


### PR DESCRIPTION
## Summary
- handle array or comma-separated list for servicesCalled when loading claim data
- support array servicesCalled in claim hooks

## Testing
- `pnpm lint` *(fails: requires interactive ESLint setup)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895236ab33c832ca3622d54d34672c9