### PR TITLE
Use array for servicesCalled

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -148,7 +148,7 @@ export default function ClaimPage() {
             inspectionContactEmail: "",
             drivers: [{ id: "", name: "", licenseNumber: "" }],
           },
-          servicesCalled: claimData.servicesCalled?.split(",") || [],
+          servicesCalled: claimData.servicesCalled || [],
           damages: claimData.damages || [],
           decisions: claimData.decisions || [],
           appeals: claimData.appeals || [],

--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -159,7 +159,7 @@ export default function EditClaimPage() {
             inspectionContactEmail: "",
             drivers: [{ id: "", name: "", licenseNumber: "" }],
           },
-          servicesCalled: claimData.servicesCalled?.split(",") || [],
+          servicesCalled: claimData.servicesCalled || [],
           damages: claimData.damages || [],
           decisions: claimData.decisions || [],
           appeals: claimData.appeals || [],

--- a/app/claims/[id]/view/page.tsx
+++ b/app/claims/[id]/view/page.tsx
@@ -126,7 +126,7 @@ export default function ViewClaimPage() {
           ...claimData,
           injuredParty: claimData.participants?.find((p: any) => p.role === "Poszkodowany"),
           perpetrator: claimData.participants?.find((p: any) => p.role === "Sprawca"),
-          servicesCalled: claimData.servicesCalled?.split(",") || [],
+          servicesCalled: claimData.servicesCalled || [],
           damages: claimData.damages || [],
           decisions: claimData.decisions || [],
           appeals: claimData.appeals || [],

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -27,7 +27,7 @@ const transformApiClaimToFrontend = (apiClaim: EventDto): Claim => {
     totalClaim: apiClaim.totalClaim ?? 0,
     payout: apiClaim.payout ?? 0,
     currency: apiClaim.currency ?? "PLN",
-    servicesCalled: apiClaim.servicesCalled?.split(",").filter(Boolean) || [],
+    servicesCalled: apiClaim.servicesCalled || [],
     damages: apiClaim.damages || [],
     decisions: apiClaim.decisions || [],
     appeals: apiClaim.appeals || [],
@@ -132,7 +132,7 @@ const transformFrontendClaimToApiPayload = (claimData: Partial<Claim>): EventUps
     reportDate: rest.reportDate ? new Date(rest.reportDate).toISOString() : undefined,
     reportDateToInsurer: rest.reportDateToInsurer ? new Date(rest.reportDateToInsurer).toISOString() : undefined,
     eventTime: rest.eventTime,
-    servicesCalled: servicesCalled?.join(","),
+    servicesCalled,
     participants: participants,
 
     documents: documents?.map((d) => ({ id: d.id, filePath: d.url })),

--- a/hooks/use-events.ts
+++ b/hooks/use-events.ts
@@ -55,7 +55,7 @@ const transformToApiEvent = (event: Partial<Event>): Partial<EventDto> => ({
   eventTime: event.eventTime || "",
   location: event.location || "",
   description: event.eventDescription,
-  servicesCalled: event.policeInvolved ? "policja" : "",
+  servicesCalled: event.policeInvolved ? ["policja"] : [],
 })
 
 export function useEvents() {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -31,7 +31,7 @@ export interface EventDto extends EventListItemDto {
   eventTime?: string
   location?: string
   description?: string
-  servicesCalled?: string
+  servicesCalled?: string[]
   insuranceCompanyId?: number
   handlerId?: number
   riskType?: string
@@ -70,7 +70,7 @@ export interface EventUpsertDto {
   eventTime?: string
   location?: string
   description?: string
-  servicesCalled?: string
+  servicesCalled?: string[]
   totalClaim?: number
   payout?: number
   currency?: string


### PR DESCRIPTION
## Summary
- Represent `servicesCalled` as a string array in Event DTOs
- Use arrays directly in claim and event hooks for `servicesCalled`
- Load claim pages with `servicesCalled` arrays

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895236b769c832c9cb95e3d8ff50643