### PR TITLE
feat: support paginated claim fetching

### DIFF
--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -44,7 +44,14 @@ export function ClaimsList({ onEditClaim, onNewClaim }: ClaimsListProps) {
   useEffect(() => {
     const loadClaims = async () => {
       try {
-        await fetchClaims({ page, pageSize })
+        await fetchClaims({
+          page,
+          pageSize,
+          search: searchTerm,
+          status: filterStatus !== "all" ? filterStatus : undefined,
+          brand: filterBrand || undefined,
+          handler: filterHandler || undefined,
+        })
       } catch (err) {
         toast({
           title: "Błąd",
@@ -54,7 +61,16 @@ export function ClaimsList({ onEditClaim, onNewClaim }: ClaimsListProps) {
       }
     }
     loadClaims()
-  }, [fetchClaims, toast, page, pageSize])
+  }, [
+    fetchClaims,
+    toast,
+    page,
+    pageSize,
+    searchTerm,
+    filterStatus,
+    filterBrand,
+    filterHandler,
+  ])
 
   // TODO: consider moving this filtering to use-claims or the API to reduce client workload
   const filteredClaims = useMemo(
@@ -128,7 +144,14 @@ export function ClaimsList({ onEditClaim, onNewClaim }: ClaimsListProps) {
   const handleRefresh = async () => {
     setIsRefreshing(true)
     try {
-      await fetchClaims({ page, pageSize })
+      await fetchClaims({
+        page,
+        pageSize,
+        search: searchTerm,
+        status: filterStatus !== "all" ? filterStatus : undefined,
+        brand: filterBrand || undefined,
+        handler: filterHandler || undefined,
+      })
       toast({
         title: "Odświeżono",
         description: "Lista szkód została odświeżona.",

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -6,7 +6,6 @@ import {
   type ClaimUpsertDto,
   type ClaimDto,
   type ParticipantUpsertDto,
-  type ClaimListItemDto,
 } from "@/lib/api"
 import type { Claim, ParticipantInfo, DriverInfo } from "@/types"
 
@@ -191,40 +190,51 @@ export function useClaims() {
   const [claims, setClaims] = useState<Claim[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [totalCount, setTotalCount] = useState(0)
 
+  const fetchClaims = useCallback(
+    async ({ page, pageSize, ...filters }: { page?: number; pageSize?: number; [key: string]: any } = {}) => {
+      try {
+        setLoading(true)
+        setError(null)
 
-  const fetchClaims = useCallback(async () => {
-    try {
-      setLoading(true)
-      setError(null)
+        const isDev = process.env.NODE_ENV !== "production"
+        if (isDev) {
+          console.log("Fetching claims from API...")
+        }
 
-      const isDev = process.env.NODE_ENV !== "production"
-      if (isDev) {
-        console.log("Fetching claims from API...")
-      }
+        const { items = [], totalCount = 0 } = await apiService.getClaims({
+          page,
+          pageSize,
+          ...filters,
+        })
 
-      const apiClaims: ClaimListItemDto[] = await apiService.getClaims()
+        if (isDev) {
+          console.log("API response:", { items, totalCount })
+        }
 
-      if (isDev) {
-        console.log("API response:", apiClaims)
-      }
+        const frontendClaims = items.map((claim) => ({
+          ...claim,
+          id: claim.id,
+          totalClaim: claim.totalClaim ?? 0,
+          payout: claim.payout ?? 0,
+          currency: claim.currency ?? "PLN",
+          clientId: claim.clientId?.toString(),
+          insuranceCompanyId: claim.insuranceCompanyId?.toString(),
+          leasingCompanyId: claim.leasingCompanyId?.toString(),
+          handlerId: claim.handlerId?.toString(),
+        })) as Claim[]
 
-      const frontendClaims = apiClaims.map((claim) => ({
-        ...claim,
-        id: claim.id,
-        totalClaim: claim.totalClaim ?? 0,
-        payout: claim.payout ?? 0,
-        currency: claim.currency ?? "PLN",
-        clientId: claim.clientId?.toString(),
-        insuranceCompanyId: claim.insuranceCompanyId?.toString(),
-        leasingCompanyId: claim.leasingCompanyId?.toString(),
-        handlerId: claim.handlerId?.toString(),
-      })) as Claim[]
-
-      setClaims(frontendClaims)
-      if (isDev) {
-        console.log("Claims set in state:", frontendClaims)
-
+        setClaims(frontendClaims)
+        setTotalCount(totalCount)
+        if (isDev) {
+          console.log("Claims set in state:", frontendClaims)
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "An unknown error occurred"
+        setError(`Failed to fetch claims: ${message}`)
+      } finally {
+        setLoading(false)
       }
     },
     [],

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -408,10 +408,23 @@ class ApiService {
   }
 
 
-  async getClaims(): Promise<ClaimListItemDto[]> {
-    const claims = await this.request<ClaimListItemDto[] | undefined>("/events")
-    return claims ?? []
+  async getClaims(
+    params: { page?: number; pageSize?: number; [key: string]: any } = {},
+  ): Promise<{ items: ClaimListItemDto[]; totalCount: number }> {
+    const query = new URLSearchParams(
+      Object.entries(params).reduce((acc, [key, value]) => {
+        if (value !== undefined && value !== null) {
+          acc[key] = String(value)
+        }
+        return acc
+      }, {} as Record<string, string>),
+    ).toString()
 
+    const result = await this.request<
+      { items: ClaimListItemDto[]; totalCount: number } | undefined
+    >(`/events${query ? `?${query}` : ""}`)
+
+    return result ?? { items: [], totalCount: 0 }
   }
 
   async getClaim(id: string): Promise<ClaimDto> {


### PR DESCRIPTION
## Summary
- track total claim count
- allow paginated claim fetching with filters
- propagate filter options from claims list

## Testing
- `npm test` *(fails: hooks/__tests__/use-damages.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6895a7498e90832c8a9c11ce1af737f8