### PR TITLE
feat: init/save damage flow and guard delete

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -190,7 +190,7 @@ export const ClaimMainContent = ({
   setRequiredDocuments,
 }: ClaimMainContentProps) => {
   const { toast } = useToast()
-  const { createDamage, deleteDamage } = useDamages(claimFormData.id)
+  const { initDamage, saveDamage, deleteDamage } = useDamages(claimFormData.id)
 
   // State for dropdown data
   const [riskTypes, setRiskTypes] = useState<RiskType[]>([])
@@ -409,13 +409,16 @@ export const ClaimMainContent = ({
     try {
       if (existing) {
         if (existing.id) {
-          await deleteDamage(existing.id)
+          await deleteDamage(existing.id, existing.isSaved !== false)
         }
         const newDamages = currentDamages.filter((d) => d.description !== partName)
         handleFormChange("damages", newDamages)
       } else {
-        const saved = await createDamage({ description: partName, detail: "Do opisu" })
-        const newDamages = [...currentDamages, saved]
+        const id = await initDamage()
+        const damage = { id, description: partName, detail: "Do opisu", isSaved: false }
+        await saveDamage(damage)
+        damage.isSaved = true
+        const newDamages = [...currentDamages, damage]
         handleFormChange("damages", newDamages)
       }
     } catch (error: any) {
@@ -433,7 +436,7 @@ export const ClaimMainContent = ({
 
     try {
       if (toRemove?.id) {
-        await deleteDamage(toRemove.id)
+        await deleteDamage(toRemove.id, toRemove.isSaved !== false)
       }
       const newDamages = currentDamages.filter((d) => d.description !== description)
       handleFormChange("damages", newDamages)

--- a/hooks/use-damages.ts
+++ b/hooks/use-damages.ts
@@ -11,27 +11,46 @@ export interface Damage {
   severity?: string
   estimatedCost?: number
   actualCost?: number
+  isSaved?: boolean
 }
 
 export function useDamages(eventId?: string) {
-  const createDamage = useCallback(
-    async (damage: Omit<Damage, "id" | "eventId">): Promise<Damage> => {
-      if (!eventId) {
-        throw new Error("Brak identyfikatora zdarzenia")
+  const initDamage = useCallback(async (): Promise<string> => {
+    if (!eventId) {
+      throw new Error("Brak identyfikatora zdarzenia")
+    }
+
+    const response = await fetch("/api/damages/init", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ eventId }),
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(errorText || "Nie udało się zainicjować szkody")
+    }
+
+    const data = await response.json()
+    return data.id
+  }, [eventId])
+
+  const saveDamage = useCallback(
+    async (damage: Damage): Promise<void> => {
+      if (!damage.id) {
+        throw new Error("Brak identyfikatora szkody")
       }
 
-      const response = await fetch("/api/damages", {
+      const response = await fetch("/api/damages/save", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...damage, eventId }),
+        body: JSON.stringify({ ...damage, eventId: damage.eventId || eventId }),
       })
 
       if (!response.ok) {
         const errorText = await response.text()
         throw new Error(errorText || "Nie udało się zapisać szkody")
       }
-
-      return response.json()
     },
     [eventId],
   )
@@ -52,17 +71,21 @@ export function useDamages(eventId?: string) {
     [eventId],
   )
 
-  const deleteDamage = useCallback(async (id: string): Promise<void> => {
-    const response = await fetch(`/api/damages/${id}`, {
-      method: "DELETE",
-    })
+  const deleteDamage = useCallback(
+    async (id: string, saved = true): Promise<void> => {
+      if (!saved) return
+      const response = await fetch(`/api/damages/${id}`, {
+        method: "DELETE",
+      })
 
-    if (!response.ok) {
-      const errorText = await response.text()
-      throw new Error(errorText || "Nie udało się usunąć szkody")
-    }
-  }, [])
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(errorText || "Nie udało się usunąć szkody")
+      }
+    },
+    [],
+  )
 
-  return { createDamage, updateDamage, deleteDamage }
+  return { initDamage, saveDamage, updateDamage, deleteDamage }
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -122,6 +122,7 @@ export interface DamageItem {
   eventId?: string
   description: string
   detail: string
+  isSaved?: boolean
 }
 
 export interface Decision {


### PR DESCRIPTION
## Summary
- replace `createDamage` with `initDamage` and add `saveDamage` for posting full damage data
- skip damage deletion HTTP call when the damage has not been saved
- expose new damage helpers to ClaimMainContent and track saved status on items

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68954435b224832c90bfe7cafeb874c1