### PR TITLE
Use document name as key fallback

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -889,7 +889,7 @@ export const DocumentsSection = ({
               <div className="border rounded-md">
                 {missingRequiredDocs.map((doc, index, arr) => (
                   <div
-                    key={`required-${doc.id}`}
+                    key={`required-${doc.id ?? doc.name}`}
                     className={`flex items-center justify-between p-4 ${index < arr.length - 1 ? "border-b" : ""}`}
                   >
                     <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- avoid React key warnings in required documents list by falling back to document name when id is missing
- confirm other document lists already use stable keys

## Testing
- `npm test`
- `TS_NODE_TRANSPILE_ONLY=1 TS_NODE_COMPILER_OPTIONS='{"module":"commonjs","moduleResolution":"node","jsx":"react-jsx"}' node -r ts-node/register -r tsconfig-paths/register scripts/render-docs.cjs` (rendered component with duplicate/undefined IDs, no warnings)


------
https://chatgpt.com/codex/tasks/task_e_689533ab9604832c936025a2c04e24cc