### PR TITLE
Use string IDs for damages

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -11,8 +11,8 @@ import type { DocumentsSectionProps } from "@/types"
 
 interface Document {
   id: string
-  eventId?: number
-  damageId?: number
+  eventId?: string
+  damageId?: string
   fileName: string
   originalFileName: string
   contentType: string

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -38,7 +38,12 @@ export const transformApiClaimToFrontend = (apiClaim: EventDto): Claim => {
       ? apiClaim.servicesCalled
       : (apiClaim.servicesCalled?.split(",").filter(Boolean) ?? []),
 
-    damages: apiClaim.damages || [],
+    damages: apiClaim.damages?.map((d: any) => ({
+      id: d.id?.toString(),
+      eventId: d.eventId?.toString(),
+      description: d.description,
+      detail: d.detail,
+    })) || [],
     decisions: apiClaim.decisions || [],
     appeals: apiClaim.appeals || [],
     clientClaims: apiClaim.clientClaims || [],
@@ -146,7 +151,12 @@ export const transformFrontendClaimToApiPayload = (
 
     documents: documents?.map((d) => ({ id: d.id, filePath: d.url })),
 
-    damages: damages?.map((d) => ({ description: d.description, detail: d.detail } as any)),
+    damages: damages?.map((d) => ({
+      id: d.id,
+      eventId: d.eventId,
+      description: d.description,
+      detail: d.detail,
+    })),
     decisions: decisions?.map((d) => ({
       ...d,
       decisionDate: d.decisionDate ? new Date(d.decisionDate).toISOString() : undefined,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -231,8 +231,8 @@ export interface DriverUpsertDto {
 }
 
 export interface DamageDto {
-  id?: number
-  eventId?: number
+  id?: string
+  eventId?: string
   damageTypeId?: number
   description?: string
   estimatedCost?: number
@@ -241,6 +241,7 @@ export interface DamageDto {
 }
 
 export interface DamageUpsertDto {
+  id?: string
   eventId?: string
   description?: string
   detail?: string

--- a/types/index.ts
+++ b/types/index.ts
@@ -118,6 +118,8 @@ export interface DriverInfo {
 }
 
 export interface DamageItem {
+  id?: string
+  eventId?: string
   description: string
   detail: string
 }


### PR DESCRIPTION
## Summary
- represent DamageDto and DamageUpsertDto identifiers as strings
- convert damage IDs to strings in claim transformations
- expect string IDs in DamageItem and document metadata

## Testing
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint? ...)*

------
https://chatgpt.com/codex/tasks/task_e_68953e8bdff4832c8c54e2d77081a2d7