### PR TITLE
Align claim types with API

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -31,6 +31,10 @@ export interface EventDto extends EventListItemDto {
   eventTime?: string
   location?: string
   description?: string
+  /**
+   * Comma-separated list of services that were called
+   * e.g. "policja,pogotowie,straz".
+   */
   servicesCalled?: string
   insuranceCompanyId?: number
   handlerId?: number
@@ -70,6 +74,10 @@ export interface EventUpsertDto {
   eventTime?: string
   location?: string
   description?: string
+  /**
+   * Comma-separated list of services that were called
+   * e.g. "policja,pogotowie,straz".
+   */
   servicesCalled?: string
   totalClaim?: number
   payout?: number

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,17 +1,35 @@
 import type React from "react"
+import type { EventDto } from "@/lib/api"
 
-export interface Claim {
+export interface Claim
+  extends Omit<
+    EventDto,
+    | "id"
+    | "clientId"
+    | "insuranceCompanyId"
+    | "leasingCompanyId"
+    | "handlerId"
+    | "servicesCalled"
+    | "participants"
+    | "damages"
+    | "decisions"
+    | "appeals"
+    | "clientClaims"
+    | "recourses"
+    | "settlements"
+  > {
   id?: string
-  spartaNumber?: string
-  claimNumber?: string
+  clientId?: string
+  insuranceCompanyId?: string
+  leasingCompanyId?: string
+  handlerId?: string
+  /**
+   * List of services called.
+   * API stores this as a comma-separated string
+   * (e.g. "policja,pogotowie").
+   */
+  servicesCalled?: Service[]
   insurerClaimNumber?: string
-  status?: string
-  riskType?: string
-  damageType?: string
-  damageDate?: string
-  eventTime?: string
-  reportDate?: string
-  reportDateToInsurer?: string
   eventLocation?: string
   eventDescription?: string
   comments?: string
@@ -20,7 +38,6 @@ export interface Claim {
   statementWithPerpetrator?: boolean
   perpetratorFined?: boolean
   reportingChannel?: string
-  servicesCalled?: Service[]
   policeDescription?: string
   ambulanceDescription?: string
   fireDescription?: string
@@ -38,24 +55,8 @@ export interface Claim {
   clientClaims?: ClientClaim[]
   recourses?: Recourse[]
   settlements?: Settlement[]
-  client?: string
-  clientId?: string
-  handler?: string
-  handlerId?: string
   handlerEmail?: string
   handlerPhone?: string
-  insuranceCompany?: string
-  insuranceCompanyId?: string
-  leasingCompany?: string
-  leasingCompanyId?: string
-  totalClaim?: number
-  payout?: number
-  currency?: string
-  liquidator?: string
-  brand?: string
-  vehicleNumber?: string
-  location?: string
-  description?: string
   documents?: UploadedFile[]
   pendingFiles?: UploadedFile[]
   documentsSectionProps?: DocumentsSectionProps


### PR DESCRIPTION
## Summary
- Base `Claim` interface on `EventDto` and convert ID fields to strings for UI
- Clarify `servicesCalled` handling and document expected comma-separated format

## Testing
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6895236d93f8832c94a7d9c258492f97