### PR TITLE
Ensure damage type is sent as string

### DIFF
--- a/components/ui/dependent-select.tsx
+++ b/components/ui/dependent-select.tsx
@@ -7,6 +7,7 @@ import { Loader2, AlertCircle } from 'lucide-react'
 interface Option {
   id: string
   name: string
+  code?: string
   [key: string]: any
 }
 
@@ -118,7 +119,7 @@ export function DependentSelect({
           !error &&
           options.length > 0 &&
           options.map((option) => (
-            <SelectItem key={option.id} value={option.id}>
+            <SelectItem key={option.id} value={option.code ?? option.id}>
               {option.name}
             </SelectItem>
           ))}

--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -8,7 +8,7 @@ import { transformFrontendClaimToApiPayload } from '../use-claims'
 test('includes dropdown selections in payload', () => {
   const payload = transformFrontendClaimToApiPayload({
     riskType: 'RT',
-    damageType: 'DT',
+    damageType: { code: 'DT', name: 'Damage' } as any,
     insuranceCompanyId: '5',
     clientId: '7',
     handlerId: '9',

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -76,6 +76,9 @@ export const transformFrontendClaimToApiPayload = (
     ...rest
   } = claimData
 
+  const damageTypeValue =
+    typeof damageType === "object" ? (damageType as any).code : damageType
+
   const participants: ParticipantUpsertDto[] = []
 
   const mapParticipant = (p: ParticipantInfo, role: string): ParticipantUpsertDto => ({
@@ -135,7 +138,7 @@ export const transformFrontendClaimToApiPayload = (
     clientId: clientId ? parseInt(clientId) : undefined,
 
     riskType,
-    damageType,
+    damageType: damageTypeValue,
     insuranceCompanyId: insuranceCompanyId ? parseInt(insuranceCompanyId) : undefined,
     clientId: clientId ? parseInt(clientId) : undefined,
     handlerId: handlerId ? parseInt(handlerId) : undefined,


### PR DESCRIPTION
## Summary
- Convert object `damageType` values to their `code` before sending to the API
- Adjust dependent select to provide damage-type codes instead of ids
- Add unit test covering object damage type payloads

## Testing
- `npm test` *(no tests found)*
- `node --loader ts-node/register --require tsconfig-paths/register --test hooks/__tests__/use-claims.test.ts` *(failed: Unknown file extension ".ts")*

------
https://chatgpt.com/codex/tasks/task_e_6895339cd20c832c943355cc0a5dbd22