### PR TITLE
Handle missing documents in documents section

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -103,7 +103,13 @@ export const DocumentsSection = ({
       console.log("Loading documents for eventId:", eventId)
       const response = await fetch(`/api/documents?eventId=${eventId}`)
 
-      if (response.ok) {
+      if (response.status === 404) {
+        setDocuments([])
+        toast({
+          title: "Brak dokumentów",
+          description: "Nie znaleziono dokumentów dla tego zdarzenia.",
+        })
+      } else if (response.ok) {
         const data: Document[] = await response.json()
         console.log("Loaded documents:", data)
         const mappedDocs: Document[] = data.map((d: any) => ({


### PR DESCRIPTION
## Summary
- gracefully handle 404 responses when loading documents by clearing the list and showing a neutral toast
- reserve destructive toasts for other failures

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895cb734134832cb86119c2b11962f8