### PR TITLE
Adjust workspace layout for full-width claims list

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -118,8 +118,8 @@ function HomePage({ user, onLogout }: PageProps) {
       <Header onMenuClick={() => {}} user={user} onLogout={onLogout} />
       <div className="flex">
         <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
-        <main className="flex-1 p-6">
-          <div className="max-w-7xl mx-auto">
+        <main className="flex-1 p-0">
+          <div className="w-full">
             <div className="mb-8">
               <h1 className="text-3xl font-bold text-gray-900">
                 System zarządzania szkodami

--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -183,7 +183,7 @@ export function ClaimsList({ onEditClaim, onNewClaim }: ClaimsListProps) {
   // Loading state
   if (loading) {
     return (
-      <div className="h-screen bg-white flex flex-col">
+      <div className="w-full h-screen bg-white flex flex-col">
         <div className="flex items-center justify-between p-6 border-b border-gray-200">
           <h1 className="text-xl font-semibold text-gray-900">Lista Szkód</h1>
           <Button disabled className="bg-[#1a3a6c] hover:bg-[#1a3a6c]/90 text-sm">
@@ -203,7 +203,7 @@ export function ClaimsList({ onEditClaim, onNewClaim }: ClaimsListProps) {
   }
 
   return (
-    <div className="h-screen bg-white flex flex-col">
+    <div className="w-full h-screen bg-white flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between p-6 border-b border-gray-200 flex-shrink-0">
         <div className="flex items-center space-x-3">


### PR DESCRIPTION
## Summary
- Remove interior padding on main content area
- Use full-width container and expand ClaimsList to `w-full h-screen`

## Testing
- `pnpm test`
- `pnpm lint` *(fails: interactive configuration for ESLint required)*

------
https://chatgpt.com/codex/tasks/task_e_689607bd3f5c832c854e9ad1e4363d57