### PR TITLE
fix: dedupe claim payload fields and serialize services

### DIFF
--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -68,8 +68,6 @@ export const transformFrontendClaimToApiPayload = (
     leasingCompanyId,
     handlerId,
     clientId,
-    clientId,
-    handlerId,
     riskType,
     damageType,
 
@@ -136,15 +134,12 @@ export const transformFrontendClaimToApiPayload = (
 
     riskType,
     damageType,
-    insuranceCompanyId: insuranceCompanyId ? parseInt(insuranceCompanyId) : undefined,
-    clientId: clientId ? parseInt(clientId) : undefined,
-    handlerId: handlerId ? parseInt(handlerId) : undefined,
 
     damageDate: rest.damageDate ? new Date(rest.damageDate).toISOString() : undefined,
     reportDate: rest.reportDate ? new Date(rest.reportDate).toISOString() : undefined,
     reportDateToInsurer: rest.reportDateToInsurer ? new Date(rest.reportDateToInsurer).toISOString() : undefined,
     eventTime: rest.eventTime,
-    servicesCalled,
+    servicesCalled: servicesCalled?.join(","),
     participants: participants,
 
     documents: documents?.map((d) => ({ id: d.id, filePath: d.url })),


### PR DESCRIPTION
## Summary
- remove duplicate destructured IDs and response assignments in use-claims hook
- send servicesCalled to API as comma-separated string
- ensure transformApiClaimToFrontend parses string back to array

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden for @hello-pangea/dnd)*

------
https://chatgpt.com/codex/tasks/task_e_689533aa62e4832c91a02d3a4af3f8b2