### PR TITLE
feat: add active tab state to sidebar

### DIFF
--- a/app/claims/layout.tsx
+++ b/app/claims/layout.tsx
@@ -1,15 +1,18 @@
 'use client'
 
 import type { ReactNode } from 'react'
+import { useState } from 'react'
 import { Header } from '@/components/header'
 import { Sidebar } from '@/components/sidebar'
 
 export default function ClaimsLayout({ children }: { children: ReactNode }) {
+  const [activeTab, setActiveTab] = useState('claims')
+
   return (
     <div className="min-h-screen bg-gray-50">
       <Header onMenuClick={() => {}} />
       <div className="flex">
-        <Sidebar />
+        <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
         <main className="flex-1">
           {children}
         </main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import { GeistSans } from "geist/font/sans"
 import { GeistMono } from "geist/font/mono"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
-import { Sidebar } from "@/components/sidebar"
 import "./globals.css"
 
 export const metadata: Metadata = {
@@ -31,10 +30,7 @@ html {
       </head>
       <body className="min-h-screen bg-gray-50">
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
-          <div className="flex">
-            <Sidebar />
-            <main className="flex-1 ml-16">{children}</main>
-          </div>
+          <main className="flex-1">{children}</main>
           <Toaster />
         </ThemeProvider>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { Header } from "@/components/header"
 import { Sidebar } from "@/components/sidebar"
@@ -23,6 +23,7 @@ interface PageProps {
 
 function HomePage({ user, onLogout }: PageProps) {
   const router = useRouter()
+  const [activeTab, setActiveTab] = useState("dashboard")
 
   useEffect(() => {
     const isAuthenticated = localStorage.getItem('isAuthenticated')

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,9 +1,13 @@
 "use client"
 import Link from "next/link"
-import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { LayoutDashboard, FileText, Car } from "lucide-react"
+
+interface SidebarProps {
+  activeTab: string
+  onTabChange: (tab: string) => void
+}
 
 const menuItems = [
   {
@@ -20,8 +24,7 @@ const menuItems = [
   },
 ]
 
-export function Sidebar() {
-  const pathname = usePathname()
+export function Sidebar(props: SidebarProps) {
   return (
     <div className="fixed left-0 top-0 z-40 h-full w-16 bg-[#1a3a6c] border-r border-[#2a4a7c] flex flex-col">
       {/* Header */}
@@ -33,8 +36,7 @@ export function Sidebar() {
       <nav className="flex-1 p-2 space-y-2">
         {menuItems.map((item) => {
           const Icon = item.icon
-          const isActive =
-            pathname === item.href || pathname.startsWith(item.href + "/")
+          const isActive = props.activeTab === item.id
 
           return (
             <Button
@@ -49,7 +51,10 @@ export function Sidebar() {
               )}
               title={item.label}
             >
-              <Link href={item.href}>
+              <Link
+                href={item.href}
+                onClick={() => props.onTabChange(item.id)}
+              >
                 <Icon className="h-5 w-5" />
               </Link>
             </Button>


### PR DESCRIPTION
## Summary
- manage dashboard tab selection with useState in home page and claims layout
- update Sidebar component to accept activeTab and notify tab changes
- remove unused root Sidebar layout

## Testing
- `npm test` (fails: Cannot find module 'tsconfig-paths/register')
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@hello-pangea%2fdnd)


------
https://chatgpt.com/codex/tasks/task_e_68974b859be8832cb95271f312f75463