### PR TITLE
Use /api/claims endpoints for claim pages

### DIFF
--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -106,7 +106,7 @@ export default function EditClaimPage() {
       setLoadError(null)
 
       // Direct API call instead of using the hook to avoid loops
-      const response = await fetch(`/api/events/${id}`)
+      const response = await fetch(`/api/claims/${id}`)
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`)
       }

--- a/app/claims/[id]/view/page.tsx
+++ b/app/claims/[id]/view/page.tsx
@@ -115,7 +115,7 @@ export default function ViewClaimPage() {
       setIsLoading(true)
       setLoadError(null)
 
-      const response = await fetch(`/api/events/${id}`)
+      const response = await fetch(`/api/claims/${id}`)
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`)
       }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -409,37 +409,37 @@ class ApiService {
 
 
   async getClaims(): Promise<ClaimListItemDto[]> {
-    const claims = await this.request<ClaimListItemDto[] | undefined>("/events")
+    const claims = await this.request<ClaimListItemDto[] | undefined>("/claims")
     return claims ?? []
 
   }
 
   async getClaim(id: string): Promise<ClaimDto> {
-    return this.request<ClaimDto>(`/events/${id}`)
+    return this.request<ClaimDto>(`/claims/${id}`)
   }
 
   async createClaim(claim: ClaimUpsertDto): Promise<ClaimDto> {
-    return this.request<ClaimDto>("/events", {
+    return this.request<ClaimDto>("/claims", {
       method: "POST",
       body: JSON.stringify(claim),
     })
   }
 
   async updateClaim(id: string, claim: ClaimUpsertDto): Promise<ClaimDto | undefined> {
-    return this.request<ClaimDto | undefined>(`/events/${id}`, {
+    return this.request<ClaimDto | undefined>(`/claims/${id}`, {
       method: "PUT",
       body: JSON.stringify(claim),
     })
   }
 
   async deleteClaim(id: string): Promise<void> {
-    return this.request<void>(`/events/${id}`, {
+    return this.request<void>(`/claims/${id}`, {
       method: "DELETE",
     })
   }
 
   async initializeClaim(): Promise<{ id: string }> {
-    return this.request<{ id: string }>("/events/initialize", {
+    return this.request<{ id: string }>("/claims/initialize", {
       method: "POST",
     })
   }


### PR DESCRIPTION
## Summary
- Fetch claim data from `/api/claims/:id` in edit and view pages
- Update API service to use `/api/claims` for get, create, update, delete, and initialize operations

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6895a74eaba4832cafcd597c503c6d5b