### PR TITLE
Preserve claim row version across transforms

### DIFF
--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -146,6 +146,7 @@ export default function EditClaimPage() {
     try {
       const updatedClaim = await updateClaim(id, claimFormData)
       if (updatedClaim) {
+        setClaimFormData(updatedClaim)
         toast({
           title: "Szkoda zaktualizowana",
           description: `Szkoda ${updatedClaim.spartaNumber || updatedClaim.claimNumber} została pomyślnie zaktualizowana.`,

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -25,6 +25,7 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
   return {
     ...apiClaim,
     id: apiClaim.id,
+    rowVersion: apiClaim.rowVersion,
     insuranceCompanyId: apiClaim.insuranceCompanyId?.toString(),
     leasingCompanyId: apiClaim.leasingCompanyId?.toString(),
     handlerId: apiClaim.handlerId?.toString(),
@@ -58,6 +59,7 @@ export const transformFrontendClaimToApiPayload = (
 ): ClaimUpsertDto => {
   const {
     id,
+    rowVersion,
     decisions,
     appeals,
     clientClaims,
@@ -144,6 +146,7 @@ export const transformFrontendClaimToApiPayload = (
 
   return {
     id,
+    rowVersion,
     ...rest,
 
     // Convert string identifiers to numbers for API payload

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -33,6 +33,7 @@ export interface EventDto extends EventListItemDto {
   eventTime?: string
   location?: string
   description?: string
+  rowVersion?: string
 
   /**
    * Comma-separated list of services that were called
@@ -61,6 +62,7 @@ export interface DocumentDto {
 
 export interface EventUpsertDto {
   id?: string
+  rowVersion?: string
   spartaNumber?: string
   claimNumber?: string
   vehicleNumber?: string


### PR DESCRIPTION
## Summary
- include `rowVersion` on claim API DTOs and transformation helpers
- keep `rowVersion` while editing claims so subsequent saves use latest concurrency token

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: module resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_6898f073fba0832c9608cd87be2774a0