### PR TITLE
Fix appeal mapping and add tests

### DIFF
--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -90,3 +90,35 @@ test('omits decisions when none are provided', () => {
   const payload = transformFrontendClaimToApiPayload({ decisions: [] } as any)
   assert.ok(!('decisions' in payload))
 })
+
+test('maps appeals to upsert DTO structure', () => {
+  const payload = transformFrontendClaimToApiPayload({
+    appeals: [
+      {
+        id: '1',
+        eventId: '2',
+        submissionDate: '2024-01-02',
+        extensionDate: '2024-01-05',
+        decisionDate: '2024-01-10',
+        reason: 'Late payment',
+        status: 'Open',
+        notes: 'note',
+        description: 'desc',
+        appealAmount: 5000,
+        decisionReason: 'reason',
+        documentPath: '/path',
+        documentName: 'file.pdf',
+        documentDescription: 'doc',
+      },
+    ],
+  } as any)
+
+  const appeal = payload.appeals?.[0] as any
+  assert.equal(
+    appeal.submissionDate,
+    new Date('2024-01-02').toISOString(),
+  )
+  assert.equal(appeal.appealAmount, 5000)
+  assert.equal(appeal.reason, 'Late payment')
+  assert.ok(!('appealDate' in appeal))
+})

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -178,10 +178,47 @@ export const transformFrontendClaimToApiPayload = (
           })),
         }
       : {}),
-    appeals: appeals?.map((a) => ({
-      ...a,
-      appealDate: a.appealDate ? new Date(a.appealDate).toISOString() : undefined,
-    })),
+    appeals: appeals?.map(
+      ({
+        id,
+        eventId,
+        appealNumber,
+        submissionDate,
+        extensionDate,
+        reason,
+        status,
+        notes,
+        description,
+        appealAmount,
+        decisionDate,
+        decisionReason,
+        documentPath,
+        documentName,
+        documentDescription,
+      }) => ({
+        ...(id ? { id } : {}),
+        ...(eventId ? { eventId } : {}),
+        ...(appealNumber ? { appealNumber } : {}),
+        submissionDate: submissionDate
+          ? new Date(submissionDate).toISOString()
+          : undefined,
+        extensionDate: extensionDate
+          ? new Date(extensionDate).toISOString()
+          : undefined,
+        reason,
+        status,
+        notes,
+        description,
+        appealAmount,
+        decisionDate: decisionDate
+          ? new Date(decisionDate).toISOString()
+          : undefined,
+        decisionReason,
+        documentPath,
+        documentName,
+        documentDescription,
+      }),
+    ),
     clientClaims: clientClaims?.map((c) => ({
       ...c,
       claimDate: c.claimDate ? new Date(c.claimDate).toISOString() : undefined,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -303,6 +303,7 @@ export interface AppealDto {
 }
 
 export interface AppealUpsertDto {
+  id?: string
   eventId?: string
   appealNumber?: string
   submissionDate?: string

--- a/types/index.ts
+++ b/types/index.ts
@@ -142,11 +142,19 @@ export interface Decision {
 export interface Appeal {
   id?: string
   eventId?: string
-  appealDate: string
-  appealType: string
-  description: string
+  appealNumber?: string
+  submissionDate?: string
+  extensionDate?: string
+  decisionDate?: string
+  reason?: string
   status?: string
-  amount?: number
+  notes?: string
+  description?: string
+  appealAmount?: number
+  decisionReason?: string
+  documentPath?: string
+  documentName?: string
+  documentDescription?: string
 }
 
 export interface ClientClaim {


### PR DESCRIPTION
## Summary
- map appeal fields to backend's `AppealUpsertDto`, converting dates to ISO strings
- align appeal-related types and interfaces with backend schema
- add unit test verifying appeal persistence in claim payload transformation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897c8f8e0c8832ca5d0647cda15ae51