### PR TITLE
Use category field for document uploads

### DIFF
--- a/app/api/documents/upload/route.ts
+++ b/app/api/documents/upload/route.ts
@@ -9,14 +9,14 @@ export async function POST(request: NextRequest) {
     const formData = await request.formData()
     const file = formData.get("file") as File
     const eventId = formData.get("eventId") as string
-    const documentType = formData.get("documentType") as string
+    const category = formData.get("category") as string
     const uploadedBy = formData.get("uploadedBy") as string
 
     console.log("Upload parameters:", {
       fileName: file?.name,
       fileSize: file?.size,
       eventId,
-      documentType,
+      category,
       uploadedBy,
     })
 
@@ -34,7 +34,7 @@ export async function POST(request: NextRequest) {
     const backendFormData = new FormData()
     backendFormData.append("File", file)
     backendFormData.append("EventId", eventId)
-    backendFormData.append("DocumentType", documentType || "OTHER")
+    backendFormData.append("Category", category || "OTHER")
     backendFormData.append("UploadedBy", uploadedBy || "System")
 
     const response = await fetch(`${API_BASE_URL}/api/documents/upload`, {

--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -160,7 +160,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
               const formDataFile = new FormData()
               formDataFile.append('file', file.file)
               formDataFile.append('eventId', saved!.id.toString())
-              formDataFile.append('documentType', file.category || 'Inne dokumenty')
+              formDataFile.append('category', file.category || 'Inne dokumenty')
               formDataFile.append('uploadedBy', 'Current User')
               await fetch('/api/documents/upload', {
                 method: 'POST',

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -236,7 +236,7 @@ export const DocumentsSection = ({
       const formData = new FormData()
       formData.append("file", file)
       formData.append("eventId", eventId.toString())
-      formData.append("documentType", category)
+      formData.append("category", category)
       formData.append("uploadedBy", "Current User")
 
       try {


### PR DESCRIPTION
## Summary
- send `category` instead of `documentType` when constructing upload `FormData`
- forward `category` to backend as `Category`

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895c6825b90832ca48a818dcdccd390