### PR TITLE
Use router-based sidebar navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
 import { Header } from "@/components/header"
 import { Sidebar } from "@/components/sidebar"
-import { ClaimsList } from "@/components/claims-list"
 import { AuthWrapper } from '@/components/auth-wrapper'
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -22,7 +22,7 @@ interface PageProps {
 }
 
 function HomePage({ user, onLogout }: PageProps) {
-  const [activeTab, setActiveTab] = useState("dashboard")
+  const router = useRouter()
 
   useEffect(() => {
     const isAuthenticated = localStorage.getItem('isAuthenticated')
@@ -117,7 +117,7 @@ function HomePage({ user, onLogout }: PageProps) {
     <div className="min-h-screen bg-gray-50">
       <Header onMenuClick={() => {}} user={user} onLogout={onLogout} />
       <div className="flex">
-        <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+        <Sidebar />
         <main className="flex-1 p-6">
           <div className="max-w-7xl mx-auto">
             <div className="mb-8">
@@ -135,15 +135,17 @@ function HomePage({ user, onLogout }: PageProps) {
                 </div>
               )}
             </div>
-            {activeTab === "dashboard" ? (
-              <div className="space-y-6">
+            <div className="space-y-6">
                 {/* Page Header */}
                 <div className="flex items-center justify-between">
                   <div>
                     <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
                     <p className="text-gray-600">Przegląd systemu zarządzania szkodami</p>
                   </div>
-                  <Button className="bg-blue-600 hover:bg-blue-700" onClick={() => setActiveTab("claims")}>
+                  <Button
+                    className="bg-blue-600 hover:bg-blue-700"
+                    onClick={() => router.push("/claims/new")}
+                  >
                     <Plus className="h-4 w-4 mr-2" />
                     Nowa szkoda
                   </Button>
@@ -290,7 +292,7 @@ function HomePage({ user, onLogout }: PageProps) {
                             className={`h-20 flex-col space-y-2 ${action.color} text-white border-0`}
                             onClick={() => {
                               if (action.title === "Nowa szkoda") {
-                                setActiveTab("claims")
+                                router.push("/claims/new")
                               }
                             }}
                           >
@@ -326,9 +328,7 @@ function HomePage({ user, onLogout }: PageProps) {
                   </CardContent>
                 </Card>
               </div>
-            ) : (
-              <ClaimsList />
-            )}
+            </div>
           </div>
         </main>
       </div>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,27 +1,27 @@
 "use client"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { LayoutDashboard, FileText, Car } from "lucide-react"
-
-interface SidebarProps {
-  activeTab: string
-  onTabChange: (tab: string) => void
-}
 
 const menuItems = [
   {
     id: "dashboard",
     label: "Dashboard",
     icon: LayoutDashboard,
+    href: "/",
   },
   {
     id: "claims",
     label: "Szkody",
     icon: FileText,
+    href: "/claims",
   },
 ]
 
-export function Sidebar({ activeTab, onTabChange }: SidebarProps) {
+export function Sidebar() {
+  const pathname = usePathname()
   return (
     <div className="fixed left-0 top-0 z-40 h-full w-16 bg-[#1a3a6c] border-r border-[#2a4a7c] flex flex-col">
       {/* Header */}
@@ -33,11 +33,13 @@ export function Sidebar({ activeTab, onTabChange }: SidebarProps) {
       <nav className="flex-1 p-2 space-y-2">
         {menuItems.map((item) => {
           const Icon = item.icon
-          const isActive = activeTab === item.id
+          const isActive =
+            pathname === item.href || pathname.startsWith(item.href + "/")
 
           return (
             <Button
               key={item.id}
+              asChild
               variant="ghost"
               className={cn(
                 "w-full h-12 p-0 flex items-center justify-center transition-all duration-200 rounded-lg",
@@ -45,10 +47,11 @@ export function Sidebar({ activeTab, onTabChange }: SidebarProps) {
                   ? "bg-white/20 text-white hover:bg-white/25"
                   : "text-white/70 hover:bg-white/10 hover:text-white",
               )}
-              onClick={() => onTabChange(item.id)}
               title={item.label}
             >
-              <Icon className="h-5 w-5" />
+              <Link href={item.href}>
+                <Icon className="h-5 w-5" />
+              </Link>
             </Button>
           )
         })}


### PR DESCRIPTION
## Summary
- link sidebar items to routes and derive active state from current path
- navigate to claim pages via router instead of tab state

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6896078066b8832cb0e41dc11ca6006f