### PR TITLE
Use damageTypeValue in claim API payload

### DIFF
--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -141,7 +141,7 @@ export const transformFrontendClaimToApiPayload = (
     clientId: clientId ? parseInt(clientId, 10) : undefined,
     handlerId: handlerId ? parseInt(handlerId, 10) : undefined,
     riskType,
-    damageType,
+    damageType: damageTypeValue,
     damageDate: rest.damageDate ? new Date(rest.damageDate).toISOString() : undefined,
     reportDate: rest.reportDate ? new Date(rest.reportDate).toISOString() : undefined,
     reportDateToInsurer: rest.reportDateToInsurer ? new Date(rest.reportDateToInsurer).toISOString() : undefined,


### PR DESCRIPTION
## Summary
- send API payload's damageType using processed damageTypeValue

## Testing
- `npx tsc --noEmit` *(fails: hooks/use-damages.ts(87,1): error TS1005: ')' expected)*

------
https://chatgpt.com/codex/tasks/task_e_689548f85308832ca58b967e88724e23