### PR TITLE
feat: add appeals api client and integrate form

### DIFF
--- a/app/api/appeals/route.ts
+++ b/app/api/appeals/route.ts
@@ -5,7 +5,7 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
-    const eventId = searchParams.get("eventId")
+    const eventId = searchParams.get("eventId") || searchParams.get("claimId")
 
     if (!eventId) {
       return NextResponse.json({ error: "eventId is required" }, { status: 400 })
@@ -40,6 +40,8 @@ export async function POST(request: NextRequest) {
         if (!backendFormData.has("Document")) {
           backendFormData.append("Document", value)
         }
+      } else if (key === "claimId" && typeof value === "string") {
+        backendFormData.append("EventId", value)
       } else if (typeof value === "string") {
         backendFormData.append(key, value)
       }

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -2062,7 +2062,7 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
               <CardTitle className="text-lg font-semibold">Odwołanie/Reklamacja</CardTitle>
             </CardHeader>
             <CardContent className="p-0 bg-white">
-              {eventId && <AppealsSection eventId={eventId} />}
+              {eventId && <AppealsSection claimId={eventId} />}
             </CardContent>
           </Card>
         </div>


### PR DESCRIPTION
## Summary
- add typed appeals API client with CRUD helpers
- validate appeal dates and switch form to use new client with claimId
- allow claimId passthrough in appeals API route

## Testing
- `npm test` *(fails: Cannot find module 'tsconfig-paths/register')*


------
https://chatgpt.com/codex/tasks/task_e_68975a990530832c9e7189d3e2e92364