### PR TITLE
Restrict driver cascade to avoid multiple paths

### DIFF
--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -73,6 +73,14 @@ namespace AutomotiveClaimsApi.Data
                 entity.HasMany(p => p.Drivers)
                       .WithOne(d => d.Participant)
                       .HasForeignKey(d => d.ParticipantId)
+                      .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            modelBuilder.Entity<Driver>(entity =>
+            {
+                entity.HasOne(d => d.Event)
+                      .WithMany()
+                      .HasForeignKey(d => d.EventId)
                       .OnDelete(DeleteBehavior.Cascade);
             });
 

--- a/backend/Migrations/20240130000012_UpdateDriverDeleteBehavior.cs
+++ b/backend/Migrations/20240130000012_UpdateDriverDeleteBehavior.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateDriverDeleteBehavior : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Drivers_Participants_ParticipantId",
+                table: "Drivers");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Drivers_Participants_ParticipantId",
+                table: "Drivers",
+                column: "ParticipantId",
+                principalTable: "Participants",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Drivers_Participants_ParticipantId",
+                table: "Drivers");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Drivers_Participants_ParticipantId",
+                table: "Drivers",
+                column: "ParticipantId",
+                principalTable: "Participants",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1056,7 +1056,7 @@ namespace AutomotiveClaimsApi.Migrations
                     b.HasOne("AutomotiveClaimsApi.Models.Participant", "Participant")
                         .WithMany("Drivers")
                         .HasForeignKey("ParticipantId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Event");


### PR DESCRIPTION
## Summary
- avoid multiple cascade paths by making participant-driver relationship restrict
- map drivers to events explicitly
- add migration updating foreign key delete behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68953c7286c8832ca5858849580254c0