### PR TITLE
Handle null claim creation and damageType conversion

### DIFF
--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -268,51 +268,51 @@ export default function NewClaimPage() {
       } as Claim
 
       const createdClaim = await createClaim(newClaimData)
-      
-      if (createdClaim) {
-        // Save repair schedules and details if any exist
-        if (repairSchedules.length > 0) {
-          for (const schedule of repairSchedules) {
-            try {
-              await fetch("/api/repair-schedules", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ ...schedule, eventId: createdClaim.id }),
-              })
-            } catch (error) {
-              console.error("Error saving repair schedule:", error)
-            }
-          }
-        }
 
-        if (repairDetails.length > 0) {
-          for (const detail of repairDetails) {
-            try {
-              await fetch("/api/repair-details", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ ...detail, eventId: createdClaim.id }),
-              })
-            } catch (error) {
-              console.error("Error saving repair detail:", error)
-            }
-          }
-        }
-
-        toast({
-          title: "Szkoda dodana",
-          description: `Nowa szkoda ${createdClaim.spartaNumber} została pomyślnie dodana.`,
-        })
-        
-        if (exitAfterSave) {
-          router.push("/")
-        } else {
-          resetForm()
-          setRepairSchedules([])
-          setRepairDetails([])
-        }
-      } else {
+      if (!createdClaim) {
         throw new Error("Nie udało się utworzyć szkody")
+      }
+
+      // Save repair schedules and details if any exist
+      if (repairSchedules.length > 0) {
+        for (const schedule of repairSchedules) {
+          try {
+            await fetch("/api/repair-schedules", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ ...schedule, eventId: createdClaim.id }),
+            })
+          } catch (error) {
+            console.error("Error saving repair schedule:", error)
+          }
+        }
+      }
+
+      if (repairDetails.length > 0) {
+        for (const detail of repairDetails) {
+          try {
+            await fetch("/api/repair-details", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ ...detail, eventId: createdClaim.id }),
+            })
+          } catch (error) {
+            console.error("Error saving repair detail:", error)
+          }
+        }
+      }
+
+      toast({
+        title: "Szkoda dodana",
+        description: `Nowa szkoda ${createdClaim.spartaNumber} została pomyślnie dodana.`,
+      })
+
+      if (exitAfterSave) {
+        router.push("/")
+      } else {
+        resetForm()
+        setRepairSchedules([])
+        setRepairDetails([])
       }
     } catch (error) {
       console.error("Error saving claim:", error)

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -79,8 +79,14 @@ export const transformFrontendClaimToApiPayload = (
     ...rest
   } = claimData
 
-  const damageTypeValue =
-    typeof damageType === "object" ? (damageType as any).code : damageType
+  let damageTypeValue: string | undefined
+  if (typeof damageType === "object" && damageType !== null) {
+    damageTypeValue = (damageType as any).code ?? (damageType as any).id
+  } else if (typeof damageType === "number") {
+    damageTypeValue = damageType.toString()
+  } else if (typeof damageType === "string") {
+    damageTypeValue = damageType
+  }
 
   const participants: ParticipantUpsertDto[] = []
 
@@ -141,7 +147,7 @@ export const transformFrontendClaimToApiPayload = (
     clientId: clientId ? parseInt(clientId, 10) : undefined,
     handlerId: handlerId ? parseInt(handlerId, 10) : undefined,
     riskType,
-    damageType: damageTypeValue,
+    ...(damageTypeValue ? { damageType: damageTypeValue } : {}),
     damageDate: rest.damageDate ? new Date(rest.damageDate).toISOString() : undefined,
     reportDate: rest.reportDate ? new Date(rest.reportDate).toISOString() : undefined,
     reportDateToInsurer: rest.reportDateToInsurer ? new Date(rest.reportDateToInsurer).toISOString() : undefined,


### PR DESCRIPTION
## Summary
- guard against failed claim creation to avoid null property access
- send only string damageType values in API payloads

## Testing
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68955038de6c832cb6e9e264023f4820