### PR TITLE
Expose document status to frontend

### DIFF
--- a/backend/Controllers/DocumentsController.cs
+++ b/backend/Controllers/DocumentsController.cs
@@ -161,6 +161,7 @@ namespace AutomotiveClaimsApi.Controllers
                 Description = doc.Description,
                 UploadedBy = doc.UploadedBy,
                 IsActive = !doc.IsDeleted,
+                Status = doc.Status,
                 CreatedAt = doc.CreatedAt,
                 UpdatedAt = doc.UpdatedAt,
                 DownloadUrl = $"/api/documents/{doc.Id}/download",

--- a/backend/DTOs/DocumentDto.cs
+++ b/backend/DTOs/DocumentDto.cs
@@ -15,6 +15,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Description { get; set; }
         public string UploadedBy { get; set; } = string.Empty;
         public bool IsActive { get; set; }
+        public string? Status { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
         public string? DownloadUrl { get; set; }

--- a/backend/Services/DocumentService.cs
+++ b/backend/Services/DocumentService.cs
@@ -243,6 +243,7 @@ namespace AutomotiveClaimsApi.Services
                 Description = doc.Description,
                 UploadedBy = doc.UploadedBy,
                 IsActive = !doc.IsDeleted,
+                Status = doc.Status,
                 CreatedAt = doc.CreatedAt,
                 UpdatedAt = doc.UpdatedAt,
                 DownloadUrl = $"/api/documents/{doc.Id}/download",

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -104,7 +104,7 @@ export const DocumentsSection = ({
       const response = await fetch(`/api/documents?eventId=${eventId}`)
 
       if (response.ok) {
-        const data = await response.json()
+        const data: Document[] = await response.json()
         console.log("Loaded documents:", data)
         setDocuments(data)
       } else {
@@ -621,6 +621,9 @@ export const DocumentsSection = ({
 
   const FileCard = ({ document, onDelete }: { document: Document; onDelete: (id: string | number) => void }) => (
     <Card className="overflow-hidden group relative">
+      <Badge variant="secondary" className="absolute top-2 left-2 capitalize">
+        {document.status}
+      </Badge>
       <div className="aspect-w-16 aspect-h-10 bg-gray-100 flex items-center justify-center min-h-[150px]">
         {document.contentType.startsWith("image/") ? (
           <img
@@ -858,6 +861,7 @@ export const DocumentsSection = ({
                             <th className="p-3 text-left font-medium text-gray-600 w-2/6">Opis pliku</th>
                             <th className="p-3 text-left font-medium text-gray-600 w-1/6">Rozmiar</th>
                             <th className="p-3 text-left font-medium text-gray-600 w-1/6">Data dodania</th>
+                            <th className="p-3 text-left font-medium text-gray-600 w-1/6">Status</th>
                             <th className="p-3 text-left font-medium text-gray-600 w-1/6">Akcja</th>
                           </tr>
                         </thead>
@@ -891,6 +895,7 @@ export const DocumentsSection = ({
                               </td>
                               <td className="p-3 text-gray-600">{formatBytes(document.fileSize)}</td>
                               <td className="p-3 text-gray-600">{new Date(document.createdAt).toLocaleDateString()}</td>
+                              <td className="p-3 text-gray-600 capitalize">{document.status}</td>
                               <td className="p-3">
                                 <div className="flex items-center gap-1">
                                   <Button


### PR DESCRIPTION
## Summary
- add nullable `Status` field to document DTO
- map document status in service and controller
- render and display document status in DocumentsSection

## Testing
- `pnpm test`
- `dotnet test` *(fails: command not found; `apt-get update` failed with unsigned repositories)*

------
https://chatgpt.com/codex/tasks/task_e_6895c6898f60832c90beff513251047a