### PR TITLE
Handle missing claim list endpoint

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -446,6 +446,9 @@ class ApiService {
     })
 
     if (!response.ok) {
+      if (response.status === 404) {
+        return { items: [], totalCount: 0 }
+      }
       const errorText = await response.text()
       throw new Error(`API Error: ${response.status} - ${errorText}`)
     }


### PR DESCRIPTION
## Summary
- avoid crashing when claims endpoint returns 404 by returning an empty list

## Testing
- `pnpm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_e_689602d34f10832c86584db1476abeca