### PR TITLE
fix damageType mapping in claims hook

### DIFF
--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -21,6 +21,14 @@ test('includes dropdown selections in payload', () => {
   assert.equal(payload.handlerId, 9)
 })
 
+test('maps damageType object to its code value', () => {
+  const payload = transformFrontendClaimToApiPayload({
+    damageType: { code: 'DT', name: 'Damage' } as any,
+  } as any)
+
+  assert.equal(payload.damageType, 'DT')
+})
+
 test('participant and driver ids are numeric', () => {
   const payload = transformFrontendClaimToApiPayload({
     injuredParty: {

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -141,7 +141,7 @@ export const transformFrontendClaimToApiPayload = (
     clientId: clientId ? parseInt(clientId, 10) : undefined,
     handlerId: handlerId ? parseInt(handlerId, 10) : undefined,
     riskType,
-    damageType,
+    damageType: damageTypeValue,
     damageDate: rest.damageDate ? new Date(rest.damageDate).toISOString() : undefined,
     reportDate: rest.reportDate ? new Date(rest.reportDate).toISOString() : undefined,
     reportDateToInsurer: rest.reportDateToInsurer ? new Date(rest.reportDateToInsurer).toISOString() : undefined,


### PR DESCRIPTION
## Summary
- use damageTypeValue when serializing claim data to API
- add test ensuring damageType objects send their code

## Testing
- `npm test` *(fails: Cannot find module 'tsconfig-paths/register')*

------
https://chatgpt.com/codex/tasks/task_e_689548f6e4e8832c80d89233707a2172