### PR TITLE
Use FormData for settlement requests

### DIFF
--- a/components/settlements-section.tsx
+++ b/components/settlements-section.tsx
@@ -72,12 +72,18 @@ export function SettlementsSection({ eventId }: SettlementsSectionProps) {
       })
       return
     }
+    const body = new FormData()
+    Object.entries(validation.data).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        body.append(key, value.toString())
+      }
+    })
     try {
       if (editingId) {
-        await updateSettlement(editingId, { ...formData, eventId })
+        await updateSettlement(editingId, body)
         toast({ title: "Sukces", description: "Rozliczenie zaktualizowane" })
       } else {
-        await createSettlement({ ...formData, eventId })
+        await createSettlement(body)
         toast({ title: "Sukces", description: "Rozliczenie dodane" })
       }
       resetForm()

--- a/lib/api/settlements.ts
+++ b/lib/api/settlements.ts
@@ -30,10 +30,7 @@ export type Settlement = z.infer<typeof settlementSchema>;
 export type SettlementUpsert = z.infer<typeof settlementUpsertSchema>;
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
-    headers: { "Content-Type": "application/json" },
-    ...options,
-  });
+  const response = await fetch(`${API_BASE_URL}${url}`, options);
   const text = await response.text();
   const data = text ? JSON.parse(text) : undefined;
   if (!response.ok) {
@@ -48,20 +45,18 @@ export async function getSettlements(eventId: string): Promise<Settlement[]> {
   return z.array(settlementSchema).parse(data);
 }
 
-export async function createSettlement(input: SettlementUpsert): Promise<Settlement> {
-  const body = settlementUpsertSchema.parse(input);
+export async function createSettlement(body: FormData): Promise<Settlement> {
   const data = await request<unknown>(`/settlements`, {
     method: "POST",
-    body: JSON.stringify(body),
+    body,
   });
   return settlementSchema.parse(data);
 }
 
-export async function updateSettlement(id: string, input: SettlementUpsert): Promise<Settlement> {
-  const body = settlementUpsertSchema.parse(input);
+export async function updateSettlement(id: string, body: FormData): Promise<Settlement> {
   const data = await request<unknown>(`/settlements/${id}`, {
     method: "PUT",
-    body: JSON.stringify(body),
+    body,
   });
   return settlementSchema.parse(data);
 }


### PR DESCRIPTION
## Summary
- use `FormData` for creating and updating settlements in API client
- build `FormData` in settlements section and send to API

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6897ad052848832cbd1cc5b66efb3e2f