### PR TITLE
Add settlements API client and UI

### DIFF
--- a/backend/Controllers/SettlementsController.cs
+++ b/backend/Controllers/SettlementsController.cs
@@ -205,6 +205,9 @@ namespace AutomotiveClaimsApi.Controllers
             {
                 Id = s.Id.ToString(),
                 EventId = s.EventId.ToString(),
+                ExternalEntity = s.ExternalEntity,
+                CustomExternalEntity = s.CustomExternalEntity,
+                TransferDate = s.TransferDate,
                 Status = s.Status,
                 SettlementDate = s.SettlementDate,
                 Amount = s.Amount,

--- a/backend/DTOs/SettlementDto.cs
+++ b/backend/DTOs/SettlementDto.cs
@@ -4,6 +4,9 @@ namespace AutomotiveClaimsApi.DTOs
     {
         public string Id { get; set; } = string.Empty;
         public string EventId { get; set; } = string.Empty;
+        public string? ExternalEntity { get; set; }
+        public string? CustomExternalEntity { get; set; }
+        public DateTime? TransferDate { get; set; }
         public string? Status { get; set; }
         public DateTime? SettlementDate { get; set; }
         public decimal? Amount { get; set; }

--- a/components/settlements-section.tsx
+++ b/components/settlements-section.tsx
@@ -1,0 +1,210 @@
+"use client"
+
+import { useEffect, useState, type FormEvent } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { useToast } from "@/hooks/use-toast"
+import {
+  getSettlements,
+  createSettlement,
+  updateSettlement,
+  deleteSettlement,
+  settlementUpsertSchema,
+  type Settlement,
+} from "@/lib/api/settlements"
+
+interface SettlementsSectionProps {
+  eventId: string
+}
+
+export function SettlementsSection({ eventId }: SettlementsSectionProps) {
+  const { toast } = useToast()
+  const [settlements, setSettlements] = useState<Settlement[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isFormVisible, setIsFormVisible] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+
+  const getInitialForm = () => ({
+    externalEntity: "",
+    transferDate: "",
+    settlementDate: "",
+    settlementAmount: 0,
+    currency: "PLN",
+    status: "",
+  })
+
+  const [formData, setFormData] = useState(getInitialForm())
+
+  useEffect(() => {
+    fetchSettlements()
+  }, [eventId])
+
+  async function fetchSettlements() {
+    try {
+      setIsLoading(true)
+      const data = await getSettlements(eventId)
+      setSettlements(data)
+    } catch (error) {
+      toast({
+        title: "Błąd",
+        description: error instanceof Error ? error.message : "Nie udało się pobrać rozliczeń",
+        variant: "destructive",
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  function resetForm() {
+    setFormData(getInitialForm())
+    setEditingId(null)
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    const validation = settlementUpsertSchema.safeParse({ ...formData, eventId })
+    if (!validation.success) {
+      toast({
+        title: "Błąd",
+        description: validation.error.errors.map((err) => err.message).join(", "),
+        variant: "destructive",
+      })
+      return
+    }
+    try {
+      if (editingId) {
+        await updateSettlement(editingId, { ...formData, eventId })
+        toast({ title: "Sukces", description: "Rozliczenie zaktualizowane" })
+      } else {
+        await createSettlement({ ...formData, eventId })
+        toast({ title: "Sukces", description: "Rozliczenie dodane" })
+      }
+      resetForm()
+      setIsFormVisible(false)
+      fetchSettlements()
+    } catch (error) {
+      toast({
+        title: "Błąd",
+        description: error instanceof Error ? error.message : "Nie udało się zapisać rozliczenia",
+        variant: "destructive",
+      })
+    }
+  }
+
+  function handleEdit(settlement: Settlement) {
+    setFormData({
+      externalEntity: settlement.externalEntity ?? "",
+      transferDate: settlement.transferDate?.slice(0, 10) ?? "",
+      settlementDate: settlement.settlementDate?.slice(0, 10) ?? "",
+      settlementAmount: settlement.settlementAmount ?? 0,
+      currency: settlement.currency ?? "PLN",
+      status: settlement.status ?? "",
+    })
+    setEditingId(settlement.id)
+    setIsFormVisible(true)
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm("Czy na pewno chcesz usunąć to rozliczenie?")) return
+    try {
+      await deleteSettlement(id)
+      toast({ title: "Sukces", description: "Rozliczenie usunięte" })
+      fetchSettlements()
+    } catch (error) {
+      toast({
+        title: "Błąd",
+        description: error instanceof Error ? error.message : "Nie udało się usunąć rozliczenia",
+        variant: "destructive",
+      })
+    }
+  }
+
+  if (isLoading) {
+    return <p>Ładowanie...</p>
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Rozliczenia</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {settlements.map((s) => (
+          <div key={s.id} className="mb-4 flex items-center justify-between">
+            <div>
+              <p className="font-medium">{s.externalEntity || "Brak kontrahenta"}</p>
+              <p className="text-sm text-muted-foreground">
+                {s.settlementAmount ?? 0} {s.currency || "PLN"}
+              </p>
+            </div>
+            <div className="space-x-2">
+              <Button variant="outline" size="sm" onClick={() => handleEdit(s)}>
+                Edytuj
+              </Button>
+              <Button variant="destructive" size="sm" onClick={() => handleDelete(s.id)}>
+                Usuń
+              </Button>
+            </div>
+          </div>
+        ))}
+
+        {isFormVisible ? (
+          <form onSubmit={handleSubmit} className="space-y-2">
+            <Input
+              placeholder="Podmiot zewnętrzny"
+              value={formData.externalEntity}
+              onChange={(e) => setFormData({ ...formData, externalEntity: e.target.value })}
+            />
+            <Input
+              type="date"
+              value={formData.transferDate}
+              onChange={(e) => setFormData({ ...formData, transferDate: e.target.value })}
+            />
+            <Input
+              type="date"
+              value={formData.settlementDate}
+              onChange={(e) => setFormData({ ...formData, settlementDate: e.target.value })}
+            />
+            <Input
+              type="number"
+              step="0.01"
+              placeholder="Kwota"
+              value={formData.settlementAmount}
+              onChange={(e) =>
+                setFormData({ ...formData, settlementAmount: parseFloat(e.target.value) || 0 })
+              }
+            />
+            <Input
+              placeholder="Waluta"
+              value={formData.currency}
+              onChange={(e) => setFormData({ ...formData, currency: e.target.value })}
+            />
+            <Input
+              placeholder="Status"
+              value={formData.status}
+              onChange={(e) => setFormData({ ...formData, status: e.target.value })}
+            />
+            <div className="space-x-2">
+              <Button type="submit">Zapisz</Button>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => {
+                  resetForm()
+                  setIsFormVisible(false)
+                }}
+              >
+                Anuluj
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <Button onClick={() => setIsFormVisible(true)}>Dodaj rozliczenie</Button>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export default SettlementsSection

--- a/lib/api/settlements.ts
+++ b/lib/api/settlements.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  process.env.API_BASE_URL ||
+  "https://claim-work-backend.azurewebsites.net/api";
+
+const settlementSchema = z.object({
+  id: z.string(),
+  eventId: z.string(),
+  externalEntity: z.string().nullish(),
+  transferDate: z.string().nullish(),
+  settlementDate: z.string().nullish(),
+  settlementAmount: z.number().nullish(),
+  currency: z.string().nullish(),
+  status: z.string().optional(),
+});
+
+const settlementUpsertSchema = z.object({
+  eventId: z.string(),
+  externalEntity: z.string().optional(),
+  transferDate: z.string().optional(),
+  settlementDate: z.string().optional(),
+  settlementAmount: z.number().optional(),
+  currency: z.string().optional(),
+  status: z.string().min(1),
+});
+
+export type Settlement = z.infer<typeof settlementSchema>;
+export type SettlementUpsert = z.infer<typeof settlementUpsertSchema>;
+
+async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${url}`, {
+    headers: { "Content-Type": "application/json" },
+    ...options,
+  });
+  const text = await response.text();
+  const data = text ? JSON.parse(text) : undefined;
+  if (!response.ok) {
+    const message = (data?.error || data?.message || text || response.statusText) as string;
+    throw new Error(message);
+  }
+  return data as T;
+}
+
+export async function getSettlements(eventId: string): Promise<Settlement[]> {
+  const data = await request<unknown>(`/settlements/event/${eventId}`);
+  return z.array(settlementSchema).parse(data);
+}
+
+export async function createSettlement(input: SettlementUpsert): Promise<Settlement> {
+  const body = settlementUpsertSchema.parse(input);
+  const data = await request<unknown>(`/settlements`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  return settlementSchema.parse(data);
+}
+
+export async function updateSettlement(id: string, input: SettlementUpsert): Promise<Settlement> {
+  const body = settlementUpsertSchema.parse(input);
+  const data = await request<unknown>(`/settlements/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+  return settlementSchema.parse(data);
+}
+
+export async function deleteSettlement(id: string): Promise<void> {
+  await request<void>(`/settlements/${id}`, { method: "DELETE" });
+}
+
+export { settlementSchema, settlementUpsertSchema };


### PR DESCRIPTION
## Summary
- expose additional settlement fields in backend DTO and mapping
- add settlements API client and React section for CRUD operations

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Command failed with exit code 1; interactive prompt)*
- `dotnet build backend/AutomotiveClaimsApi.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975aa7035c832c90edf2857b92eb3e