### PR TITLE
Route decisions API through Next.js by default

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,9 @@
 # Base URL for backend API, used on the server only
-API_BASE_URL=http://localhost:5200/api
+# API_BASE_URL=http://localhost:5200/api
 
-# Base URL for backend API, exposed to the browser
-NEXT_PUBLIC_API_URL=http://localhost:5200/api
+# Optional override for backend API, exposed to the browser.
+# Leave unset to proxy through Next.js API routes during development.
+# NEXT_PUBLIC_API_URL=https://example.com/api
 
 # Optional: number of times to retry requests to the backend
 # FETCH_RETRY_COUNT=1

--- a/lib/api/decisions.ts
+++ b/lib/api/decisions.ts
@@ -1,9 +1,6 @@
 import { z } from "zod";
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  process.env.API_BASE_URL ||
-  "https://claim-work-backend.azurewebsites.net/api";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "/api";
 
 export const decisionSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
## Summary
- Default decisions API client to use `/api` so development requests hit Next.js API routes
- Note `NEXT_PUBLIC_API_URL` as optional override for production in `.env`

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6897954fc1a0832c8da9fefddf7d0b2f