### PR TITLE
Avoid clearing decisions when updating claims

### DIFF
--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -85,3 +85,8 @@ test('settlement ids are validated as GUIDs', () => {
   assert.equal(valid?.id, validId)
   assert.equal(invalid?.id, undefined)
 })
+
+test('omits decisions when none are provided', () => {
+  const payload = transformFrontendClaimToApiPayload({ decisions: [] } as any)
+  assert.ok(!('decisions' in payload))
+})

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -168,10 +168,16 @@ export const transformFrontendClaimToApiPayload = (
       description: d.description,
       detail: d.detail,
     })),
-    decisions: decisions?.map((d) => ({
-      ...d,
-      decisionDate: d.decisionDate ? new Date(d.decisionDate).toISOString() : undefined,
-    })),
+    ...(Array.isArray(decisions) && decisions.length > 0
+      ? {
+          decisions: decisions.map((d) => ({
+            ...d,
+            decisionDate: d.decisionDate
+              ? new Date(d.decisionDate).toISOString()
+              : undefined,
+          })),
+        }
+      : {}),
     appeals: appeals?.map((a) => ({
       ...a,
       appealDate: a.appealDate ? new Date(a.appealDate).toISOString() : undefined,


### PR DESCRIPTION
## Summary
- Don't include `decisions` in claim payload when the array is empty
- Add test confirming empty decisions are omitted from payload

## Testing
- `npm test`
- `npm test hooks/__tests__/use-claims.test.ts` *(fails: Cannot require() ES Module in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_6897bac8b088832cb86afdde69161bc4