### PR TITLE
feat: fetch damages for claim

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -190,7 +190,7 @@ export const ClaimMainContent = ({
   setRequiredDocuments,
 }: ClaimMainContentProps) => {
   const { toast } = useToast()
-  const { createDamage, deleteDamage } = useDamages(claimFormData.id)
+  const { createDamage, deleteDamage, fetchDamages } = useDamages(claimFormData.id)
 
   // State for dropdown data
   const [riskTypes, setRiskTypes] = useState<RiskType[]>([])
@@ -218,6 +218,25 @@ export const ClaimMainContent = ({
     priority: "wszystkie",
     search: "",
   })
+
+  useEffect(() => {
+    if (!claimFormData.id) return
+
+    const loadDamages = async () => {
+      try {
+        const data = await fetchDamages(claimFormData.id)
+        handleFormChange("damages", data)
+      } catch (error) {
+        toast({
+          title: "Błąd",
+          description: "Nie udało się pobrać szkód.",
+          variant: "destructive",
+        })
+      }
+    }
+
+    loadDamages()
+  }, [claimFormData.id])
 
   useEffect(() => {
     if (!claimFormData.id) return

--- a/hooks/use-damages.ts
+++ b/hooks/use-damages.ts
@@ -63,6 +63,20 @@ export function useDamages(eventId?: string) {
     }
   }, [])
 
-  return { createDamage, updateDamage, deleteDamage }
+  const fetchDamages = useCallback(
+    async (eventIdToFetch: string): Promise<Damage[]> => {
+      const response = await fetch(`/api/damages/event/${eventIdToFetch}`)
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(errorText || "Nie udało się pobrać listy szkód")
+      }
+
+      return response.json()
+    },
+    [],
+  )
+
+  return { createDamage, updateDamage, deleteDamage, fetchDamages }
 }
 


### PR DESCRIPTION
## Summary
- add `fetchDamages` to damages hook for retrieving damages by event id
- load damages in claim form when claim id is available

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689544ffb12c832cb8753c3dbfc5e6b4