### PR TITLE
Fix duplicate event tracking in CreateClaim

### DIFF
--- a/backend/AutomotiveClaimsApi.Tests/ClaimsControllerTests.cs
+++ b/backend/AutomotiveClaimsApi.Tests/ClaimsControllerTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using AutomotiveClaimsApi.Controllers;
+using AutomotiveClaimsApi.Data;
+using AutomotiveClaimsApi.Models;
+using AutomotiveClaimsApi.DTOs;
+
+namespace AutomotiveClaimsApi.Tests
+{
+    public class ClaimsControllerTests
+    {
+        [Fact]
+        public async Task CreateClaim_WithExistingId_UpdatesEntityInsteadOfInserting()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            await using var context = new ApplicationDbContext(options);
+            var existing = new Event
+            {
+                Id = Guid.NewGuid(),
+                Status = "Initial",
+                CreatedAt = DateTime.UtcNow.AddMinutes(-10),
+                UpdatedAt = DateTime.UtcNow.AddMinutes(-10)
+            };
+            context.Events.Add(existing);
+            await context.SaveChangesAsync();
+
+            var oldUpdatedAt = existing.UpdatedAt;
+            var controller = new ClaimsController(context, NullLogger<ClaimsController>.Instance);
+            var dto = new ClaimUpsertDto { Id = existing.Id };
+
+            await controller.CreateClaim(dto);
+
+            var events = await context.Events.ToListAsync();
+            Assert.Single(events);
+            Assert.True(events[0].UpdatedAt > oldUpdatedAt);
+        }
+    }
+}
+

--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -209,7 +209,10 @@ namespace AutomotiveClaimsApi.Controllers
 
                 eventEntity.SpartaNumber = await GenerateNextSpartaNumber();
 
-                _context.Events.Add(eventEntity);
+                if (_context.Entry(eventEntity).State == EntityState.Detached)
+                {
+                    _context.Events.Add(eventEntity);
+                }
 
 
                 if (eventDto.Documents != null && eventDto.Documents.Any())


### PR DESCRIPTION
## Summary
- Prevent `CreateClaim` from re-adding already tracked events
- Add test ensuring existing claim updates rather than inserts

## Testing
- `dotnet test backend/AutomotiveClaimsApi.Tests/AutomotiveClaimsApi.Tests.csproj` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898ea0b8d28832ca44b64d92d939018