### PR TITLE
Fix deleteDamage fetch handling

### DIFF
--- a/hooks/use-damages.ts
+++ b/hooks/use-damages.ts
@@ -68,12 +68,9 @@ export function useDamages(eventId?: string) {
   )
 
   const deleteDamage = useCallback(async (id: string): Promise<void> => {
-    await fetch(`${API_ENDPOINTS.DAMAGES}/${id}`, {
+    const response = await fetch(`${API_ENDPOINTS.DAMAGES}/${id}`, {
       method: "DELETE",
     })
-  }, [])
-
-
 
     if (!response.ok) {
       const errorText = await response.text()


### PR DESCRIPTION
## Summary
- ensure deleteDamage handles fetch response and errors internally

## Testing
- `pnpm test`
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689556b543ac832cbe055f2e5dc1a1ee