### PR TITLE
Standardize API base URL handling

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # Base URL for backend API, used on the server only
-API_BASE_URL=http://localhost:5200
+API_BASE_URL=http://localhost:5200/api
 
 # Base URL for backend API, exposed to the browser
-NEXT_PUBLIC_API_URL=http://localhost:5200
+NEXT_PUBLIC_API_URL=http://localhost:5200/api
 
 # Optional: number of times to retry requests to the backend
 # FETCH_RETRY_COUNT=1

--- a/app/api/appeals/[id]/download/route.ts
+++ b/app/api/appeals/[id]/download/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -8,7 +9,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
 
     // In production, fetch file from your backend
     if (process.env.NEXT_PUBLIC_API_URL) {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/appeals/${id}/download`, {
+      const response = await fetch(`${API_BASE_URL}/appeals/${id}/download`, {
         method: "GET",
       })
 

--- a/app/api/appeals/[id]/preview/route.ts
+++ b/app/api/appeals/[id]/preview/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -8,7 +9,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
 
     // In production, fetch file from your backend
     if (process.env.NEXT_PUBLIC_API_URL) {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/appeals/${id}/preview`, {
+      const response = await fetch(`${API_BASE_URL}/appeals/${id}/preview`, {
         method: "GET",
       })
 

--- a/app/api/appeals/[id]/route.ts
+++ b/app/api/appeals/[id]/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 // Mock data - in production this would come from your database
 const mockAppeals = [
@@ -36,7 +37,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
 
     // In production, fetch from your backend
     if (process.env.NEXT_PUBLIC_API_URL) {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/appeals/${id}`, {
+      const response = await fetch(`${API_BASE_URL}/appeals/${id}`, {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
@@ -86,7 +87,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
         backendFormData.append("file", file)
       }
 
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/appeals/${id}`, {
+      const response = await fetch(`${API_BASE_URL}/appeals/${id}`, {
         method: "PUT",
         body: backendFormData,
       })
@@ -132,7 +133,7 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
 
     // In production, send to your backend
     if (process.env.NEXT_PUBLIC_API_URL) {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/appeals/${id}`, {
+      const response = await fetch(`${API_BASE_URL}/appeals/${id}`, {
         method: "DELETE",
         headers: {
           "Content-Type": "application/json",

--- a/app/api/appeals/route.ts
+++ b/app/api/appeals/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "eventId is required" }, { status: 400 })
     }
 
-    const response = await fetch(`${API_BASE_URL}/api/appeals/event/${eventId}`, {
+    const response = await fetch(`${API_BASE_URL}/appeals/event/${eventId}`, {
       method: "GET",
       headers: { "Content-Type": "application/json" },
     })
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
       }
     })
 
-    const response = await fetch(`${API_BASE_URL}/api/appeals`, {
+    const response = await fetch(`${API_BASE_URL}/appeals`, {
       method: "POST",
       body: backendFormData,
     })

--- a/app/api/claim-statuses/route.ts
+++ b/app/api/claim-statuses/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/dictionaries/claim-statuses`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/claim-statuses`, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/app/api/claims/[claimId]/decisions/[decisionId]/route.ts
+++ b/app/api/claims/[claimId]/decisions/[decisionId]/route.ts
@@ -1,13 +1,13 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function PUT(request: NextRequest, { params }: { params: { claimId: string; decisionId: string } }) {
   try {
     const formData = await request.formData()
 
     const response = await fetch(
-      `${API_BASE_URL}/api/claims/${params.claimId}/decisions/${params.decisionId}`,
+      `${API_BASE_URL}/claims/${params.claimId}/decisions/${params.decisionId}`,
       {
         method: "PUT",
         body: formData,
@@ -36,7 +36,7 @@ export async function PUT(request: NextRequest, { params }: { params: { claimId:
 export async function DELETE(request: NextRequest, { params }: { params: { claimId: string; decisionId: string } }) {
   try {
     const response = await fetch(
-      `${API_BASE_URL}/api/claims/${params.claimId}/decisions/${params.decisionId}`,
+      `${API_BASE_URL}/claims/${params.claimId}/decisions/${params.decisionId}`,
       {
         method: "DELETE",
       },

--- a/app/api/claims/[claimId]/decisions/route.ts
+++ b/app/api/claims/[claimId]/decisions/route.ts
@@ -1,10 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { claimId: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/claims/${params.claimId}/decisions`, {
+    const response = await fetch(`${API_BASE_URL}/claims/${params.claimId}/decisions`, {
       method: "GET",
       headers: { "Content-Type": "application/json" },
     })
@@ -32,7 +32,7 @@ export async function POST(request: NextRequest, { params }: { params: { claimId
   try {
     const formData = await request.formData()
 
-    const response = await fetch(`${API_BASE_URL}/api/claims/${params.claimId}/decisions`, {
+    const response = await fetch(`${API_BASE_URL}/claims/${params.claimId}/decisions`, {
       method: "POST",
       body: formData,
     })

--- a/app/api/client-claims/route.ts
+++ b/app/api/client-claims/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Event ID is required" }, { status: 400 })
     }
 
-    const response = await fetch(`${API_BASE_URL}/api/client-claims/event/${eventId}`, {
+    const response = await fetch(`${API_BASE_URL}/client-claims/event/${eventId}`, {
       headers: {
         "Content-Type": "application/json",
       },
@@ -63,7 +63,7 @@ export async function POST(request: NextRequest) {
     if (documentDescription) backendFormData.append("DocumentDescription", documentDescription)
     if (document) backendFormData.append("Document", document)
 
-    const response = await fetch(`${API_BASE_URL}/api/client-claims`, {
+    const response = await fetch(`${API_BASE_URL}/client-claims`, {
       method: "POST",
       body: backendFormData,
     })

--- a/app/api/contract-types/route.ts
+++ b/app/api/contract-types/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/dictionaries/contract-types`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/contract-types`, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/app/api/countries/route.ts
+++ b/app/api/countries/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/dictionaries/countries`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/countries`, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/app/api/currencies/route.ts
+++ b/app/api/currencies/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/dictionaries/currencies`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/currencies`, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/app/api/damage-types/route.ts
+++ b/app/api/damage-types/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   const urlObj = new URL(request.url)
   const dependsOn = urlObj.searchParams.get('dependsOn') // This is the RiskId
 
   try {
-    const url = `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5200'}/api/damage-types`
+    const url = `${API_BASE_URL}/damage-types`
 
     const response = await fetch(url)
 

--- a/app/api/decisions/[id]/route.ts
+++ b/app/api/decisions/[id]/route.ts
@@ -1,10 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/decisions/${params.id}`, {
+    const response = await fetch(`${API_BASE_URL}/decisions/${params.id}`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -31,7 +31,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
   try {
     const formData = await request.formData()
 
-    const response = await fetch(`${API_BASE_URL}/api/decisions/${params.id}`, {
+    const response = await fetch(`${API_BASE_URL}/decisions/${params.id}`, {
       method: "PUT",
       body: formData,
     })
@@ -54,7 +54,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
 export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/decisions/${params.id}`, {
+    const response = await fetch(`${API_BASE_URL}/decisions/${params.id}`, {
       method: "DELETE",
     })
 

--- a/app/api/decisions/route.ts
+++ b/app/api/decisions/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "ClaimId is required" }, { status: 400 })
     }
 
-    const url = `${API_BASE_URL}/api/decisions?claimId=${claimId}`
+    const url = `${API_BASE_URL}/decisions?claimId=${claimId}`
 
 
     const response = await fetch(url, {
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData()
 
-    const response = await fetch(`${API_BASE_URL}/api/decisions`, {
+    const response = await fetch(`${API_BASE_URL}/decisions`, {
       method: "POST",
       body: formData,
     })

--- a/app/api/dictionaries/case-handlers/route.ts
+++ b/app/api/dictionaries/case-handlers/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5200'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${BACKEND_URL}/api/dictionaries/case-handlers`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/case-handlers`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/dictionaries/claim-statuses/route.ts
+++ b/app/api/dictionaries/claim-statuses/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5200'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${BACKEND_URL}/api/dictionaries/claim-statuses`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/claim-statuses`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/dictionaries/contract-types/route.ts
+++ b/app/api/dictionaries/contract-types/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5200'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${BACKEND_URL}/api/dictionaries/contract-types`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/contract-types`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/dictionaries/countries/route.ts
+++ b/app/api/dictionaries/countries/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5200'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${BACKEND_URL}/api/dictionaries/countries`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/countries`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/dictionaries/currencies/route.ts
+++ b/app/api/dictionaries/currencies/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5200'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${BACKEND_URL}/api/dictionaries/currencies`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/currencies`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/dictionaries/damage-types/route.ts
+++ b/app/api/dictionaries/damage-types/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams
     const riskType = searchParams.get('riskType')
     
-    let url = `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5200'}/api/dictionaries/damage-types`
+    let url = `${API_BASE_URL}/dictionaries/damage-types`
     
     if (riskType) {
       url += `?riskType=${encodeURIComponent(riskType)}`

--- a/app/api/dictionaries/document-statuses/route.ts
+++ b/app/api/dictionaries/document-statuses/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5200'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${BACKEND_URL}/api/dictionaries/document-statuses`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/document-statuses`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/dictionaries/event-statuses/route.ts
+++ b/app/api/dictionaries/event-statuses/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5200'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${BACKEND_URL}/api/dictionaries/event-statuses`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/event-statuses`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/dictionaries/insurance-companies/route.ts
+++ b/app/api/dictionaries/insurance-companies/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5200'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${BACKEND_URL}/api/dictionaries/insurance-companies`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/insurance-companies`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/dictionaries/leasing-companies/route.ts
+++ b/app/api/dictionaries/leasing-companies/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5200'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${BACKEND_URL}/api/dictionaries/leasing-companies`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/leasing-companies`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/dictionaries/payment-methods/route.ts
+++ b/app/api/dictionaries/payment-methods/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5200'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${BACKEND_URL}/api/dictionaries/payment-methods`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/payment-methods`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/dictionaries/priorities/route.ts
+++ b/app/api/dictionaries/priorities/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5200'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${BACKEND_URL}/api/dictionaries/priorities`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/priorities`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/dictionaries/risk-types/route.ts
+++ b/app/api/dictionaries/risk-types/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
     const claimObjectTypeId = searchParams.get('claimObjectTypeId') || '1' // Default to communication claims
     
-    const url = `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5200'}/api/dictionaries/risk-types`
+    const url = `${API_BASE_URL}/dictionaries/risk-types`
     
     const response = await fetch(url)
     

--- a/app/api/dictionaries/vehicle-types/route.ts
+++ b/app/api/dictionaries/vehicle-types/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:5200'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${BACKEND_URL}/api/dictionaries/vehicle-types`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/vehicle-types`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/document-statuses/route.ts
+++ b/app/api/document-statuses/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/dictionaries/document-statuses`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/document-statuses`, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/app/api/documents/[id]/download/route.ts
+++ b/app/api/documents/[id]/download/route.ts
@@ -1,10 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/documents/${params.id}/download`, {
+    const response = await fetch(`${API_BASE_URL}/documents/${params.id}/download`, {
       method: "GET",
     })
 

--- a/app/api/documents/[id]/generate-description/route.ts
+++ b/app/api/documents/[id]/generate-description/route.ts
@@ -1,10 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/documents/${params.id}/generate-description`, {
+    const response = await fetch(`${API_BASE_URL}/documents/${params.id}/generate-description`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/app/api/documents/[id]/preview/route.ts
+++ b/app/api/documents/[id]/preview/route.ts
@@ -1,10 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/documents/${params.id}/preview`, {
+    const response = await fetch(`${API_BASE_URL}/documents/${params.id}/preview`, {
       method: "GET",
     })
 

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -1,10 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/documents/${params.id}`, {
+    const response = await fetch(`${API_BASE_URL}/documents/${params.id}`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -34,7 +34,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
   try {
     const body = await request.json()
 
-    const response = await fetch(`${API_BASE_URL}/api/documents/${params.id}`, {
+    const response = await fetch(`${API_BASE_URL}/documents/${params.id}`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
@@ -63,7 +63,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
 export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/documents/${params.id}`, {
+    const response = await fetch(`${API_BASE_URL}/documents/${params.id}`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",

--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
@@ -9,7 +9,7 @@ export async function GET(request: NextRequest) {
 
     console.log("Fetching documents with params:", queryString)
 
-    const response = await fetch(`${API_BASE_URL}/api/documents?${queryString}`, {
+    const response = await fetch(`${API_BASE_URL}/documents?${queryString}`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
 
     console.log("Proxying document upload to backend API")
 
-    const response = await fetch(`${API_BASE_URL}/api/documents/upload`, {
+    const response = await fetch(`${API_BASE_URL}/documents/upload`, {
       method: "POST",
       body: formData,
     })

--- a/app/api/documents/upload/route.ts
+++ b/app/api/documents/upload/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function POST(request: NextRequest) {
   try {
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
     backendFormData.append("Category", category || "OTHER")
     backendFormData.append("UploadedBy", uploadedBy || "System")
 
-    const response = await fetch(`${API_BASE_URL}/api/documents/upload`, {
+    const response = await fetch(`${API_BASE_URL}/documents/upload`, {
       method: "POST",
       body: backendFormData,
     })

--- a/app/api/event-statuses/route.ts
+++ b/app/api/event-statuses/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/dictionaries/event-statuses`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/event-statuses`, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/app/api/insurance-companies/route.ts
+++ b/app/api/insurance-companies/route.ts
@@ -1,13 +1,13 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const BACKEND_API_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
     const search = searchParams.get("search")
 
-    const url = `${BACKEND_API_URL}/dictionaries/insurance-companies`
+    const url = `${API_BASE_URL}/dictionaries/insurance-companies`
 
     const response = await fetch(url, {
       headers: {
@@ -49,7 +49,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
 
-    const response = await fetch(`${BACKEND_API_URL}/dictionaries/insurance-companies`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/insurance-companies`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/app/api/leasing-companies/route.ts
+++ b/app/api/leasing-companies/route.ts
@@ -1,13 +1,13 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const BACKEND_API_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
     const search = searchParams.get("search")
 
-    const url = `${BACKEND_API_URL}/dictionaries/leasing-companies`
+    const url = `${API_BASE_URL}/dictionaries/leasing-companies`
 
     const response = await fetch(url, {
       headers: {
@@ -49,7 +49,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
 
-    const response = await fetch(`${BACKEND_API_URL}/dictionaries/leasing-companies`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/leasing-companies`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/app/api/notes/[id]/route.ts
+++ b/app/api/notes/[id]/route.ts
@@ -1,10 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/notes/${params.id}`, {
+    const response = await fetch(`${API_BASE_URL}/notes/${params.id}`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -30,7 +30,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
   try {
     const body = await request.json()
 
-    const response = await fetch(`${API_BASE_URL}/api/notes/${params.id}`, {
+    const response = await fetch(`${API_BASE_URL}/notes/${params.id}`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
@@ -54,7 +54,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
 export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/notes/${params.id}`, {
+    const response = await fetch(`${API_BASE_URL}/notes/${params.id}`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",

--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest) {
     const eventId = searchParams.get("eventId")
     const category = searchParams.get("category")
 
-    let url = `${API_BASE_URL}/api/notes`
+    let url = `${API_BASE_URL}/notes`
     const params = new URLSearchParams()
 
     if (eventId) params.append("eventId", eventId)
@@ -41,7 +41,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
 
-    const response = await fetch(`${API_BASE_URL}/api/notes`, {
+    const response = await fetch(`${API_BASE_URL}/notes`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/app/api/payment-methods/route.ts
+++ b/app/api/payment-methods/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/dictionaries/payment-methods`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/payment-methods`, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/app/api/priorities/route.ts
+++ b/app/api/priorities/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/dictionaries/priorities`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/priorities`, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/app/api/recourses/route.ts
+++ b/app/api/recourses/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 
 export async function GET(request: NextRequest) {
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "EventId is required" }, { status: 400 })
     }
 
-    const url = new URL(`${API_BASE_URL}/api/recourses`)
+    const url = new URL(`${API_BASE_URL}/recourses`)
     url.searchParams.set("claimId", claimId)
 
 
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const response = await fetch(`${API_BASE_URL}/api/recourses`, {
+    const response = await fetch(`${API_BASE_URL}/recourses`, {
       method: "POST",
       body: formData,
     })

--- a/app/api/settlements/[id]/download/route.ts
+++ b/app/api/settlements/[id]/download/route.ts
@@ -1,10 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/settlements/${params.id}/download`, {
+    const response = await fetch(`${API_BASE_URL}/settlements/${params.id}/download`, {
       method: "GET",
     })
 

--- a/app/api/settlements/[id]/preview/route.ts
+++ b/app/api/settlements/[id]/preview/route.ts
@@ -1,10 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/settlements/${params.id}/preview`, {
+    const response = await fetch(`${API_BASE_URL}/settlements/${params.id}/preview`, {
       method: "GET",
     })
 

--- a/app/api/settlements/[id]/route.ts
+++ b/app/api/settlements/[id]/route.ts
@@ -1,10 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/settlements/${params.id}`, {
+    const response = await fetch(`${API_BASE_URL}/settlements/${params.id}`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -31,7 +31,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
   try {
     const formData = await request.formData()
 
-    const response = await fetch(`${API_BASE_URL}/api/settlements/${params.id}`, {
+    const response = await fetch(`${API_BASE_URL}/settlements/${params.id}`, {
       method: "PUT",
       body: formData,
     })
@@ -57,7 +57,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
 export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/settlements/${params.id}`, {
+    const response = await fetch(`${API_BASE_URL}/settlements/${params.id}`, {
       method: "DELETE",
     })
 

--- a/app/api/settlements/route.ts
+++ b/app/api/settlements/route.ts
@@ -38,7 +38,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const claimId = searchParams.get("claimId")
 
-    let url = `${API_BASE_URL}/api/settlements`
+    let url = `${API_BASE_URL}/settlements`
     if (claimId) {
       url += `?claimId=${claimId}`
     }
@@ -82,7 +82,7 @@ export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData()
 
-    const response = await fetchWithRetry(`${API_BASE_URL}/api/settlements`, {
+    const response = await fetchWithRetry(`${API_BASE_URL}/settlements`, {
       method: "POST",
       body: formData,
     })

--- a/app/api/vehicle-types/route.ts
+++ b/app/api/vehicle-types/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200"
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/dictionaries/vehicle-types`, {
+    const response = await fetch(`${API_BASE_URL}/dictionaries/vehicle-types`, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,7 +1,8 @@
 // API Configuration
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL ||
-  (process.env.API_BASE_URL ? `${process.env.API_BASE_URL}/api` : "https://claim-work-backend.azurewebsites.net/api")
+  process.env.API_BASE_URL ||
+  "https://claim-work-backend.azurewebsites.net/api"
 
 // Types for API responses
 export interface EventListItemDto {


### PR DESCRIPTION
## Summary
- Define API_BASE_URL and NEXT_PUBLIC_API_URL with `/api` suffix
- Refactor frontend API routes to assume base URLs include `/api`
- Simplify API client configuration

## Testing
- `pnpm lint` *(fails: next lint requires configuration)*
- `pnpm test`
- `node` verification that `fetch(`${API_BASE_URL}/claims`)` hits server (status 200)


------
https://chatgpt.com/codex/tasks/task_e_6895cf3bdca0832caba619d3a97f2364