### PR TITLE
Fix RepairSchedules API base URL and endpoints

### DIFF
--- a/app/api/repair-schedules/[id]/route.ts
+++ b/app/api/repair-schedules/[id]/route.ts
@@ -1,13 +1,13 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const { id } = params
     console.log(`Fetching repair schedule ${id} from backend`)
 
-    const response = await fetch(`${API_BASE_URL}/repair-schedules/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/RepairSchedules/${id}`, {
       headers: {
         "Content-Type": "application/json",
       },
@@ -40,7 +40,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
     console.log(`Updating repair schedule ${id}:`, body)
 
-    const response = await fetch(`${API_BASE_URL}/repair-schedules/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/RepairSchedules/${id}`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
@@ -67,7 +67,7 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     const { id } = params
     console.log(`Deleting repair schedule ${id}`)
 
-    const response = await fetch(`${API_BASE_URL}/repair-schedules/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/RepairSchedules/${id}`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",

--- a/app/api/repair-schedules/route.ts
+++ b/app/api/repair-schedules/route.ts
@@ -1,13 +1,13 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
     const eventId = searchParams.get("eventId") || searchParams.get("claimId")
 
-    let url = `${API_BASE_URL}/repair-schedules`
+    let url = `${API_BASE_URL}/RepairSchedules`
     if (eventId) {
       url += `?eventId=${eventId}`
     }
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
 
     console.log("Creating new repair schedule:", body)
 
-    const response = await fetch(`${API_BASE_URL}/repair-schedules`, {
+    const response = await fetch(`${API_BASE_URL}/RepairSchedules`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- use `http://localhost:5200/api` as the base URL for repair schedule routes
- call backend `RepairSchedules` controller for all repair schedule CRUD requests

## Testing
- `pnpm test`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68974c77dea0832ca38c944a8b76b96f