### PR TITLE
Implement document download logic in DocumentService

### DIFF
--- a/backend/Services/DocumentService.cs
+++ b/backend/Services/DocumentService.cs
@@ -117,9 +117,31 @@ namespace AutomotiveClaimsApi.Services
             return true;
         }
 
-        public Task<DocumentDownloadResult?> DownloadDocumentAsync(Guid id)
+        public async Task<DocumentDownloadResult?> DownloadDocumentAsync(Guid id)
         {
-            throw new NotImplementedException();
+            var document = await _context.Documents
+                .Where(d => d.Id == id && !d.IsDeleted)
+                .FirstOrDefaultAsync();
+
+            if (document == null)
+            {
+                return null;
+            }
+
+            var fullPath = Path.Combine(_uploadsPath, document.FilePath.Replace("uploads/", ""));
+            if (!File.Exists(fullPath))
+            {
+                return null;
+            }
+
+            var memoryStream = new MemoryStream(await File.ReadAllBytesAsync(fullPath));
+
+            return new DocumentDownloadResult
+            {
+                FileStream = memoryStream,
+                ContentType = GetContentType(fullPath),
+                FileName = document.OriginalFileName ?? document.FileName
+            };
         }
 
         public async Task<bool> DeleteDocumentAsync(string filePath)


### PR DESCRIPTION
## Summary
- Implement `DownloadDocumentAsync` to retrieve stored document files, returning a stream and metadata

## Testing
- `pnpm test`
- `dotnet build` *(fails: bash: command not found: dotnet)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed.)*


------
https://chatgpt.com/codex/tasks/task_e_689529f6b848832c8965744c7f208b4f