### PR TITLE
feat: set frontend api base

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,8 @@
 # Base URL for backend API, used on the server only
 API_BASE_URL=http://localhost:5200
 
+# Base URL for backend API, exposed to the browser
+NEXT_PUBLIC_API_URL=http://localhost:5200/api
+
 # Optional: number of times to retry requests to the backend
 # FETCH_RETRY_COUNT=1

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,5 +1,7 @@
 // API Configuration
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  (process.env.API_BASE_URL ? `${process.env.API_BASE_URL}/api` : "https://claim-work-backend.azurewebsites.net/api")
 
 // Types for API responses
 export interface EventListItemDto {


### PR DESCRIPTION
## Summary
- expose API base URL to frontend via NEXT_PUBLIC_API_URL
- use server API_BASE_URL or production URL when client env var missing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68953f966514832c9e08dc15d569ca6f