### PR TITLE
feat: allow dismissing claims fetch errors

### DIFF
--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -26,7 +26,7 @@ export function ClaimsList({ onEditClaim, onNewClaim }: ClaimsListProps) {
   const [showFilters, setShowFilters] = useState(false)
   const [isRefreshing, setIsRefreshing] = useState(false)
 
-  const { claims, loading, error, deleteClaim, fetchClaims } = useClaims()
+  const { claims, loading, error, deleteClaim, fetchClaims, clearError } = useClaims()
   const { toast } = useToast()
 
   // Refresh data on component mount
@@ -201,7 +201,12 @@ export function ClaimsList({ onEditClaim, onNewClaim }: ClaimsListProps) {
               <br />
               <span className="text-sm">Sprawdź połączenie z API lub konfigurację backendu.</span>
             </AlertDescription>
-            <Button variant="ghost" size="sm" className="absolute top-2 right-2 h-6 w-6 p-0">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="absolute top-2 right-2 h-6 w-6 p-0"
+              onClick={clearError}
+            >
               <X className="h-3 w-3" />
             </Button>
           </Alert>


### PR DESCRIPTION
## Summary
- Destructure `clearError` from `useClaims`
- Close button in claim list error alert now clears error state

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68953f9b2e58832c93be409af02b428d