### PR TITLE
Remove duplicate fields in event DTOs

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -9,7 +9,6 @@ export interface EventListItemDto {
   vehicleNumber?: string
   clientId?: number
   client?: string
-  clientId?: number
   liquidator?: string
   brand?: string
   status?: string
@@ -62,14 +61,17 @@ export interface EventUpsertDto {
   vehicleNumber?: string
   clientId?: number
   client?: string
-  clientId?: number
   liquidator?: string
   brand?: string
   status?: string
   riskType?: string
   damageType?: string
   insuranceCompanyId?: number
+  insuranceCompany?: string
+  leasingCompanyId?: number
+  leasingCompany?: string
   handlerId?: number
+  handler?: string
   damageDate?: string
   reportDate?: string
   reportDateToInsurer?: string
@@ -86,12 +88,6 @@ export interface EventUpsertDto {
   totalClaim?: number
   payout?: number
   currency?: string
-  insuranceCompanyId?: number
-  insuranceCompany?: string
-  leasingCompanyId?: number
-  leasingCompany?: string
-  handlerId?: number
-  handler?: string
   participants?: ParticipantUpsertDto[]
 
   notes?: NoteUpsertDto[]


### PR DESCRIPTION
## Summary
- remove duplicate clientId property from EventListItemDto
- deduplicate and reorganize client and company fields in EventUpsertDto

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689533a95b54832ca6aac3df763477ba