### PR TITLE
feat: add damage initialization endpoint

### DIFF
--- a/backend/Controllers/DamagesController.cs
+++ b/backend/Controllers/DamagesController.cs
@@ -53,11 +53,22 @@ namespace AutomotiveClaimsApi.Controllers
             }
         }
 
+        [HttpPost("init")]
+        public ActionResult InitDamage()
+        {
+            var id = Guid.NewGuid();
+            return Ok(new { id });
+        }
+
         [HttpPost]
         public async Task<ActionResult<DamageDto>> PostDamage(DamageUpsertDto upsertDto)
         {
             try
             {
+                if (!upsertDto.Id.HasValue || upsertDto.Id == Guid.Empty)
+                {
+                    return BadRequest("Damage ID is required. Use the init endpoint to obtain one.");
+                }
                 if (!upsertDto.EventId.HasValue || upsertDto.EventId == Guid.Empty)
                 {
                     return BadRequest("EventId is required.");
@@ -70,7 +81,7 @@ namespace AutomotiveClaimsApi.Controllers
 
                 var damage = new Damage
                 {
-                    Id = upsertDto.Id ?? Guid.NewGuid(),
+                    Id = upsertDto.Id.Value,
                     EventId = upsertDto.EventId.Value,
                     Description = upsertDto.Description,
                     Detail = upsertDto.Detail,

--- a/backend/Controllers/README.md
+++ b/backend/Controllers/README.md
@@ -1,0 +1,9 @@
+# Controllers
+
+## DamagesController
+
+### POST /api/damages/init
+Creates and returns a new `Guid` for a damage record without persisting it.
+
+### POST /api/damages
+Persists a new damage using the id from the init endpoint and the submitted details.


### PR DESCRIPTION
## Summary
- add `/api/damages/init` to generate a damage id without persisting
- require an explicit damage id when persisting a damage
- document damage initialization and creation routes

## Testing
- `dotnet test backend.Tests/AutomotiveClaimsApi.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68954433e980832c9be297a6d4bcea1d