### PR TITLE
feat: auto-generate sparta number

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -143,7 +143,6 @@ export default function ClaimPage() {
         const newClaimData = {
           ...claimFormData,
           id: generateId(),
-          spartaNumber: `SPARTA/2025/${String(Date.now()).slice(-4)}`,
           claimNumber: `PL${new Date().getFullYear()}${String(Date.now()).slice(-8)}`,
         } as Claim
 

--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -263,7 +263,6 @@ export default function NewClaimPage() {
       const newClaimData = {
         ...claimFormData,
         id: generateId(),
-        spartaNumber: `SPARTA/2025/${String(Date.now()).slice(-4)}`,
         claimNumber: `PL${new Date().getFullYear()}${String(Date.now()).slice(-8)}`,
       } as Claim
 

--- a/components/claim-form/claim-top-header.tsx
+++ b/components/claim-form/claim-top-header.tsx
@@ -93,7 +93,7 @@ export function ClaimTopHeader({ claimFormData, onClose }: ClaimTopHeaderProps) 
             <div className="flex-1 min-w-0">
               <span className="block text-sm font-medium text-gray-700 mb-1">Nr szkody Sparta</span>
               <span className="block text-sm text-gray-900 font-semibold truncate">
-                {claimFormData.spartaNumber || "SPARTA/2025/0297"}
+                {claimFormData.spartaNumber || "-"}
               </span>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- assign SPARTA numbers on the backend with yearly sequential format
- remove frontend SPARTA number generation
- show placeholder when SPARTA number missing in claim header

## Testing
- `pnpm test`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c50235b0832c8a85ba96b436b2a3