### PR TITLE
Support fetching documents by event GUID

### DIFF
--- a/app/api/documents/event/[eventId]/route.ts
+++ b/app/api/documents/event/[eventId]/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { eventId: string } },
+) {
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/api/documents/event/${encodeURIComponent(params.eventId)}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    )
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      return NextResponse.json(
+        { error: `Backend API error: ${response.status} ${response.statusText}` },
+        { status: response.status },
+      )
+    }
+
+    const data = await response.json()
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error("Error fetching documents:", error)
+    return NextResponse.json(
+      {
+        error: "Failed to fetch documents",
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
+    )
+  }
+}
+

--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -5,11 +5,19 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
+    const eventId = searchParams.get("eventId")
     const queryString = searchParams.toString()
 
-    console.log("Fetching documents with params:", queryString)
+    const url = eventId
+      ? `${API_BASE_URL}/api/documents/event/${encodeURIComponent(eventId)}`
+      : `${API_BASE_URL}/api/documents${queryString ? `?${queryString}` : ""}`
 
-    const response = await fetch(`${API_BASE_URL}/api/documents?${queryString}`, {
+    console.log(
+      "Fetching documents with params:",
+      eventId ? `event/${eventId}` : queryString,
+    )
+
+    const response = await fetch(url, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",

--- a/components/claim-form/claim-form.tsx
+++ b/components/claim-form/claim-form.tsx
@@ -366,7 +366,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
               setPendingFiles={setPendingFiles}
               requiredDocuments={requiredDocuments}
               setRequiredDocuments={setRequiredDocuments}
-              eventId={formData.id}
+              eventId={formData.id as string}
             />
 
           </CardContent>

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -2020,7 +2020,7 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
                   setUploadedFiles={setUploadedFiles}
                   requiredDocuments={requiredDocuments}
                   setRequiredDocuments={setRequiredDocuments}
-                  eventId={claimFormData.id}
+                  eventId={claimFormData.id as string}
                 />
               )}
             </CardContent>
@@ -2778,7 +2778,7 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
                   setUploadedFiles={setUploadedFiles}
                   requiredDocuments={[]}
                   setRequiredDocuments={() => {}}
-                  eventId={claimFormData.id}
+                  eventId={claimFormData.id as string}
                   hideRequiredDocuments={true}
                 />
               )}

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -98,7 +98,7 @@ export const DocumentsSection = ({
     setLoading(true)
     try {
       console.log("Loading documents for eventId:", eventId)
-      const response = await fetch(`/api/documents?eventId=${eventId}`)
+      const response = await fetch(`/api/documents/event/${encodeURIComponent(eventId)}`)
 
       if (response.ok) {
         const data = await response.json()

--- a/types/index.ts
+++ b/types/index.ts
@@ -210,7 +210,7 @@ export interface DocumentsSectionProps {
   requiredDocuments: RequiredDocument[]
   setRequiredDocuments: React.Dispatch<React.SetStateAction<RequiredDocument[]>>
 
-  eventId?: number | string
+  eventId?: string
   pendingFiles?: UploadedFile[]
   setPendingFiles?: React.Dispatch<React.SetStateAction<UploadedFile[]>>
 


### PR DESCRIPTION
## Summary
- Fetch documents via `/api/documents/event/<eventId>` in `DocumentsSection`
- Proxy event specific document requests to backend and accept GUID event IDs
- Ensure all `DocumentsSection` usages pass a GUID string event id

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68955c50a354832c9e51ff36e514da5f