### PR TITLE
refactor: send EventUpsertDto directly

### DIFF
--- a/backend/Controllers/EventsController.cs
+++ b/backend/Controllers/EventsController.cs
@@ -147,11 +147,10 @@ namespace AutomotiveClaimsApi.Controllers
         }
 
         [HttpPost]
-        public async Task<ActionResult<EventDto>> CreateEvent([FromBody] EventUpsertRequest request)
+        public async Task<ActionResult<EventDto>> CreateEvent([FromBody] EventUpsertDto eventDto)
         {
             try
             {
-                var eventDto = request.EventDto;
                 var eventEntity = new Event
                 {
                     Id = Guid.NewGuid(),
@@ -282,11 +281,10 @@ namespace AutomotiveClaimsApi.Controllers
         }
 
         [HttpPut("{id}")]
-        public async Task<IActionResult> UpdateEvent(Guid id, [FromBody] EventUpsertRequest request)
+        public async Task<IActionResult> UpdateEvent(Guid id, [FromBody] EventUpsertDto eventDto)
         {
             try
             {
-                var eventDto = request.EventDto;
                 var eventEntity = await _context.Events
                     .Include(e => e.Participants).ThenInclude(p => p.Drivers)
                     .Include(e => e.Damages)

--- a/backend/DTOs/EventUpsertRequest.cs
+++ b/backend/DTOs/EventUpsertRequest.cs
@@ -1,7 +1,0 @@
-namespace AutomotiveClaimsApi.DTOs
-{
-    public class EventUpsertRequest
-    {
-        public EventUpsertDto EventDto { get; set; } = new EventUpsertDto();
-    }
-}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -417,14 +417,14 @@ class ApiService {
   async createClaim(claim: EventUpsertDto): Promise<EventDto> {
     return this.request<EventDto>("/events", {
       method: "POST",
-      body: JSON.stringify({ eventDto: claim }),
+      body: JSON.stringify(claim),
     })
   }
 
   async updateClaim(id: string, claim: EventUpsertDto): Promise<EventDto> {
     return this.request<EventDto>(`/events/${id}`, {
       method: "PUT",
-      body: JSON.stringify({ eventDto: claim }),
+      body: JSON.stringify(claim),
     })
   }
 


### PR DESCRIPTION
## Summary
- accept EventUpsertDto directly in event create/update API
- remove EventUpsertRequest wrapper and map DTO parameters
- send claim payload directly from frontend API calls

## Testing
- `dotnet build backend/AutomotiveClaimsApi.csproj` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689528beaef4832cb5b1510b7f093856