### PR TITLE
Switch settlement APIs to FormData bodies

### DIFF
--- a/components/settlements-section.tsx
+++ b/components/settlements-section.tsx
@@ -73,11 +73,21 @@ export function SettlementsSection({ eventId }: SettlementsSectionProps) {
       return
     }
     try {
+      const data = validation.data
+      const payload = new FormData()
+      payload.append("eventId", data.eventId)
+      if (data.externalEntity) payload.append("externalEntity", data.externalEntity)
+      if (data.transferDate) payload.append("transferDate", data.transferDate)
+      if (data.settlementDate) payload.append("settlementDate", data.settlementDate)
+      if (data.settlementAmount !== undefined)
+        payload.append("settlementAmount", data.settlementAmount.toString())
+      if (data.currency) payload.append("currency", data.currency)
+      payload.append("status", data.status)
       if (editingId) {
-        await updateSettlement(editingId, { ...formData, eventId })
+        await updateSettlement(editingId, payload)
         toast({ title: "Sukces", description: "Rozliczenie zaktualizowane" })
       } else {
-        await createSettlement({ ...formData, eventId })
+        await createSettlement(payload)
         toast({ title: "Sukces", description: "Rozliczenie dodane" })
       }
       resetForm()

--- a/lib/api/settlements.ts
+++ b/lib/api/settlements.ts
@@ -30,10 +30,7 @@ export type Settlement = z.infer<typeof settlementSchema>;
 export type SettlementUpsert = z.infer<typeof settlementUpsertSchema>;
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
-    headers: { "Content-Type": "application/json" },
-    ...options,
-  });
+  const response = await fetch(`${API_BASE_URL}${url}`, options);
   const text = await response.text();
   const data = text ? JSON.parse(text) : undefined;
   if (!response.ok) {
@@ -48,20 +45,21 @@ export async function getSettlements(eventId: string): Promise<Settlement[]> {
   return z.array(settlementSchema).parse(data);
 }
 
-export async function createSettlement(input: SettlementUpsert): Promise<Settlement> {
-  const body = settlementUpsertSchema.parse(input);
+export async function createSettlement(form: FormData): Promise<Settlement> {
   const data = await request<unknown>(`/settlements`, {
     method: "POST",
-    body: JSON.stringify(body),
+    body: form,
   });
   return settlementSchema.parse(data);
 }
 
-export async function updateSettlement(id: string, input: SettlementUpsert): Promise<Settlement> {
-  const body = settlementUpsertSchema.parse(input);
+export async function updateSettlement(
+  id: string,
+  form: FormData,
+): Promise<Settlement> {
   const data = await request<unknown>(`/settlements/${id}`, {
     method: "PUT",
-    body: JSON.stringify(body),
+    body: form,
   });
   return settlementSchema.parse(data);
 }


### PR DESCRIPTION
## Summary
- Use FormData in settlement API client and drop JSON content-type header
- Pass FormData from SettlementsSection when creating or updating settlements

## Testing
- `pnpm lint` *(fails: prompts for ESLint config)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6897adba568c832caa3591bea0955a58