### PR TITLE
Allow null document fields in decision schema

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -277,9 +277,9 @@ export interface DecisionDto {
   amount?: number
   currency?: string
   compensationTitle?: string
-  documentDescription?: string
-  documentName?: string
-  documentPath?: string
+  documentDescription?: string | null
+  documentName?: string | null
+  documentPath?: string | null
 }
 
 export interface AppealDto {

--- a/lib/api/decisions.ts
+++ b/lib/api/decisions.ts
@@ -10,9 +10,9 @@ export const decisionSchema = z.object({
   amount: z.number().nullable().optional(),
   currency: z.string().optional(),
   compensationTitle: z.string().optional(),
-  documentDescription: z.string().optional(),
-  documentName: z.string().optional(),
-  documentPath: z.string().optional(),
+  documentDescription: z.string().nullish(),
+  documentName: z.string().nullish(),
+  documentPath: z.string().nullish(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -134,9 +134,9 @@ export interface Decision {
   amount?: number
   currency?: string
   compensationTitle?: string
-  documentDescription?: string
-  documentName?: string
-  documentPath?: string
+  documentDescription?: string | null
+  documentName?: string | null
+  documentPath?: string | null
 }
 
 export interface Appeal {


### PR DESCRIPTION
## Summary
- permit null values for decision documentDescription, documentName, and documentPath
- update Decision and DecisionDto types to include null document fields

## Testing
- `pnpm test`
- `node -e "require('ts-node/register'); const { decisionSchema } = require('./lib/api/decisions'); console.log(decisionSchema.parse({id:'1',eventId:'e1',decisionDate:'2024-01-01',createdAt:'2024',updatedAt:'2024',documentDescription:null,documentName:null,documentPath:null}));"`
- `pnpm lint` *(fails: Next.js requested interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6897a79fd000832cb4616bbbe8bc1070