### PR TITLE
Align claim references with eventId

### DIFF
--- a/app/api/decisions/route.ts
+++ b/app/api/decisions/route.ts
@@ -4,14 +4,14 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 
 export async function GET(request: NextRequest) {
   try {
-    const { searchParams } = new URL(request.url)
-    const claimId = searchParams.get("claimId")
+      const { searchParams } = new URL(request.url)
+      const eventId = searchParams.get("eventId") || searchParams.get("claimId")
 
-    if (!claimId) {
-      return NextResponse.json({ error: "ClaimId is required" }, { status: 400 })
-    }
+      if (!eventId) {
+        return NextResponse.json({ error: "EventId is required" }, { status: 400 })
+      }
 
-    const url = `${API_BASE_URL}/decisions?claimId=${claimId}`
+      const url = `${API_BASE_URL}/decisions?eventId=${eventId}`
 
 
     const response = await fetch(url, {
@@ -44,6 +44,12 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData()
+
+    const eventId = (formData.get("eventId") as string | null) || (formData.get("claimId") as string | null)
+    if (eventId) {
+      formData.set("eventId", eventId)
+      formData.delete("claimId")
+    }
 
     const response = await fetch(`${API_BASE_URL}/decisions`, {
       method: "POST",

--- a/app/api/recourses/route.ts
+++ b/app/api/recourses/route.ts
@@ -7,15 +7,14 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
 
-    const claimId = searchParams.get("claimId") || searchParams.get("eventId")
-
+    const eventId = searchParams.get("eventId") || searchParams.get("claimId")
 
     if (!eventId) {
       return NextResponse.json({ error: "EventId is required" }, { status: 400 })
     }
 
     const url = new URL(`${API_BASE_URL}/recourses`)
-    url.searchParams.set("claimId", claimId)
+    url.searchParams.set("eventId", eventId)
 
 
     const response = await fetch(url.toString(), {
@@ -44,17 +43,19 @@ export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData()
 
-
-    const claimId = formData.get("claimId") as string | null
+    const eventId = (formData.get("eventId") as string | null) || (formData.get("claimId") as string | null)
     const filingDate = formData.get("filingDate") as string | null
     const insuranceCompany = formData.get("insuranceCompany") as string | null
 
-    if (!claimId || !filingDate || !insuranceCompany) {
+    if (!eventId || !filingDate || !insuranceCompany) {
       return NextResponse.json(
-        { error: "ClaimId, filingDate, and insuranceCompany are required" },
+        { error: "EventId, filingDate, and insuranceCompany are required" },
         { status: 400 },
       )
     }
+
+    formData.set("eventId", eventId)
+    formData.delete("claimId")
 
     const response = await fetch(`${API_BASE_URL}/recourses`, {
       method: "POST",

--- a/app/api/repair-details/route.ts
+++ b/app/api/repair-details/route.ts
@@ -5,7 +5,7 @@ import type { RepairDetail } from "@/lib/repair-details-store"
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
-    const eventId = searchParams.get("eventId")
+    const eventId = searchParams.get("eventId") || searchParams.get("claimId")
 
     let filteredDetails = repairDetails
 
@@ -24,9 +24,11 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
 
+    const eventId = body.eventId || body.claimId
+
     const newRepairDetail: RepairDetail = {
       id: Math.random().toString(36).substr(2, 9),
-      eventId: body.eventId,
+      eventId,
       branchId: body.branchId || "",
       employeeEmail: body.employeeEmail || "",
       replacementVehicleRequired: body.replacementVehicleRequired || false,

--- a/app/api/repair-schedules/[id]/route.ts
+++ b/app/api/repair-schedules/[id]/route.ts
@@ -32,6 +32,12 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
   try {
     const { id } = params
     const body = await request.json()
+
+    if (!body.eventId && body.claimId) {
+      body.eventId = body.claimId
+      delete body.claimId
+    }
+
     console.log(`Updating repair schedule ${id}:`, body)
 
     const response = await fetch(`${API_BASE_URL}/repair-schedules/${id}`, {

--- a/app/api/repair-schedules/route.ts
+++ b/app/api/repair-schedules/route.ts
@@ -5,7 +5,7 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost:5200/
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
-    const eventId = searchParams.get("eventId")
+    const eventId = searchParams.get("eventId") || searchParams.get("claimId")
 
     let url = `${API_BASE_URL}/repair-schedules`
     if (eventId) {
@@ -42,6 +42,12 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
+
+    if (!body.eventId && body.claimId) {
+      body.eventId = body.claimId
+      delete body.claimId
+    }
+
     console.log("Creating new repair schedule:", body)
 
     const response = await fetch(`${API_BASE_URL}/repair-schedules`, {

--- a/app/api/settlements/route.ts
+++ b/app/api/settlements/route.ts
@@ -36,11 +36,11 @@ export async function GET(request: NextRequest) {
 
   try {
     const { searchParams } = new URL(request.url)
-    const claimId = searchParams.get("claimId")
+    const eventId = searchParams.get("eventId") || searchParams.get("claimId")
 
     let url = `${API_BASE_URL}/settlements`
-    if (claimId) {
-      url += `?claimId=${claimId}`
+    if (eventId) {
+      url += `?eventId=${eventId}`
     }
 
     const response = await fetchWithRetry(url, {
@@ -81,6 +81,12 @@ export async function POST(request: NextRequest) {
 
   try {
     const formData = await request.formData()
+
+    const eventId = (formData.get("eventId") as string | null) || (formData.get("claimId") as string | null)
+    if (eventId) {
+      formData.set("eventId", eventId)
+      formData.delete("claimId")
+    }
 
     const response = await fetchWithRetry(`${API_BASE_URL}/settlements`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- Accept `claimId` as an alias for `eventId` across repair schedules, repair details, recourses, decisions, and settlements API routes
- Normalize incoming payloads by renaming `claimId` to `eventId`

## Testing
- `pnpm test`
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6896908102a8832c96def4e249308fef