### PR TITLE
Handle missing documents gracefully

### DIFF
--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -16,6 +16,11 @@ export async function GET(request: NextRequest) {
       },
     })
 
+    if (response.status === 404) {
+      console.warn("Documents not found on backend, returning empty array")
+      return NextResponse.json([], { status: 200 })
+    }
+
     if (!response.ok) {
       console.error("Backend API error:", response.status, response.statusText)
       const errorText = await response.text()

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -104,6 +104,9 @@ export const DocumentsSection = ({
         const data = await response.json()
         console.log("Loaded documents:", data)
         setDocuments(data)
+      } else if (response.status === 404) {
+        console.log("No documents found for eventId:", eventId)
+        setDocuments([])
       } else {
         let errorMessage = "Nie udało się załadować dokumentów"
         try {
@@ -726,6 +729,9 @@ export const DocumentsSection = ({
             </div>
           </CardContent>
         </Card>
+        {!loading && allDocuments.length === 0 && (
+          <p className="text-center text-gray-500">Nie znaleziono dokumentów</p>
+        )}
 
         {documentCategories.map((category) => {
           const documentsForCategory = allDocuments.filter((d) => d.documentType === category)


### PR DESCRIPTION
## Summary
- Return an empty array with 200 status when the backend documents API returns 404
- On 404, avoid error toast in `loadDocuments` and set documents to an empty list
- Show a message when no documents are found

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68955c54e334832ca97e3a4505c6a110