### PR TITLE
Document service stream disposal guidance

### DIFF
--- a/backend/Controllers/DocumentsController.cs
+++ b/backend/Controllers/DocumentsController.cs
@@ -105,6 +105,7 @@ namespace AutomotiveClaimsApi.Controllers
             if (result == null)
                 return NotFound();
 
+            // File() handles disposing the stream after the response is sent.
             return File(result.FileStream, result.ContentType, result.FileName);
         }
 
@@ -115,6 +116,7 @@ namespace AutomotiveClaimsApi.Controllers
             if (result == null)
                 return NotFound();
 
+            // File() handles disposing the stream after the response is sent.
             return File(result.FileStream, result.ContentType);
         }
 

--- a/backend/Services/IDocumentService.cs
+++ b/backend/Services/IDocumentService.cs
@@ -14,8 +14,20 @@ namespace AutomotiveClaimsApi.Services
         Task<DocumentDto> UploadAndCreateDocumentAsync(IFormFile file, CreateDocumentDto createDto);
         Task<bool> DeleteDocumentAsync(Guid id);
         Task<bool> DeleteDocumentAsync(string filePath);
+        /// <summary>
+        /// Retrieves a document for download by its identifier.
+        /// </summary>
+        /// <remarks>
+        /// Callers are responsible for disposing the <see cref="DocumentDownloadResult.FileStream"/> returned in the result.
+        /// </remarks>
         Task<DocumentDownloadResult?> DownloadDocumentAsync(Guid id);
         Task<(string FilePath, string OriginalFileName)> SaveDocumentAsync(IFormFile file, string category, string? description);
+        /// <summary>
+        /// Retrieves a document based on its file path.
+        /// </summary>
+        /// <remarks>
+        /// Callers are responsible for disposing the <see cref="DocumentDownloadResult.FileStream"/> returned in the result.
+        /// </remarks>
         Task<DocumentDownloadResult?> GetDocumentAsync(string filePath);
         Task<Stream> GetDocumentStreamAsync(string filePath);
         Task<DocumentDto> UploadDocumentAsync(IFormFile file, string category, string entityId);


### PR DESCRIPTION
## Summary
- Documented stream disposal responsibility for DownloadDocumentAsync and GetDocumentAsync
- Noted controller actions rely on ASP.NET to dispose streams

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689529f96f68832c9bbf505bc2f7ad10