### PR TITLE
feat: add case handlers dictionary endpoint

### DIFF
--- a/backend/Controllers/DictionariesController.cs
+++ b/backend/Controllers/DictionariesController.cs
@@ -22,6 +22,39 @@ namespace AutomotiveClaimsApi.Controllers
             _logger = logger;
         }
 
+        [HttpGet("case-handlers")]
+        public async Task<ActionResult<DictionaryResponseDto>> GetCaseHandlers()
+        {
+            try
+            {
+                var handlers = await _context.CaseHandlers
+                    .Where(h => h.IsActive)
+                    .OrderBy(h => h.Name)
+                    .Select(h => new DictionaryItemDto
+                    {
+                        Id = h.Id.ToString(),
+                        Name = h.Name,
+                        Code = h.Code,
+                        IsActive = h.IsActive
+                    })
+                    .ToListAsync();
+
+                var response = new DictionaryResponseDto
+                {
+                    Items = handlers,
+                    TotalCount = handlers.Count,
+                    Category = "CaseHandlers"
+                };
+
+                return Ok(response);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving case handlers");
+                return StatusCode(500, new { error = "Failed to retrieve case handlers" });
+            }
+        }
+
         [HttpGet("countries")]
         public async Task<ActionResult<DictionaryResponseDto>> GetCountries()
         {


### PR DESCRIPTION
## Summary
- expose `/api/dictionaries/case-handlers` endpoint for active case handlers

## Testing
- `pnpm test` (no tests)
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68953765db1c832c829a3f75c5dd7b8d