### PR TITLE
feat(claims): validate settlement ids

### DIFF
--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -47,3 +47,17 @@ test('includes id field when provided', () => {
   const payload = transformFrontendClaimToApiPayload({ id: 'abc' } as any)
   assert.equal(payload.id, 'abc')
 })
+
+test('settlement ids are validated as GUIDs', () => {
+  const validId = '123e4567-e89b-12d3-a456-426614174000'
+  const payload = transformFrontendClaimToApiPayload({
+    settlements: [
+      { id: validId, settlementDate: '2024-01-01' },
+      { id: 'not-a-guid', settlementDate: '2024-01-01' },
+    ],
+  } as any)
+
+  const [valid, invalid] = (payload as any).settlements || []
+  assert.equal(valid?.id, validId)
+  assert.equal(invalid?.id, undefined)
+})

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -179,10 +179,28 @@ export const transformFrontendClaimToApiPayload = (
       ...r,
       recourseDate: r.recourseDate ? new Date(r.recourseDate).toISOString() : undefined,
     })),
-    settlements: settlements?.map((s) => ({
-      ...s,
-      settlementDate: s.settlementDate ? new Date(s.settlementDate).toISOString() : undefined,
-    })),
+    // Settlements may be managed through dedicated endpoints. When included
+    // in the claim payload, ensure IDs are valid GUID strings; otherwise omit
+    // them to prevent backend validation errors.
+    ...(settlements && settlements.length > 0
+      ? {
+          settlements: settlements.map((s) => {
+            const { id, settlementDate, ...rest } = s
+
+            const isGuid =
+              typeof id === "string" &&
+              /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id)
+
+            return {
+              ...rest,
+              ...(isGuid ? { id } : {}),
+              settlementDate: settlementDate
+                ? new Date(settlementDate).toISOString()
+                : undefined,
+            }
+          }),
+        }
+      : {}),
 
   }
 }


### PR DESCRIPTION
## Summary
- validate settlement IDs as GUIDs before adding to claim payload
- add tests for settlement ID mapping

## Testing
- `TS_NODE_TRANSPILE_ONLY=1 node --test -r ts-node/register -r tsconfig-paths/register hooks/__tests__/use-claims.test.ts` (fails: Unknown file extension ".ts")

------
https://chatgpt.com/codex/tasks/task_e_6897ad05e0ac832c9668183c8c483abe