### PR TITLE
fix: ensure unique list keys across sources

### DIFF
--- a/components/client-dropdown.tsx
+++ b/components/client-dropdown.tsx
@@ -181,7 +181,7 @@ export default function ClientDropdown({
           ) : (
             filteredClients.map((client) => (
               <div
-                key={client.id}
+                key={`client-${client.id}`}
                 className={`dropdown-item ${selectedClient?.id === client.id ? "selected" : ""}`}
                 onClick={() => selectClient(client)}
               >

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -847,7 +847,7 @@ export const DocumentsSection = ({
                         <tbody>
                           {documentsForCategory.map((document, index) => (
                             <tr
-                              key={document.id}
+                              key={`${document.status}-${document.id}`}
                               className={`border-t ${index % 2 === 0 ? "bg-white" : "bg-gray-50/50"}`}
                             >
                               <td className="p-3 font-medium flex items-center gap-2">
@@ -931,7 +931,11 @@ export const DocumentsSection = ({
                   ) : documentsForCategory.length > 0 ? (
                     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
                       {documentsForCategory.map((document) => (
-                        <FileCard key={document.id} document={document} onDelete={handleFileDelete} />
+                        <FileCard
+                          key={`${document.status}-${document.id}`}
+                          document={document}
+                          onDelete={handleFileDelete}
+                        />
                       ))}
                     </div>
                   ) : (
@@ -972,7 +976,7 @@ export const DocumentsSection = ({
               <div className="border rounded-md">
                 {missingRequiredDocs.map((doc, index, arr) => (
                   <div
-                    key={doc.id}
+                    key={`required-${doc.id}`}
                     className={`flex items-center justify-between p-4 ${index < arr.length - 1 ? "border-b" : ""}`}
                   >
                     <div className="flex items-center gap-3">
@@ -1005,7 +1009,7 @@ export const DocumentsSection = ({
                 {allDocuments
                   .filter((d) => d.documentType === groupPreviewCategory)
                   .map((document) => (
-                    <Card key={document.id} className="overflow-hidden">
+                    <Card key={`${document.status}-${document.id}`} className="overflow-hidden">
                       <div className="aspect-w-16 aspect-h-12 bg-gray-100 flex items-center justify-center min-h-[200px]">
                         {document.contentType.startsWith("image/") ? (
                           <img

--- a/components/handler-dropdown.tsx
+++ b/components/handler-dropdown.tsx
@@ -166,7 +166,7 @@ export default function HandlerDropdown({
           ) : (
             filteredHandlers.map((handler) => (
               <div
-                key={handler.id}
+                key={`handler-${handler.id}`}
                 className={`dropdown-item ${selectedHandler?.id === handler.id ? "selected" : ""}`}
                 onClick={() => selectHandler(handler)}
               >

--- a/components/insurance-dropdown.tsx
+++ b/components/insurance-dropdown.tsx
@@ -168,7 +168,7 @@ export default function InsuranceDropdown({
           ) : (
             filteredCompanies.map((company) => (
               <div
-                key={company.id}
+                key={`insurance-${company.id}`}
                 className={`dropdown-item ${selectedCompany?.id === company.id ? "selected" : ""}`}
                 onClick={() => selectCompany(company)}
               >

--- a/components/leasing-dropdown.tsx
+++ b/components/leasing-dropdown.tsx
@@ -168,7 +168,7 @@ export default function LeasingDropdown({
           ) : (
             filteredCompanies.map((company) => (
               <div
-                key={company.id}
+                key={`leasing-${company.id}`}
                 className={`dropdown-item ${selectedCompany?.id === company.id ? "selected" : ""}`}
                 onClick={() => selectCompany(company)}
               >

--- a/components/vehicle-type-dropdown.tsx
+++ b/components/vehicle-type-dropdown.tsx
@@ -141,7 +141,7 @@ export default function VehicleTypeDropdown({
                   <CommandGroup>
                     {filteredVehicleTypes.map((vehicleType) => (
                       <CommandItem
-                        key={vehicleType.id}
+                        key={`vehicle-type-${vehicleType.id}`}
                         value={vehicleType.id}
                         onSelect={() => handleVehicleTypeSelect(vehicleType)}
                         className="cursor-pointer"


### PR DESCRIPTION
## Summary
- ensure dropdowns use source-prefixed keys for merged datasets
- prefix document keys with status to avoid duplicate list keys

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68952689332c832cbc56fc014daec209