### PR TITLE
Adjust layout for sidebar width

### DIFF
--- a/app/claims/layout.tsx
+++ b/app/claims/layout.tsx
@@ -10,9 +10,9 @@ export default function ClaimsLayout({ children }: { children: ReactNode }) {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header onMenuClick={() => {}} />
-      <div className="flex">
-        <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+      <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+      <div className="ml-16 flex flex-col min-h-screen">
+        <Header onMenuClick={() => {}} />
         <main className="flex-1">
           {children}
         </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -115,10 +115,9 @@ function HomePage({ user, onLogout }: PageProps) {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Header onMenuClick={() => {}} user={user} onLogout={onLogout} />
-      <div className="flex">
-
-        <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+      <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+      <div className="ml-16 flex flex-col min-h-screen">
+        <Header onMenuClick={() => {}} user={user} onLogout={onLogout} />
         <main className="flex-1 p-0">
           <div className="w-full">
 


### PR DESCRIPTION
## Summary
- Offset main content by sidebar width so lists span full page

## Testing
- `pnpm lint` *(fails: next: not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*

------
https://chatgpt.com/codex/tasks/task_e_6898ca900940832c95f1622ca15142a1