### PR TITLE
Handle concurrent claim update conflicts

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -164,20 +164,16 @@ export default function ClaimPage() {
         }
       } else if (mode === "edit" && claimId) {
         const updatedClaim = await updateClaim(claimId, claimFormData)
-        if (updatedClaim) {
-          toast({
-            title: "Szkoda zaktualizowana",
-            description: `Szkoda ${updatedClaim.spartaNumber || updatedClaim.claimNumber} została pomyślnie zaktualizowana.`,
-          })
+        toast({
+          title: "Szkoda zaktualizowana",
+          description: `Szkoda ${updatedClaim.spartaNumber || updatedClaim.claimNumber} została pomyślnie zaktualizowana.`,
+        })
 
-          if (exitAfterSave) {
-            router.push("/")
-          } else {
-            // Refresh the data
-            await loadClaimData()
-          }
+        if (exitAfterSave) {
+          router.push("/")
         } else {
-          throw new Error("Nie udało się zaktualizować szkody")
+          // Refresh the data
+          await loadClaimData()
         }
       }
     } catch (error) {

--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -145,17 +145,13 @@ export default function EditClaimPage() {
     setIsSaving(true)
     try {
       const updatedClaim = await updateClaim(id, claimFormData)
-      if (updatedClaim) {
-        toast({
-          title: "Szkoda zaktualizowana",
-          description: `Szkoda ${updatedClaim.spartaNumber || updatedClaim.claimNumber} została pomyślnie zaktualizowana.`,
-        })
+      toast({
+        title: "Szkoda zaktualizowana",
+        description: `Szkoda ${updatedClaim.spartaNumber || updatedClaim.claimNumber} została pomyślnie zaktualizowana.`,
+      })
 
-        if (exitAfterSave) {
-          router.push("/")
-        }
-      } else {
-        throw new Error("Nie udało się zaktualizować szkody")
+      if (exitAfterSave) {
+        router.push("/")
       }
     } catch (error) {
       console.error("Error updating claim:", error)

--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -13,6 +13,7 @@ import { DocumentsSection } from '../documents-section'
 import { useClaims } from '@/hooks/use-claims'
 import { useDamages } from '@/hooks/use-damages'
 import { useRouter } from 'next/navigation'
+import { useToast } from '@/hooks/use-toast'
 import type { Claim, ParticipantInfo, UploadedFile, RequiredDocument } from '@/types'
 
 interface ClaimFormProps {
@@ -23,6 +24,7 @@ interface ClaimFormProps {
 export function ClaimForm({ initialData, mode }: ClaimFormProps) {
   const router = useRouter()
   const { createClaim, updateClaim, initializeClaim, loading, error } = useClaims()
+  const { toast } = useToast()
   const initialized = useRef(false)
   const [formData, setFormData] = useState<Claim>({
     spartaNumber: '',
@@ -175,6 +177,11 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
       }
     } catch (err) {
       console.error('Error submitting form:', err)
+      toast({
+        title: 'Błąd',
+        description: err instanceof Error ? err.message : 'Wystąpił błąd podczas zapisywania szkody.',
+        variant: 'destructive',
+      })
     }
   }
 


### PR DESCRIPTION
## Summary
- detect HTTP 409 conflicts when updating a claim and surface a friendly message
- show conflict messages in claim editing pages and reusable claim form

## Testing
- `pnpm lint` (fails: How would you like to configure ESLint?)
- `pnpm test` (fails: Cannot find module '/workspace/claimWork/app/api/appeals/route')

------
https://chatgpt.com/codex/tasks/task_e_6898f07be1d4832cbad1bc62d81d3090