### PR TITLE
Handle participant cleanup on event deletion

### DIFF
--- a/backend.Tests/AutomotiveClaimsApi.Tests.csproj
+++ b/backend.Tests/AutomotiveClaimsApi.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../backend/AutomotiveClaimsApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/backend.Tests/EventsControllerTests.cs
+++ b/backend.Tests/EventsControllerTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using AutomotiveClaimsApi.Controllers;
+using AutomotiveClaimsApi.Data;
+using AutomotiveClaimsApi.Models;
+using Xunit;
+
+namespace AutomotiveClaimsApi.Tests
+{
+    public class EventsControllerTests
+    {
+        private static ApplicationDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new ApplicationDbContext(options);
+        }
+
+        [Fact]
+        public async Task DeleteEvent_NoParticipants_RemovesEvent()
+        {
+            using var context = CreateContext();
+            var controller = new EventsController(context, NullLogger<EventsController>.Instance);
+
+            var evt = new Event { Id = Guid.NewGuid() };
+            context.Events.Add(evt);
+            await context.SaveChangesAsync();
+
+            var result = await controller.DeleteEvent(evt.Id);
+
+            Assert.IsType<NoContentResult>(result);
+            Assert.False(context.Events.Any());
+        }
+
+        [Fact]
+        public async Task DeleteEvent_WithParticipants_RemovesDependents()
+        {
+            using var context = CreateContext();
+            var controller = new EventsController(context, NullLogger<EventsController>.Instance);
+
+            var evt = new Event { Id = Guid.NewGuid() };
+            var participant = new Participant { Id = Guid.NewGuid(), EventId = evt.Id };
+            var driver = new Driver { Id = Guid.NewGuid(), EventId = evt.Id, ParticipantId = participant.Id };
+            participant.Drivers.Add(driver);
+            evt.Participants.Add(participant);
+
+            context.Events.Add(evt);
+            context.Participants.Add(participant);
+            context.Drivers.Add(driver);
+            await context.SaveChangesAsync();
+
+            var result = await controller.DeleteEvent(evt.Id);
+
+            Assert.IsType<NoContentResult>(result);
+            Assert.False(context.Events.Any());
+            Assert.False(context.Participants.Any());
+            Assert.False(context.Drivers.Any());
+        }
+    }
+}

--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -58,14 +58,20 @@ namespace AutomotiveClaimsApi.Data
                 entity.HasMany(e => e.Decisions).WithOne(d => d.Event).HasForeignKey(d => d.EventId).OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.Recourses).WithOne(r => r.Event).HasForeignKey(r => r.EventId).OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.Settlements).WithOne(s => s.Event).HasForeignKey(s => s.EventId).OnDelete(DeleteBehavior.Cascade);
-                entity.HasMany(e => e.Participants).WithOne(p => p.Event).HasForeignKey(p => p.EventId).OnDelete(DeleteBehavior.Restrict);
+                entity.HasMany(e => e.Participants)
+                      .WithOne(p => p.Event)
+                      .HasForeignKey(p => p.EventId)
+                      .OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.Notes).WithOne(n => n.Event).HasForeignKey(n => n.EventId).OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.Documents).WithOne(d => d.Event).HasForeignKey(d => d.EventId).OnDelete(DeleteBehavior.Restrict);
             });
 
             modelBuilder.Entity<Participant>(entity =>
             {
-                entity.HasMany(p => p.Drivers).WithOne().HasForeignKey(d => d.ParticipantId).OnDelete(DeleteBehavior.Restrict);
+                entity.HasMany(p => p.Drivers)
+                      .WithOne(d => d.Participant)
+                      .HasForeignKey(d => d.ParticipantId)
+                      .OnDelete(DeleteBehavior.Cascade);
             });
 
             modelBuilder.Entity<DamageType>(entity =>


### PR DESCRIPTION
## Summary
- Cascade delete participants and their drivers when removing events
- Add integration tests for deleting events with and without participants

## Testing
- `dotnet test backend.Tests/AutomotiveClaimsApi.Tests.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689536de2670832c820bac815ccaf99b