### PR TITLE
feat: persist event notes

### DIFF
--- a/hooks/use-events.ts
+++ b/hooks/use-events.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useCallback } from "react"
-import { apiService, type EventDto } from "@/lib/api"
+import { apiService, type EventDto, type NoteDto } from "@/lib/api"
 
 export interface Event {
   id: string
@@ -23,6 +23,7 @@ export interface Event {
   injuryDescription?: string
   createdAt: string
   updatedAt: string
+  notes?: NoteDto[]
 }
 
 // Transform API event to frontend event format
@@ -46,6 +47,7 @@ const transformApiEvent = (apiEvent: EventDto): Event => ({
   injuryDescription: "",
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
+  notes: apiEvent.notes || [],
 })
 
 // Transform frontend event to API format
@@ -56,6 +58,7 @@ const transformToApiEvent = (event: Partial<Event>): Partial<EventDto> => ({
   location: event.location || "",
   description: event.eventDescription,
   servicesCalled: event.policeInvolved ? ["policja"] : [],
+  notes: event.notes,
 })
 
 export function useEvents() {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -45,6 +45,7 @@ export interface EventDto extends EventListItemDto {
   damageType?: string
   participants?: ParticipantDto[]
   damages?: DamageDto[]
+  notes?: NoteDto[]
   decisions?: DecisionDto[]
   appeals?: AppealDto[]
   clientClaims?: ClientClaimDto[]
@@ -99,6 +100,21 @@ export interface EventUpsertDto {
 export interface ClaimListItemDto extends EventListItemDto {}
 export interface ClaimDto extends EventDto {}
 export interface ClaimUpsertDto extends EventUpsertDto {}
+
+export interface NoteDto {
+  id: string
+  eventId: string
+  category?: string
+  title?: string
+  content: string
+  createdBy?: string
+  updatedBy?: string
+  createdAt: string
+  updatedAt: string
+  isPrivate: boolean
+  priority?: string
+  tags?: string[]
+}
 
 export interface NoteUpsertDto {
   eventId?: string


### PR DESCRIPTION
## Summary
- expose event notes in API layer
- persist notes via events hook

## Testing
- `pnpm test`
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_6895b4dc1224832caf548a41c14a6500