### PR TITLE
refactor: centralize claim transformation

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -26,7 +26,7 @@ import { ClaimFormSidebar } from "@/components/claim-form/claim-form-sidebar"
 import { ClaimTopHeader } from "@/components/claim-form/claim-top-header"
 import { ClaimMainContent } from "@/components/claim-form/claim-main-content"
 import { useClaimForm } from "@/hooks/use-claim-form"
-import { useClaims } from "@/hooks/use-claims"
+import { useClaims, transformApiClaimToFrontend } from "@/hooks/use-claims"
 import { generateId } from "@/lib/constants"
 import type { Claim, UploadedFile, RequiredDocument } from "@/types"
 
@@ -103,59 +103,7 @@ export default function ClaimPage() {
 
       const claimData = await response.json()
       if (claimData) {
-        // Transform API data to frontend format
-        const transformedData = {
-          ...claimData,
-          injuredParty: claimData.participants?.find((p: any) => p.role === "Poszkodowany") || {
-            id: "",
-            name: "",
-            phone: "",
-            email: "",
-            address: "",
-            city: "",
-            postalCode: "",
-            country: "Polska",
-            insuranceCompany: "",
-            policyNumber: "",
-            vehicleRegistration: "",
-            vehicleVin: "",
-            vehicleType: "",
-            vehicleBrand: "",
-            vehicleModel: "",
-            inspectionContactName: "",
-            inspectionContactPhone: "",
-            inspectionContactEmail: "",
-            drivers: [{ id: "", name: "", licenseNumber: "" }],
-          },
-          perpetrator: claimData.participants?.find((p: any) => p.role === "Sprawca") || {
-            id: "",
-            name: "",
-            phone: "",
-            email: "",
-            address: "",
-            city: "",
-            postalCode: "",
-            country: "Polska",
-            insuranceCompany: "",
-            policyNumber: "",
-            vehicleRegistration: "",
-            vehicleVin: "",
-            vehicleType: "",
-            vehicleBrand: "",
-            vehicleModel: "",
-            inspectionContactName: "",
-            inspectionContactPhone: "",
-            inspectionContactEmail: "",
-            drivers: [{ id: "", name: "", licenseNumber: "" }],
-          },
-          servicesCalled: claimData.servicesCalled?.split(",") || [],
-          damages: claimData.damages || [],
-          decisions: claimData.decisions || [],
-          appeals: claimData.appeals || [],
-          clientClaims: claimData.clientClaims || [],
-          recourses: claimData.recourses || [],
-          settlements: claimData.settlements || [],
-        }
+        const transformedData = transformApiClaimToFrontend(claimData)
 
         setClaim(transformedData)
         if (mode === "edit") {

--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -10,7 +10,7 @@ import { ClaimFormSidebar } from "@/components/claim-form/claim-form-sidebar"
 import { ClaimTopHeader } from "@/components/claim-form/claim-top-header"
 import { ClaimMainContent } from "@/components/claim-form/claim-main-content"
 import { useClaimForm } from "@/hooks/use-claim-form"
-import { useClaims } from "@/hooks/use-claims"
+import { useClaims, transformApiClaimToFrontend } from "@/hooks/use-claims"
 import type { UploadedFile, RequiredDocument } from "@/types"
 
 export default function EditClaimPage() {
@@ -113,61 +113,7 @@ export default function EditClaimPage() {
 
       const claimData = await response.json()
       if (claimData) {
-        // Transform API data to frontend format if needed
-        const transformedData = {
-          ...claimData,
-          // Ensure participants have proper structure
-          injuredParty: claimData.participants?.find((p: any) => p.role === "Poszkodowany") || {
-            id: "",
-            name: "",
-            phone: "",
-            email: "",
-            address: "",
-            city: "",
-            postalCode: "",
-            country: "Polska",
-            insuranceCompany: "",
-            policyNumber: "",
-            vehicleRegistration: "",
-            vehicleVin: "",
-            vehicleType: "",
-            vehicleBrand: "",
-            vehicleModel: "",
-            inspectionContactName: "",
-            inspectionContactPhone: "",
-            inspectionContactEmail: "",
-            drivers: [{ id: "", name: "", licenseNumber: "" }],
-          },
-          perpetrator: claimData.participants?.find((p: any) => p.role === "Sprawca") || {
-            id: "",
-            name: "",
-            phone: "",
-            email: "",
-            address: "",
-            city: "",
-            postalCode: "",
-            country: "Polska",
-            insuranceCompany: "",
-            policyNumber: "",
-            vehicleRegistration: "",
-            vehicleVin: "",
-            vehicleType: "",
-            vehicleBrand: "",
-            vehicleModel: "",
-            inspectionContactName: "",
-            inspectionContactPhone: "",
-            inspectionContactEmail: "",
-            drivers: [{ id: "", name: "", licenseNumber: "" }],
-          },
-          servicesCalled: claimData.servicesCalled?.split(",") || [],
-          damages: claimData.damages || [],
-          decisions: claimData.decisions || [],
-          appeals: claimData.appeals || [],
-          clientClaims: claimData.clientClaims || [],
-          recourses: claimData.recourses || [],
-          settlements: claimData.settlements || [],
-        }
-
+        const transformedData = transformApiClaimToFrontend(claimData)
         setClaimFormData(transformedData)
       } else {
         throw new Error("Nie znaleziono danych szkody")

--- a/app/claims/[id]/view/page.tsx
+++ b/app/claims/[id]/view/page.tsx
@@ -19,6 +19,7 @@ import { ArrowLeft, Edit, FileText, User, AlertTriangle, Car, Calendar, Phone, M
 import type { Claim } from "@/types"
 import { pksData, type Employee } from "@/lib/pks-data"
 import type { RepairDetail } from "@/lib/repair-details-store"
+import { transformApiClaimToFrontend } from "@/hooks/use-claims"
 
 interface RepairSchedule {
   id?: string
@@ -121,19 +122,7 @@ export default function ViewClaimPage() {
 
       const claimData = await response.json()
       if (claimData) {
-        // Transform API data to frontend format
-        const transformedData = {
-          ...claimData,
-          injuredParty: claimData.participants?.find((p: any) => p.role === "Poszkodowany"),
-          perpetrator: claimData.participants?.find((p: any) => p.role === "Sprawca"),
-          servicesCalled: claimData.servicesCalled?.split(",") || [],
-          damages: claimData.damages || [],
-          decisions: claimData.decisions || [],
-          appeals: claimData.appeals || [],
-          clientClaims: claimData.clientClaims || [],
-          recourses: claimData.recourses || [],
-          settlements: claimData.settlements || [],
-        }
+        const transformedData = transformApiClaimToFrontend(claimData)
         setClaim(transformedData)
       } else {
         throw new Error("Nie znaleziono danych szkody")

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -1,10 +1,16 @@
 "use client"
 
 import { useState, useCallback } from "react"
-import { apiService, type EventUpsertDto, type EventDto, type ParticipantUpsertDto, type EventListItemDto } from "@/lib/api"
+import {
+  apiService,
+  type EventUpsertDto,
+  type EventDto,
+  type ParticipantUpsertDto,
+  type EventListItemDto,
+} from "@/lib/api"
 import type { Claim, ParticipantInfo, DriverInfo } from "@/types"
 
-const transformApiClaimToFrontend = (apiClaim: EventDto): Claim => {
+export const transformApiClaimToFrontend = (apiClaim: EventDto): Claim => {
   const injuredParty = apiClaim.participants?.find((p: any) => p.role === "Poszkodowany")
   const perpetrator = apiClaim.participants?.find((p: any) => p.role === "Sprawca")
 
@@ -39,7 +45,9 @@ const transformApiClaimToFrontend = (apiClaim: EventDto): Claim => {
   }
 }
 
-const transformFrontendClaimToApiPayload = (claimData: Partial<Claim>): EventUpsertDto => {
+export const transformFrontendClaimToApiPayload = (
+  claimData: Partial<Claim>,
+): EventUpsertDto => {
   const {
     id,
     decisions,


### PR DESCRIPTION
## Summary
- export `transformApiClaimToFrontend` for consistent claim mapping
- use shared mapping helper in claim pages to replace inline transformations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895236cd990832c808d36ec26e6fdf7