### PR TITLE
Rename client claim fields and include document details

### DIFF
--- a/components/claim-form/client-claims-section.tsx
+++ b/components/claim-form/client-claims-section.tsx
@@ -162,11 +162,13 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
       const claimData: ClientClaim = {
         id: editingClaim?.id || Date.now().toString(),
         eventId: claimId,
-        submissionDate: formData.claimDate,
-        type: formData.claimType,
+        claimDate: formData.claimDate,
+        claimType: formData.claimType,
         amount: Number.parseFloat(formData.claimAmount),
+        currency: formData.currency,
         status: formData.status as any,
         description: formData.description,
+        documentDescription: formData.documentDescription,
         document: selectedFile
           ? {
               id: Date.now().toString(),
@@ -212,13 +214,13 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
     setEditingClaim(claim)
     setIsEditing(true)
     setFormData({
-      claimDate: claim.submissionDate,
-      claimType: claim.type,
+      claimDate: claim.claimDate,
+      claimType: claim.claimType,
       claimAmount: claim.amount?.toString() || "",
       currency: claim.currency || "PLN",
       status: claim.status,
       description: claim.description || "",
-      documentDescription: claim.document?.name || "",
+      documentDescription: claim.documentDescription || "",
     })
     setIsFormVisible(true)
   }
@@ -702,12 +704,12 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
                       <td className="py-3 px-4">
                         <div className="flex items-center space-x-2">
                           <Calendar className="h-4 w-4 text-gray-400" />
-                          <span className="text-sm">{formatDate(claim.submissionDate)}</span>
+                          <span className="text-sm">{formatDate(claim.claimDate)}</span>
                         </div>
                       </td>
                       <td className="py-3 px-4">
                         <Badge variant="outline" className="text-blue-600 border-blue-200">
-                          {claim.type}
+                          {claim.claimType}
                         </Badge>
                       </td>
                       <td className="py-3 px-4">
@@ -730,7 +732,9 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
                         {claim.document ? (
                           <div className="flex items-center space-x-2">
                             <FileText className="h-4 w-4 text-blue-600" />
-                            <span className="text-sm text-blue-600">Załącznik</span>
+                            <span className="text-sm text-blue-600">
+                              {claim.documentDescription || "Załącznik"}
+                            </span>
                             <div className="flex gap-1">
                               {isPreviewable(claim.document.name) && (
                                 <Button

--- a/types/index.ts
+++ b/types/index.ts
@@ -158,6 +158,7 @@ export interface ClientClaim {
   description: string
   amount?: number
   status?: string
+  documentDescription?: string
 }
 
 export interface Recourse {


### PR DESCRIPTION
## Summary
- rename client claim fields to `claimDate` and `claimType`
- store currency and document description for each claim
- show new fields when editing and in claim table

## Testing
- `pnpm test`
- `pnpm lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68955a0e9828832cbd3965b5cabb48ed