### PR TITLE
Initialize claim drafts and streamline document handling

### DIFF
--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -51,7 +51,7 @@ interface RepairSchedule {
 export default function NewClaimPage() {
   const router = useRouter()
   const { toast } = useToast()
-  const { createClaim } = useClaims()
+  const { createClaim, initializeClaim } = useClaims()
   const [activeClaimSection, setActiveClaimSection] = useState("dane-zdarzenia")
   const [isSaving, setIsSaving] = useState(false)
   
@@ -100,6 +100,14 @@ export default function NewClaimPage() {
     handleRemoveDriver,
     resetForm,
   } = useClaimForm()
+
+  useEffect(() => {
+    initializeClaim().then((id) => {
+      if (id) {
+        setClaimFormData((prev) => ({ ...prev, id }))
+      }
+    })
+  }, [initializeClaim, setClaimFormData])
 
   const getInitialScheduleData = (): Partial<RepairSchedule> => ({
     eventId: "new",

--- a/backend/Controllers/EventsController.cs
+++ b/backend/Controllers/EventsController.cs
@@ -146,6 +146,32 @@ namespace AutomotiveClaimsApi.Controllers
             }
         }
 
+        [HttpPost("initialize")]
+        public async Task<ActionResult<object>> InitializeEvent()
+        {
+            try
+            {
+                var eventEntity = new Event
+                {
+                    Id = Guid.NewGuid(),
+                    Status = "Nowa",
+                    Currency = "PLN",
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                };
+
+                _context.Events.Add(eventEntity);
+                await _context.SaveChangesAsync();
+
+                return Ok(new { id = eventEntity.Id });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error initializing event");
+                return StatusCode(500, new { error = "Failed to initialize event" });
+            }
+        }
+
         [HttpPost]
         public async Task<ActionResult<EventDto>> CreateEvent([FromBody] EventUpsertDto eventDto)
         {

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -218,12 +218,11 @@ export const ClaimMainContent = ({
   })
 
   useEffect(() => {
-    const eventId = claimFormData.id || claimFormData.spartaNumber
-    if (!eventId) return
+    if (!claimFormData.id) return
 
     const loadNotes = async () => {
       try {
-        const response = await fetch(`/api/notes?eventId=${eventId}`)
+        const response = await fetch(`/api/notes?eventId=${claimFormData.id}`)
         if (!response.ok) throw new Error()
         const data = await response.json()
         const mappedNotes: Note[] = data.map((note: any) => ({
@@ -248,7 +247,7 @@ export const ClaimMainContent = ({
     }
 
     loadNotes()
-  }, [claimFormData.id, claimFormData.spartaNumber])
+  }, [claimFormData.id])
 
   // State for expanded sections in teczka-szkodowa
   const [expandedSections, setExpandedSections] = useState({
@@ -435,7 +434,7 @@ export const ClaimMainContent = ({
       return
     }
 
-    const eventId = claimFormData.id || claimFormData.spartaNumber
+    const eventId = claimFormData.id
     if (!eventId) {
       toast({
         title: "Błąd",
@@ -1944,7 +1943,6 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
       )
 
     case "dokumenty": {
-      const eventId = claimFormData.id || claimFormData.spartaNumber
       return (
         <div className="space-y-4">
           <Card className="overflow-hidden shadow-sm border-gray-200 rounded-xl">
@@ -1955,18 +1953,14 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
               <CardTitle className="text-lg font-semibold">Dokumenty</CardTitle>
             </CardHeader>
             <CardContent className="p-0 bg-white">
-              {eventId ? (
+              {claimFormData.id && (
                 <DocumentsSection
                   uploadedFiles={uploadedFiles}
                   setUploadedFiles={setUploadedFiles}
                   requiredDocuments={requiredDocuments}
                   setRequiredDocuments={setRequiredDocuments}
-                  eventId={eventId}
+                  eventId={claimFormData.id}
                 />
-              ) : (
-                <div className="p-4 text-sm text-gray-500">
-                  Zapisz roszczenie, aby dodać dokumenty.
-                </div>
               )}
             </CardContent>
           </Card>
@@ -2711,19 +2705,15 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
               </div>
             </div>
             <div className="p-4">
-              {eventId ? (
+              {claimFormData.id && (
                 <DocumentsSection
                   uploadedFiles={uploadedFiles}
                   setUploadedFiles={setUploadedFiles}
-                  requiredDocuments={[]} // Empty array to hide required documents section
-                  setRequiredDocuments={() => {}} // No-op function
-                  eventId={eventId}
-                  hideRequiredDocuments={true} // Add this prop to hide required docs
+                  requiredDocuments={[]}
+                  setRequiredDocuments={() => {}}
+                  eventId={claimFormData.id}
+                  hideRequiredDocuments={true}
                 />
-              ) : (
-                <p className="text-sm text-gray-500">
-                  Zapisz roszczenie, aby dodać dokumenty.
-                </p>
               )}
             </div>
           </div>

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { useToast } from "@/hooks/use-toast"
 import { File, Search, Filter, Eye, Download, Upload, X, Trash2, Grid, List, Wand, Plus, FileText, Paperclip, ZoomIn, ZoomOut, ChevronLeft, ChevronRight, RotateCw, Maximize2, Minimize2 } from 'lucide-react'
-import type { DocumentsSectionProps, UploadedFile } from "@/types"
+import type { DocumentsSectionProps } from "@/types"
 
 interface Document {
   id: string
@@ -35,8 +35,6 @@ export const DocumentsSection = ({
   requiredDocuments,
   setRequiredDocuments,
   eventId,
-  pendingFiles = [],
-  setPendingFiles,
   hideRequiredDocuments = false,
 }: DocumentsSectionProps & { hideRequiredDocuments?: boolean }) => {
   const { toast } = useToast()
@@ -60,28 +58,7 @@ export const DocumentsSection = ({
   const [currentPreviewIndex, setCurrentPreviewIndex] = useState(0)
   const [previewDocuments, setPreviewDocuments] = useState<Document[]>([])
 
-  const uploadedFileToDocument = (file: UploadedFile): Document => ({
-    id: file.id,
-    fileName: file.name,
-    originalFileName: file.name,
-    contentType: file.file?.type || "",
-    fileSize: file.size,
-    filePath: file.url,
-    description: file.description,
-    status: "pending",
-    uploadedBy: "Current User",
-    createdAt: file.uploadedAt,
-    updatedAt: file.uploadedAt,
-    canPreview: file.type === "image" || file.type === "pdf",
-    previewUrl: file.url,
-    downloadUrl: file.url,
-    documentType: file.category || "Inne dokumenty",
-  })
-
-  const allDocuments = React.useMemo(
-    () => [...documents, ...pendingFiles.map(uploadedFileToDocument)],
-    [documents, pendingFiles]
-  )
+  const allDocuments = documents
 
   // Load documents from API
   useEffect(() => {
@@ -137,61 +114,13 @@ export const DocumentsSection = ({
   }, [requiredDocuments, allDocuments])
 
   const handleFileUpload = async (files: FileList | null, category: string | null) => {
-    if (!files || !category) {
+    if (!files || !category || !eventId) {
       console.error("Missing required parameters:", { files: !!files, category })
       toast({
         title: "Błąd",
         description: "Brak wymaganych parametrów do przesłania pliku",
         variant: "destructive",
       })
-      return
-    }
-
-    // Handle temporary uploads when eventId is not provided
-    if (!eventId) {
-      const newFiles: UploadedFile[] = []
-      Array.from(files).forEach((file, index) => {
-        if (file.size > 50 * 1024 * 1024) {
-          toast({
-            title: "Plik za duży",
-            description: `Plik "${file.name}" jest za duży. Maksymalny rozmiar to 50MB.`,
-            variant: "destructive",
-          })
-          return
-        }
-        if (file.size === 0) {
-          toast({
-            title: "Pusty plik",
-            description: `Plik "${file.name}" jest pusty.`,
-            variant: "destructive",
-          })
-          return
-        }
-        newFiles.push({
-          id: `temp-${Date.now()}-${index}`,
-          name: file.name,
-          size: file.size,
-          type: file.type.includes("image")
-            ? "image"
-            : file.type.includes("pdf")
-            ? "pdf"
-            : file.type.includes("msword") || file.type.includes("wordprocessingml")
-            ? "doc"
-            : "other",
-          uploadedAt: new Date().toISOString(),
-          url: URL.createObjectURL(file),
-          category: category || "Inne dokumenty",
-          file: file,
-        })
-      })
-
-      if (newFiles.length > 0) {
-        setPendingFiles?.((prev) => [...prev, ...newFiles])
-        toast({
-          title: "Dodano pliki",
-          description: `Dodano ${newFiles.length} plik(ów) do kategorii "${category}".`,
-        })
-      }
       return
     }
 
@@ -365,17 +294,6 @@ export const DocumentsSection = ({
   }
 
   const handleFileDelete = async (documentId: string | number) => {
-    const isPending = pendingFiles.some((f) => f.id === documentId)
-    if (isPending) {
-      if (!window.confirm("Czy na pewno chcesz usunąć ten dokument?")) return
-      setPendingFiles?.((prev) => prev.filter((f) => f.id !== documentId))
-      toast({
-        title: "Plik usunięty",
-        description: "Dokument został pomyślnie usunięty.",
-      })
-      return
-    }
-
     if (!window.confirm("Czy na pewno chcesz usunąć ten dokument?")) {
       return
     }
@@ -406,11 +324,6 @@ export const DocumentsSection = ({
   }
 
   const handleDescriptionChange = async (documentId: string | number, description: string) => {
-    const pendingIndex = pendingFiles.findIndex((f) => f.id === documentId)
-    if (pendingIndex !== -1) {
-      setPendingFiles?.((prev) => prev.map((f) => (f.id === documentId ? { ...f, description } : f)))
-      return
-    }
     try {
       const response = await fetch(`/api/documents/${documentId}`, {
         method: "PUT",

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -224,6 +224,18 @@ export function useClaims() {
     }
   }
 
+  const initializeClaim = async (): Promise<string | null> => {
+    try {
+      setError(null)
+      const { id } = await apiService.initializeClaim()
+      return id
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "An unknown error occurred"
+      setError(`Failed to initialize claim: ${message}`)
+      return null
+    }
+  }
+
   const createClaim = async (claimData: Claim): Promise<Claim | null> => {
     try {
       setError(null)
@@ -277,6 +289,7 @@ export function useClaims() {
     error,
     fetchClaims,
     getClaim,
+    initializeClaim,
     createClaim,
     updateClaim,
     deleteClaim,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -434,6 +434,12 @@ class ApiService {
     })
   }
 
+  async initializeClaim(): Promise<{ id: string }> {
+    return this.request<{ id: string }>("/events/initialize", {
+      method: "POST",
+    })
+  }
+
   // Events API
   async getEvents(): Promise<EventDto[]> {
     return this.request<EventDto[]>("/events")

--- a/types/index.ts
+++ b/types/index.ts
@@ -58,7 +58,6 @@ export interface Claim
   handlerEmail?: string
   handlerPhone?: string
   documents?: UploadedFile[]
-  pendingFiles?: UploadedFile[]
   documentsSectionProps?: DocumentsSectionProps
 }
 
@@ -203,7 +202,5 @@ export interface DocumentsSectionProps {
   setUploadedFiles: React.Dispatch<React.SetStateAction<UploadedFile[]>>
   requiredDocuments: RequiredDocument[]
   setRequiredDocuments: React.Dispatch<React.SetStateAction<RequiredDocument[]>>
-  eventId?: number | string
-  pendingFiles?: UploadedFile[]
-  setPendingFiles?: React.Dispatch<React.SetStateAction<UploadedFile[]>>
+  eventId: string | number
 }


### PR DESCRIPTION
## Summary
- add backend endpoint to create empty claim and return its id
- expose initializeClaim API and hook for draft creation
- pre-initialize claim IDs in creation flows and simplify document uploads/notes

## Testing
- `npm test`
- `dotnet build` *(fails: command not found, apt-get update 403)*

------
https://chatgpt.com/codex/tasks/task_e_68952cab2d10832ca84e740228a70e76