### PR TITLE
Handle empty claims response

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -409,7 +409,8 @@ class ApiService {
   }
 
   async getClaims(): Promise<EventListItemDto[]> {
-    return this.request<EventListItemDto[]>("/events")
+    const claims = await this.request<EventListItemDto[] | undefined>("/events")
+    return claims ?? []
   }
 
   async getClaim(id: string): Promise<EventDto> {


### PR DESCRIPTION
## Summary
- Guard against empty API responses by defaulting claims list to an empty array

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689539edc744832cb6fb3e44a4c76e10