### PR TITLE
Enable cascade delete for Event participants and documents

### DIFF
--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -58,9 +58,18 @@ namespace AutomotiveClaimsApi.Data
                 entity.HasMany(e => e.Decisions).WithOne(d => d.Event).HasForeignKey(d => d.EventId).OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.Recourses).WithOne(r => r.Event).HasForeignKey(r => r.EventId).OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.Settlements).WithOne(s => s.Event).HasForeignKey(s => s.EventId).OnDelete(DeleteBehavior.Cascade);
-                entity.HasMany(e => e.Participants).WithOne(p => p.Event).HasForeignKey(p => p.EventId).OnDelete(DeleteBehavior.Restrict);
-                entity.HasMany(e => e.Notes).WithOne(n => n.Event).HasForeignKey(n => n.EventId).OnDelete(DeleteBehavior.Cascade);
-                entity.HasMany(e => e.Documents).WithOne(d => d.Event).HasForeignKey(d => d.EventId).OnDelete(DeleteBehavior.Restrict);
+                entity.HasMany(e => e.Participants)
+                    .WithOne(p => p.Event)
+                    .HasForeignKey(p => p.EventId)
+                    .OnDelete(DeleteBehavior.Cascade);
+                entity.HasMany(e => e.Notes)
+                    .WithOne(n => n.Event)
+                    .HasForeignKey(n => n.EventId)
+                    .OnDelete(DeleteBehavior.Cascade);
+                entity.HasMany(e => e.Documents)
+                    .WithOne(d => d.Event)
+                    .HasForeignKey(d => d.EventId)
+                    .OnDelete(DeleteBehavior.Cascade);
             });
 
             modelBuilder.Entity<Participant>(entity =>

--- a/backend/Migrations/20240130000011_UpdateCascadeOnEventRelations.cs
+++ b/backend/Migrations/20240130000011_UpdateCascadeOnEventRelations.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateCascadeOnEventRelations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Participants_Events_EventId",
+                table: "Participants");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Documents_Events_EventId",
+                table: "Documents");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Participants_Events_EventId",
+                table: "Participants",
+                column: "EventId",
+                principalTable: "Events",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Documents_Events_EventId",
+                table: "Documents",
+                column: "EventId",
+                principalTable: "Events",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Participants_Events_EventId",
+                table: "Participants");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Documents_Events_EventId",
+                table: "Documents");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Participants_Events_EventId",
+                table: "Participants",
+                column: "EventId",
+                principalTable: "Events",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Documents_Events_EventId",
+                table: "Documents",
+                column: "EventId",
+                principalTable: "Events",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- configure Event→Participants and Event→Documents relations to cascade on delete
- add migration to update foreign keys to cascade deletes

## Testing
- `dotnet build backend` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689535c03f74832cbd77d221a6442b41