### PR TITLE
Send numeric participant and driver IDs

### DIFF
--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -21,7 +21,7 @@ test('includes dropdown selections in payload', () => {
   assert.equal(payload.handlerId, 9)
 })
 
-test('participant and driver ids remain strings', () => {
+test('participant and driver ids are numeric', () => {
   const payload = transformFrontendClaimToApiPayload({
     injuredParty: {
       id: '123',
@@ -31,6 +31,6 @@ test('participant and driver ids remain strings', () => {
 
   const participant = payload.participants?.[0]
   const driver = participant?.drivers?.[0]
-  assert.equal(participant?.id, '123')
-  assert.equal(driver?.id, '456')
+  assert.equal(participant?.id, 123)
+  assert.equal(driver?.id, 456)
 })

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -81,7 +81,7 @@ export const transformFrontendClaimToApiPayload = (
 
   const mapParticipant = (p: ParticipantInfo, role: string): ParticipantUpsertDto => ({
 
-    id: p.id ? p.id.toString() : undefined,
+    id: p.id ? Number(p.id) : undefined,
     role,
 
     name: p.name,
@@ -103,7 +103,7 @@ export const transformFrontendClaimToApiPayload = (
     inspectionContactEmail: p.inspectionContactEmail,
     drivers: p.drivers?.map((d: DriverInfo) => ({
 
-      id: d.id ? d.id.toString() : undefined,
+      id: d.id ? Number(d.id) : undefined,
 
       name: d.name,
       licenseNumber: d.licenseNumber,


### PR DESCRIPTION
## Summary
- send participant IDs as numbers instead of strings
- send driver IDs as numbers instead of strings
- update use-claims unit test to expect numeric participant/driver IDs

## Testing
- `npm test` *(no tests found)*
- `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689539fee718832ca874caff96dd99d8