### PR TITLE
feat: add repair details API

### DIFF
--- a/backend/Controllers/RepairDetailsController.cs
+++ b/backend/Controllers/RepairDetailsController.cs
@@ -1,0 +1,115 @@
+using Microsoft.AspNetCore.Mvc;
+using AutomotiveClaimsApi.Models;
+using AutomotiveClaimsApi.DTOs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AutomotiveClaimsApi.Controllers
+{
+    [ApiController]
+    [Route("api/repair-details")]
+    public class RepairDetailsController : ControllerBase
+    {
+        private static readonly List<RepairDetail> _details = new();
+
+        [HttpGet]
+        public ActionResult<IEnumerable<RepairDetailDto>> GetDetails([FromQuery] Guid? eventId)
+        {
+            var query = _details.AsEnumerable();
+            if (eventId.HasValue)
+            {
+                query = query.Where(d => d.EventId == eventId.Value);
+            }
+
+            return Ok(query.Select(RepairDetailDto.FromModel));
+        }
+
+        [HttpGet("{id}")]
+        public ActionResult<RepairDetailDto> GetDetail(Guid id)
+        {
+            var detail = _details.FirstOrDefault(d => d.Id == id);
+            if (detail == null)
+                return NotFound();
+            return Ok(RepairDetailDto.FromModel(detail));
+        }
+
+        [HttpPost]
+        public ActionResult<RepairDetailDto> CreateDetail([FromBody] CreateRepairDetailDto createDto)
+        {
+            var detail = new RepairDetail
+            {
+                Id = Guid.NewGuid(),
+                EventId = createDto.EventId,
+                BranchId = createDto.BranchId,
+                EmployeeEmail = createDto.EmployeeEmail,
+                ReplacementVehicleRequired = createDto.ReplacementVehicleRequired,
+                ReplacementVehicleInfo = createDto.ReplacementVehicleInfo,
+                VehicleTabNumber = createDto.VehicleTabNumber,
+                VehicleRegistration = createDto.VehicleRegistration,
+                DamageDateTime = createDto.DamageDateTime,
+                AppraiserWaitingDate = createDto.AppraiserWaitingDate,
+                RepairStartDate = createDto.RepairStartDate,
+                RepairEndDate = createDto.RepairEndDate,
+                OtherVehiclesAvailable = createDto.OtherVehiclesAvailable,
+                OtherVehiclesInfo = createDto.OtherVehiclesInfo,
+                BodyworkHours = createDto.BodyworkHours,
+                PaintingHours = createDto.PaintingHours,
+                AssemblyHours = createDto.AssemblyHours,
+                OtherWorkHours = createDto.OtherWorkHours,
+                OtherWorkDescription = createDto.OtherWorkDescription,
+                DamageDescription = createDto.DamageDescription,
+                AdditionalDescription = createDto.AdditionalDescription,
+                Status = createDto.Status,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+
+            _details.Add(detail);
+            return CreatedAtAction(nameof(GetDetail), new { id = detail.Id }, RepairDetailDto.FromModel(detail));
+        }
+
+        [HttpPut("{id}")]
+        public ActionResult<RepairDetailDto> UpdateDetail(Guid id, [FromBody] UpdateRepairDetailDto updateDto)
+        {
+            var detail = _details.FirstOrDefault(d => d.Id == id);
+            if (detail == null)
+                return NotFound();
+
+            if (updateDto.EventId.HasValue) detail.EventId = updateDto.EventId.Value;
+            if (updateDto.BranchId != null) detail.BranchId = updateDto.BranchId;
+            if (updateDto.EmployeeEmail != null) detail.EmployeeEmail = updateDto.EmployeeEmail;
+            if (updateDto.ReplacementVehicleRequired.HasValue) detail.ReplacementVehicleRequired = updateDto.ReplacementVehicleRequired.Value;
+            if (updateDto.ReplacementVehicleInfo != null) detail.ReplacementVehicleInfo = updateDto.ReplacementVehicleInfo;
+            if (updateDto.VehicleTabNumber != null) detail.VehicleTabNumber = updateDto.VehicleTabNumber;
+            if (updateDto.VehicleRegistration != null) detail.VehicleRegistration = updateDto.VehicleRegistration;
+            if (updateDto.DamageDateTime != null) detail.DamageDateTime = updateDto.DamageDateTime;
+            if (updateDto.AppraiserWaitingDate != null) detail.AppraiserWaitingDate = updateDto.AppraiserWaitingDate;
+            if (updateDto.RepairStartDate != null) detail.RepairStartDate = updateDto.RepairStartDate;
+            if (updateDto.RepairEndDate != null) detail.RepairEndDate = updateDto.RepairEndDate;
+            if (updateDto.OtherVehiclesAvailable.HasValue) detail.OtherVehiclesAvailable = updateDto.OtherVehiclesAvailable.Value;
+            if (updateDto.OtherVehiclesInfo != null) detail.OtherVehiclesInfo = updateDto.OtherVehiclesInfo;
+            if (updateDto.BodyworkHours.HasValue) detail.BodyworkHours = updateDto.BodyworkHours.Value;
+            if (updateDto.PaintingHours.HasValue) detail.PaintingHours = updateDto.PaintingHours.Value;
+            if (updateDto.AssemblyHours.HasValue) detail.AssemblyHours = updateDto.AssemblyHours.Value;
+            if (updateDto.OtherWorkHours.HasValue) detail.OtherWorkHours = updateDto.OtherWorkHours.Value;
+            if (updateDto.OtherWorkDescription != null) detail.OtherWorkDescription = updateDto.OtherWorkDescription;
+            if (updateDto.DamageDescription != null) detail.DamageDescription = updateDto.DamageDescription;
+            if (updateDto.AdditionalDescription != null) detail.AdditionalDescription = updateDto.AdditionalDescription;
+            if (updateDto.Status != null) detail.Status = updateDto.Status;
+
+            detail.UpdatedAt = DateTime.UtcNow;
+            return Ok(RepairDetailDto.FromModel(detail));
+        }
+
+        [HttpDelete("{id}")]
+        public IActionResult DeleteDetail(Guid id)
+        {
+            var detail = _details.FirstOrDefault(d => d.Id == id);
+            if (detail == null)
+                return NotFound();
+            _details.Remove(detail);
+            return NoContent();
+        }
+    }
+}

--- a/backend/DTOs/CreateRepairDetailDto.cs
+++ b/backend/DTOs/CreateRepairDetailDto.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class CreateRepairDetailDto
+    {
+        public Guid EventId { get; set; }
+        public string? BranchId { get; set; }
+        public string? EmployeeEmail { get; set; }
+        public bool ReplacementVehicleRequired { get; set; }
+        public string? ReplacementVehicleInfo { get; set; }
+        public string? VehicleTabNumber { get; set; }
+        public string? VehicleRegistration { get; set; }
+        public string? DamageDateTime { get; set; }
+        public string? AppraiserWaitingDate { get; set; }
+        public string? RepairStartDate { get; set; }
+        public string? RepairEndDate { get; set; }
+        public bool OtherVehiclesAvailable { get; set; }
+        public string? OtherVehiclesInfo { get; set; }
+        public double BodyworkHours { get; set; }
+        public double PaintingHours { get; set; }
+        public double AssemblyHours { get; set; }
+        public double OtherWorkHours { get; set; }
+        public string? OtherWorkDescription { get; set; }
+        public string? DamageDescription { get; set; }
+        public string? AdditionalDescription { get; set; }
+        public string? Status { get; set; }
+    }
+}

--- a/backend/DTOs/RepairDetailDto.cs
+++ b/backend/DTOs/RepairDetailDto.cs
@@ -1,0 +1,64 @@
+using System;
+using AutomotiveClaimsApi.Models;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class RepairDetailDto
+    {
+        public Guid Id { get; set; }
+        public Guid EventId { get; set; }
+        public string? BranchId { get; set; }
+        public string? EmployeeEmail { get; set; }
+        public bool ReplacementVehicleRequired { get; set; }
+        public string? ReplacementVehicleInfo { get; set; }
+        public string? VehicleTabNumber { get; set; }
+        public string? VehicleRegistration { get; set; }
+        public string? DamageDateTime { get; set; }
+        public string? AppraiserWaitingDate { get; set; }
+        public string? RepairStartDate { get; set; }
+        public string? RepairEndDate { get; set; }
+        public bool OtherVehiclesAvailable { get; set; }
+        public string? OtherVehiclesInfo { get; set; }
+        public double BodyworkHours { get; set; }
+        public double PaintingHours { get; set; }
+        public double AssemblyHours { get; set; }
+        public double OtherWorkHours { get; set; }
+        public string? OtherWorkDescription { get; set; }
+        public string? DamageDescription { get; set; }
+        public string? AdditionalDescription { get; set; }
+        public string? Status { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+
+        public static RepairDetailDto FromModel(RepairDetail detail)
+        {
+            return new RepairDetailDto
+            {
+                Id = detail.Id,
+                EventId = detail.EventId,
+                BranchId = detail.BranchId,
+                EmployeeEmail = detail.EmployeeEmail,
+                ReplacementVehicleRequired = detail.ReplacementVehicleRequired,
+                ReplacementVehicleInfo = detail.ReplacementVehicleInfo,
+                VehicleTabNumber = detail.VehicleTabNumber,
+                VehicleRegistration = detail.VehicleRegistration,
+                DamageDateTime = detail.DamageDateTime,
+                AppraiserWaitingDate = detail.AppraiserWaitingDate,
+                RepairStartDate = detail.RepairStartDate,
+                RepairEndDate = detail.RepairEndDate,
+                OtherVehiclesAvailable = detail.OtherVehiclesAvailable,
+                OtherVehiclesInfo = detail.OtherVehiclesInfo,
+                BodyworkHours = detail.BodyworkHours,
+                PaintingHours = detail.PaintingHours,
+                AssemblyHours = detail.AssemblyHours,
+                OtherWorkHours = detail.OtherWorkHours,
+                OtherWorkDescription = detail.OtherWorkDescription,
+                DamageDescription = detail.DamageDescription,
+                AdditionalDescription = detail.AdditionalDescription,
+                Status = detail.Status,
+                CreatedAt = detail.CreatedAt,
+                UpdatedAt = detail.UpdatedAt
+            };
+        }
+    }
+}

--- a/backend/DTOs/UpdateRepairDetailDto.cs
+++ b/backend/DTOs/UpdateRepairDetailDto.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class UpdateRepairDetailDto
+    {
+        public Guid? EventId { get; set; }
+        public string? BranchId { get; set; }
+        public string? EmployeeEmail { get; set; }
+        public bool? ReplacementVehicleRequired { get; set; }
+        public string? ReplacementVehicleInfo { get; set; }
+        public string? VehicleTabNumber { get; set; }
+        public string? VehicleRegistration { get; set; }
+        public string? DamageDateTime { get; set; }
+        public string? AppraiserWaitingDate { get; set; }
+        public string? RepairStartDate { get; set; }
+        public string? RepairEndDate { get; set; }
+        public bool? OtherVehiclesAvailable { get; set; }
+        public string? OtherVehiclesInfo { get; set; }
+        public double? BodyworkHours { get; set; }
+        public double? PaintingHours { get; set; }
+        public double? AssemblyHours { get; set; }
+        public double? OtherWorkHours { get; set; }
+        public string? OtherWorkDescription { get; set; }
+        public string? DamageDescription { get; set; }
+        public string? AdditionalDescription { get; set; }
+        public string? Status { get; set; }
+    }
+}

--- a/backend/Models/RepairDetail.cs
+++ b/backend/Models/RepairDetail.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class RepairDetail
+    {
+        public Guid Id { get; set; }
+        public Guid EventId { get; set; }
+        public string? BranchId { get; set; }
+        public string? EmployeeEmail { get; set; }
+        public bool ReplacementVehicleRequired { get; set; }
+        public string? ReplacementVehicleInfo { get; set; }
+        public string? VehicleTabNumber { get; set; }
+        public string? VehicleRegistration { get; set; }
+        public string? DamageDateTime { get; set; }
+        public string? AppraiserWaitingDate { get; set; }
+        public string? RepairStartDate { get; set; }
+        public string? RepairEndDate { get; set; }
+        public bool OtherVehiclesAvailable { get; set; }
+        public string? OtherVehiclesInfo { get; set; }
+        public double BodyworkHours { get; set; }
+        public double PaintingHours { get; set; }
+        public double AssemblyHours { get; set; }
+        public double OtherWorkHours { get; set; }
+        public string? OtherWorkDescription { get; set; }
+        public string? DamageDescription { get; set; }
+        public string? AdditionalDescription { get; set; }
+        public string? Status { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/lib/api/repair-details.ts
+++ b/lib/api/repair-details.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  process.env.API_BASE_URL ||
+  "https://claim-work-backend.azurewebsites.net/api";
+
+const repairDetailSchema = z.object({
+  id: z.string(),
+  eventId: z.string(),
+  branchId: z.string().min(1, "Oddział jest wymagany"),
+  employeeEmail: z.string().min(1, "Pracownik jest wymagany"),
+  replacementVehicleRequired: z.boolean(),
+  replacementVehicleInfo: z.string().optional().default(""),
+  vehicleTabNumber: z.string().min(1, "Nr taborowy pojazdu jest wymagany"),
+  vehicleRegistration: z.string().min(1, "Nr rejestracyjny jest wymagany"),
+  damageDateTime: z.string().min(1, "Data i godzina szkody są wymagane"),
+  appraiserWaitingDate: z.string().min(1, "Data oczekiwania na rzeczoznawcę jest wymagana"),
+  repairStartDate: z.string().min(1, "Data przystąpienia do naprawy jest wymagana"),
+  repairEndDate: z.string().min(1, "Data zakończenia naprawy jest wymagana"),
+  otherVehiclesAvailable: z.boolean(),
+  otherVehiclesInfo: z.string().optional().default(""),
+  bodyworkHours: z.number(),
+  paintingHours: z.number(),
+  assemblyHours: z.number(),
+  otherWorkHours: z.number(),
+  otherWorkDescription: z.string().optional().default(""),
+  damageDescription: z.string().optional().default(""),
+  additionalDescription: z.string().optional().default(""),
+  status: z.enum(["draft", "in-progress", "completed"]),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+const repairDetailUpsertSchema = repairDetailSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export type RepairDetail = z.infer<typeof repairDetailSchema>;
+export type RepairDetailUpsert = z.infer<typeof repairDetailUpsertSchema>;
+
+async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${url}`, {
+    headers: { "Content-Type": "application/json" },
+    ...options,
+  });
+  const text = await response.text();
+  const data = text ? JSON.parse(text) : undefined;
+  if (!response.ok) {
+    const message = data?.error || data?.message || text || response.statusText;
+    throw new Error(message);
+  }
+  return data as T;
+}
+
+export async function getRepairDetails(eventId: string): Promise<RepairDetail[]> {
+  const data = await request<unknown>(`/repair-details?eventId=${eventId}`);
+  return z.array(repairDetailSchema).parse(data);
+}
+
+export async function createRepairDetail(detail: RepairDetailUpsert): Promise<RepairDetail> {
+  const body = repairDetailUpsertSchema.parse(detail);
+  const data = await request<unknown>(`/repair-details`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  return repairDetailSchema.parse(data);
+}
+
+export async function updateRepairDetail(id: string, detail: RepairDetailUpsert): Promise<RepairDetail> {
+  const body = repairDetailUpsertSchema.parse(detail);
+  const data = await request<unknown>(`/repair-details/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+  return repairDetailSchema.parse(data);
+}
+
+export async function deleteRepairDetail(id: string): Promise<void> {
+  await request<void>(`/repair-details/${id}`, { method: "DELETE" });
+}
+
+export { repairDetailSchema, repairDetailUpsertSchema };


### PR DESCRIPTION
## Summary
- add C# RepairDetailsController with CRUD endpoints
- create TS client for repair details with Zod validation
- hook repair-details-section to client and show backend errors with toasts

## Testing
- `npm test`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68974055dfb8832ca0b50d715b30718b