### PR TITLE
Handle empty API responses

### DIFF
--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -259,7 +259,12 @@ export function useClaims() {
       setError(null)
       const payload = transformFrontendClaimToApiPayload(claimData)
       const updatedApiClaim = await apiService.updateClaim(id, payload)
-      const updatedClaim = transformApiClaimToFrontend(updatedApiClaim)
+      const existingClaim = claims.find((c) => c.id === id)
+
+      const updatedClaim: Claim = updatedApiClaim
+        ? transformApiClaimToFrontend(updatedApiClaim)
+        : { ...(existingClaim || {}), ...claimData } as Claim
+
       setClaims((prev) => prev.map((c) => (c.id === id ? updatedClaim : c)))
       return updatedClaim
     } catch (err) {

--- a/hooks/use-events.ts
+++ b/hooks/use-events.ts
@@ -113,7 +113,12 @@ export function useEvents() {
       setError(null)
       const apiEventData = transformToApiEvent(eventData)
       const apiEvent = await apiService.updateEvent(id, apiEventData)
-      const updatedEvent = transformApiEvent(apiEvent)
+      const existingEvent = events.find((event) => event.id === id)
+
+      const updatedEvent: Event = apiEvent
+        ? transformApiEvent(apiEvent)
+        : { ...(existingEvent || {}), ...eventData } as Event
+
       setEvents((prev) => prev.map((event) => (event.id === id ? updatedEvent : event)))
       return updatedEvent
     } catch (err) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -397,6 +397,12 @@ class ApiService {
       throw new Error(`API Error: ${response.status} - ${errorText}`)
     }
 
+    const contentLength = response.headers.get("content-length")
+    if (response.status === 204 || !contentLength || contentLength === "0") {
+      console.log("No content in response")
+      return undefined as T
+    }
+
     const data = await response.json()
     console.log("Response data:", data)
     return data
@@ -417,8 +423,8 @@ class ApiService {
     })
   }
 
-  async updateClaim(id: string, claim: EventUpsertDto): Promise<EventDto> {
-    return this.request<EventDto>(`/events/${id}`, {
+  async updateClaim(id: string, claim: EventUpsertDto): Promise<EventDto | undefined> {
+    return this.request<EventDto | undefined>(`/events/${id}`, {
       method: "PUT",
       body: JSON.stringify(claim),
     })
@@ -452,8 +458,8 @@ class ApiService {
     })
   }
 
-  async updateEvent(id: string, event: Partial<EventDto>): Promise<EventDto> {
-    return this.request<EventDto>(`/events/${id}`, {
+  async updateEvent(id: string, event: Partial<EventDto>): Promise<EventDto | undefined> {
+    return this.request<EventDto | undefined>(`/events/${id}`, {
       method: "PUT",
       body: JSON.stringify(event),
     })


### PR DESCRIPTION
## Summary
- Avoid JSON parsing for 204 or empty responses in API client
- Allow claim and event updates to return void and update local state accordingly

## Testing
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68953765b534832cbc4402264c0861f7