### PR TITLE
Add initialization endpoint for damages and keep creation endpoint

### DIFF
--- a/app/api/damages/init/route.ts
+++ b/app/api/damages/init/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server"
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost:5200/api"
+
+export async function POST() {
+  try {
+    const response = await fetch(`${API_BASE_URL}/damages/init`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      return NextResponse.json({ error: `Backend API error: ${errorText}` }, { status: response.status })
+    }
+
+    const data = await response.json()
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error("Initialize damage API error:", error)
+    return NextResponse.json({ error: "Failed to initialize damage" }, { status: 500 })
+  }
+}

--- a/app/api/damages/route.ts
+++ b/app/api/damages/route.ts
@@ -1,4 +1,4 @@
-import { type NextRequest, NextResponse } from "next/server"
+import { NextResponse } from "next/server"
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost:5200/api"
 
@@ -19,30 +19,5 @@ export async function GET() {
   } catch (error) {
     console.error("Damages API error:", error)
     return NextResponse.json({ error: "Failed to fetch damages" }, { status: 500 })
-  }
-}
-
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json()
-
-    const response = await fetch(`${API_BASE_URL}/damages`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    })
-
-    if (!response.ok) {
-      const errorText = await response.text()
-      return NextResponse.json({ error: `Backend API error: ${errorText}` }, { status: response.status })
-    }
-
-    const data = await response.json()
-    return NextResponse.json(data)
-  } catch (error) {
-    console.error("Create damage API error:", error)
-    return NextResponse.json({ error: "Failed to create damage" }, { status: 500 })
   }
 }

--- a/app/api/damages/save/route.ts
+++ b/app/api/damages/save/route.ts
@@ -1,0 +1,28 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost:5200/api"
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    const response = await fetch(`${API_BASE_URL}/damages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      return NextResponse.json({ error: `Backend API error: ${errorText}` }, { status: response.status })
+    }
+
+    const data = await response.json()
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error("Create damage API error:", error)
+    return NextResponse.json({ error: "Failed to create damage" }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- forward POST /api/damages/init to backend to generate a new damage ID
- move existing damage creation logic to POST /api/damages/save
- clean up damages root API route to only handle retrieval

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68954434d09c832c901ad0165961560f