### PR TITLE
chore: treat claim ids as strings

### DIFF
--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -25,7 +25,7 @@ export const transformApiClaimToFrontend = (apiClaim: EventDto): Claim => {
 
   return {
     ...apiClaim,
-    id: apiClaim.id?.toString(),
+    id: apiClaim.id,
     insuranceCompanyId: apiClaim.insuranceCompanyId?.toString(),
     leasingCompanyId: apiClaim.leasingCompanyId?.toString(),
     handlerId: apiClaim.handlerId?.toString(),
@@ -187,7 +187,7 @@ export function useClaims() {
 
       const frontendClaims = apiClaims.map((claim) => ({
         ...claim,
-        id: claim.id.toString(),
+        id: claim.id,
         totalClaim: claim.totalClaim ?? 0,
         payout: claim.payout ?? 0,
         currency: claim.currency ?? "PLN",

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -3,7 +3,7 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 
 // Types for API responses
 export interface EventListItemDto {
-  id: number
+  id: string
   spartaNumber?: string
   claimNumber?: string
   vehicleNumber?: string


### PR DESCRIPTION
## Summary
- represent claim IDs as strings
- ensure claim hooks map IDs as strings

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68953fa17ff8832c8a9f758e86395841