### PR TITLE
Use API document URLs when tracking uploads

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -316,7 +316,7 @@ export const DocumentsSection = ({
               ? "doc"
               : "other",
             uploadedAt: doc.createdAt,
-            url: doc.filePath,
+            url: doc.previewUrl || doc.downloadUrl,
             category: doc.documentType,
             description: doc.description,
           })),


### PR DESCRIPTION
## Summary
- track uploaded documents using API-provided preview or download URLs

## Testing
- `pnpm lint` *(fails: ELIFECYCLE Command failed with exit code 1)*
- `pnpm test` *(fails: ERR_REQUIRE_CYCLE_MODULE, ERR_INVALID_TYPESCRIPT_SYNTAX)*

------
https://chatgpt.com/codex/tasks/task_e_6895c690672c832c84247f09890e148c