### PR TITLE
Ensure file removal when soft deleting documents

### DIFF
--- a/backend/Services/DocumentService.cs
+++ b/backend/Services/DocumentService.cs
@@ -114,6 +114,24 @@ namespace AutomotiveClaimsApi.Services
             document.IsDeleted = true;
             await _context.SaveChangesAsync();
             _logger.LogInformation("Document with ID {DocumentId} soft-deleted.", id);
+
+            try
+            {
+                var deleted = await DeleteDocumentAsync(document.FilePath);
+                if (!deleted)
+                {
+                    _logger.LogWarning(
+                        "File deletion failed for Document ID {DocumentId} at {FilePath}",
+                        id, document.FilePath);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Unexpected error deleting file for Document ID {DocumentId} at {FilePath}",
+                    id, document.FilePath);
+            }
+
             return true;
         }
 


### PR DESCRIPTION
## Summary
- Attempt to remove document files after marking them as deleted
- Log failures so database state remains consistent even when file removal errors occur

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689529f87070832c890e0df8a0cf823c