### PR TITLE
Add guard to claim initialization to avoid duplicates

### DIFF
--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -52,6 +52,7 @@ export default function NewClaimPage() {
   const router = useRouter()
   const { toast } = useToast()
   const { createClaim, initializeClaim } = useClaims()
+  const initialized = useRef(false)
   const [activeClaimSection, setActiveClaimSection] = useState("dane-zdarzenia")
   const [isSaving, setIsSaving] = useState(false)
   
@@ -102,11 +103,14 @@ export default function NewClaimPage() {
   } = useClaimForm()
 
   useEffect(() => {
-    initializeClaim().then((id) => {
-      if (id) {
-        setClaimFormData((prev) => ({ ...prev, id }))
-      }
-    })
+    if (!initialized.current) {
+      initialized.current = true
+      initializeClaim().then((id) => {
+        if (id) {
+          setClaimFormData((prev) => ({ ...prev, id }))
+        }
+      })
+    }
   }, [initializeClaim, setClaimFormData])
 
   const getInitialScheduleData = (): Partial<RepairSchedule> => ({

--- a/components/claim-form/claim-form.tsx
+++ b/components/claim-form/claim-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
@@ -22,6 +22,7 @@ interface ClaimFormProps {
 export function ClaimForm({ initialData, mode }: ClaimFormProps) {
   const router = useRouter()
   const { createClaim, updateClaim, initializeClaim, loading, error } = useClaims()
+  const initialized = useRef(false)
   
   const [formData, setFormData] = useState<Claim>({
     spartaNumber: '',
@@ -83,7 +84,8 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
   const isDisabled = mode === 'view'
 
   useEffect(() => {
-    if (mode === 'create' && !formData.id) {
+    if (!initialized.current && mode === 'create' && !formData.id) {
+      initialized.current = true
       initializeClaim().then((id) => {
         if (id) {
           setFormData((prev) => ({ ...prev, id }))


### PR DESCRIPTION
## Summary
- ensure claim initialization runs once in ClaimForm
- guard new claim page initialization with useRef

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895352a262c832cbf3a1b2a75c8beb2