### PR TITLE
Map appeal form fields to backend naming

### DIFF
--- a/app/api/appeals/__tests__/route.test.js
+++ b/app/api/appeals/__tests__/route.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+// Test to ensure formData fields are mapped to backend naming
+
+test('maps appeal form data to backend casing', async () => {
+  const { POST } = await import('../route')
+  const fd = new FormData()
+  fd.append('claimId', '123')
+  fd.append('filingDate', '2024-01-01')
+  fd.append('responseDate', '2024-02-02')
+  fd.append('status', 'Pending')
+  fd.append('documentDescription', 'Desc')
+  fd.append('extensionDate', '2024-03-03')
+  const file = new File(['hello'], 'test.txt', { type: 'text/plain' })
+  fd.append('documents', file)
+
+  let sentBody
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async (_url, init) => {
+    sentBody = init && init.body
+    return new Response('{}', { status: 200 })
+  }
+
+  await POST(new Request('http://localhost/api/appeals', { method: 'POST', body: fd }))
+
+  globalThis.fetch = originalFetch
+
+  assert.ok(sentBody)
+  assert.equal(sentBody.get('EventId'), '123')
+  assert.equal(sentBody.get('FilingDate'), '2024-01-01')
+  assert.equal(sentBody.get('DecisionDate'), '2024-02-02')
+  assert.equal(sentBody.get('Status'), 'Pending')
+  assert.equal(sentBody.get('DocumentDescription'), 'Desc')
+  assert.equal(sentBody.get('ExtensionDate'), '2024-03-03')
+  assert.ok(sentBody.get('Document') instanceof File)
+  assert.equal(sentBody.get('filingDate'), null)
+})

--- a/app/api/appeals/route.ts
+++ b/app/api/appeals/route.ts
@@ -35,15 +35,25 @@ export async function POST(request: NextRequest) {
     const formData = await request.formData()
     const backendFormData = new FormData()
 
+    const fieldMap: Record<string, string> = {
+      claimId: "EventId",
+      filingDate: "FilingDate",
+      responseDate: "DecisionDate",
+      status: "Status",
+      documentDescription: "DocumentDescription",
+    }
+
+    const toBackendKey = (key: string) => {
+      return fieldMap[key] || `${key.charAt(0).toUpperCase()}${key.slice(1)}`
+    }
+
     formData.forEach((value, key) => {
       if (key === "documents" && value instanceof File) {
         if (!backendFormData.has("Document")) {
           backendFormData.append("Document", value)
         }
-      } else if (key === "claimId" && typeof value === "string") {
-        backendFormData.append("EventId", value)
       } else if (typeof value === "string") {
-        backendFormData.append(key, value)
+        backendFormData.append(toBackendKey(key), value)
       }
     })
 


### PR DESCRIPTION
## Summary
- Normalize appeal POST route field names to backend casing and include mappings for filing/decision dates, status, and document details
- Add unit test verifying form data is converted to backend naming conventions

## Testing
- `npm test -- app/api/appeals/__tests__/route.test.js` *(fails: Cannot find package 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_6897c06a20d0832c8751e43f1ec9da04