### PR TITLE
Remove duplicate IDs in claim transform

### DIFF
--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -68,8 +68,6 @@ export const transformFrontendClaimToApiPayload = (
     leasingCompanyId,
     handlerId,
     clientId,
-    clientId,
-    handlerId,
     riskType,
     damageType,
 
@@ -136,10 +134,6 @@ export const transformFrontendClaimToApiPayload = (
 
     riskType,
     damageType,
-    insuranceCompanyId: insuranceCompanyId ? parseInt(insuranceCompanyId) : undefined,
-    clientId: clientId ? parseInt(clientId) : undefined,
-    handlerId: handlerId ? parseInt(handlerId) : undefined,
-
     damageDate: rest.damageDate ? new Date(rest.damageDate).toISOString() : undefined,
     reportDate: rest.reportDate ? new Date(rest.reportDate).toISOString() : undefined,
     reportDateToInsurer: rest.reportDateToInsurer ? new Date(rest.reportDateToInsurer).toISOString() : undefined,


### PR DESCRIPTION
## Summary
- eliminate repeated `clientId` and `handlerId` entries in `transformFrontendClaimToApiPayload`
- clean returned payload to reference unique client and handler IDs

## Testing
- `pnpm exec tsc --noEmit` *(fails: Duplicate identifier errors in lib/api.ts)*
- `pnpm test`
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6895339d5890832cb153e32f1e5ebd26