### PR TITLE
feat: sync decisions with claim form

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -2045,7 +2045,7 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
               <CardTitle className="text-lg font-semibold">Decyzje</CardTitle>
             </CardHeader>
             <CardContent className="p-0 bg-white">
-              <DecisionsSection claimId={claimFormData.id} />
+              <DecisionsSection claimId={claimFormData.id} onChange={handleDecisionsChange} />
             </CardContent>
           </Card>
         </div>

--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -31,10 +31,11 @@ import {
 } from "@/components/ui/alert-dialog"
 
 interface DecisionsSectionProps {
-  claimId: string
+  claimId?: string
+  onChange?: (decisions: Decision[]) => void
 }
 
-export function DecisionsSection({ claimId }: DecisionsSectionProps) {
+export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
   const [decisions, setDecisions] = useState<Decision[]>([])
   const [isFormVisible, setIsFormVisible] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
@@ -90,6 +91,7 @@ export function DecisionsSection({ claimId }: DecisionsSectionProps) {
     try {
       const data = await apiGetDecisions(claimId)
       setDecisions(data)
+      onChange?.(data)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       console.error("Error loading decisions:", message)


### PR DESCRIPTION
## Summary
- allow DecisionsSection to notify parent components when decisions change
- wire ClaimMainContent to keep claim form decisions in sync

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6897bac5f168832cb2ab55f6f8635039