### PR TITLE
Add rowversion concurrency column to Events

### DIFF
--- a/backend/Migrations/20240130000014_AddRowVersionToEvents.cs
+++ b/backend/Migrations/20240130000014_AddRowVersionToEvents.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRowVersionToEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "Events",
+                type: "rowversion",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: new byte[0]);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "Events");
+        }
+    }
+}
+

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -708,6 +708,10 @@ namespace AutomotiveClaimsApi.Migrations
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
 
+                    b.Property<byte[]>("RowVersion")
+                        .IsRowVersion()
+                        .HasColumnType("rowversion");
+
                     b.Property<decimal?>("TotalClaim")
                         .HasColumnType("decimal(18,2)");
 


### PR DESCRIPTION
## Summary
- add EF Core migration to add `RowVersion` column to `Events`
- update model snapshot for `RowVersion` concurrency token

## Testing
- `dotnet ef database update` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6898ea0d7658832c81a5286faddfdbb6