### PR TITLE
Add tests for useDamages error handling

### DIFF
--- a/hooks/__tests__/use-damages.test.ts
+++ b/hooks/__tests__/use-damages.test.ts
@@ -1,0 +1,70 @@
+// @ts-ignore
+import { strict as assert } from 'node:assert'
+// @ts-ignore
+import { test } from 'node:test'
+import { useDamages } from '../use-damages'
+
+test('createDamage throws when eventId is missing', async () => {
+  const { createDamage } = useDamages()
+
+  await assert.rejects(
+    () => createDamage({ description: 'desc' }),
+    /Brak identyfikatora zdarzenia/,
+  )
+})
+
+test('createDamage throws on failed response', async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () => ({ ok: false, text: async () => 'fail' }) as any
+
+  try {
+    const { createDamage } = useDamages('123')
+    await assert.rejects(
+      () => createDamage({ description: 'desc' }),
+      /Nie udało się zapisać szkody|fail/,
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('createDamage returns data on success', async () => {
+  const originalFetch = globalThis.fetch
+  const data = { id: '1', eventId: '123', description: 'desc' }
+  globalThis.fetch = async () => ({ ok: true, json: async () => data }) as any
+
+  try {
+    const { createDamage } = useDamages('123')
+    const result = await createDamage({ description: 'desc' })
+    assert.deepEqual(result, data)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('initDamages throws on failed response', async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () => ({ ok: false, text: async () => 'bad' }) as any
+
+  try {
+    const { initDamages } = useDamages('123')
+    await assert.rejects(() => initDamages(), /Nie udało się pobrać szkód|bad/)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('initDamages returns data on success', async () => {
+  const originalFetch = globalThis.fetch
+  const damages = [{ id: '1', eventId: '123', description: 'desc' }]
+  globalThis.fetch = async () => ({ ok: true, json: async () => damages }) as any
+
+  try {
+    const { initDamages } = useDamages('123')
+    const result = await initDamages()
+    assert.deepEqual(result, damages)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+

--- a/hooks/use-damages.ts
+++ b/hooks/use-damages.ts
@@ -3,8 +3,6 @@
 import { useCallback } from "react"
 import { API_ENDPOINTS } from "@/lib/constants"
 
-
-
 export interface Damage {
   id?: string
   eventId?: string
@@ -18,7 +16,6 @@ export interface Damage {
 }
 
 export function useDamages(eventId?: string) {
-
   const initDamages = useCallback(async (): Promise<Damage[]> => {
     const response = await fetch(API_ENDPOINTS.DAMAGES_INIT)
 
@@ -30,26 +27,24 @@ export function useDamages(eventId?: string) {
     return response.json()
   }, [])
 
-
   const createDamage = useCallback(
     async (damage: Omit<Damage, "id" | "eventId">): Promise<Damage> => {
       if (!eventId) {
         throw new Error("Brak identyfikatora zdarzenia")
-
       }
 
-
       const response = await fetch(API_ENDPOINTS.DAMAGES, {
-
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...damage, eventId: damage.eventId || eventId }),
+        body: JSON.stringify({ ...damage, eventId: (damage as any).eventId || eventId }),
       })
 
       if (!response.ok) {
         const errorText = await response.text()
         throw new Error(errorText || "Nie udało się zapisać szkody")
       }
+
+      return response.json()
     },
     [eventId],
   )
@@ -70,17 +65,17 @@ export function useDamages(eventId?: string) {
     [eventId],
   )
 
-
   const deleteDamage = useCallback(async (id: string): Promise<void> => {
     const response = await fetch(`${API_ENDPOINTS.DAMAGES}/${id}`, {
       method: "DELETE",
     })
 
-
-  return { initDamage, createDamage, updateDamage, deleteDamage }
-
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(errorText || "Nie udało się usunąć szkody")
+    }
+  }, [])
 
   return { createDamage, updateDamage, deleteDamage, initDamages }
-
 }
 


### PR DESCRIPTION
## Summary
- add unit tests for `useDamages` covering success paths and expected errors
- ensure `useDamages` propagates API errors and returns response data

## Testing
- `tsc hooks/use-damages.ts hooks/__tests__/use-damages.test.ts --module commonjs --target ES2020 --outDir build --esModuleInterop --skipLibCheck --noEmit false --incremental false`
- `node --test build/__tests__/use-damages.test.js`
- `npm test` *(fails: Cannot find module 'tsconfig-paths/register')*

------
https://chatgpt.com/codex/tasks/task_e_68954b0c08c8832c8a3b929c1302063a