### PR TITLE
fix: reattach detached entity with row version

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -349,6 +349,7 @@ namespace AutomotiveClaimsApi.Controllers
             try
             {
                 var eventEntity = await _context.Events
+                    .AsNoTracking()
                     .Include(e => e.Participants).ThenInclude(p => p.Drivers)
                     .Include(e => e.Damages)
                     .Include(e => e.Appeals)
@@ -368,6 +369,12 @@ namespace AutomotiveClaimsApi.Controllers
                 MapUpsertDtoToEvent(eventDto, eventEntity, _context);
 
                 eventEntity.UpdatedAt = DateTime.UtcNow;
+
+                _context.Events.Update(eventEntity);
+                if (eventDto.RowVersion != null)
+                {
+                    _context.Entry(eventEntity).Property(e => e.RowVersion).OriginalValue = eventDto.RowVersion;
+                }
 
                 if (eventDto.Documents != null && eventDto.Documents.Any())
                 {


### PR DESCRIPTION
## Summary
- reattach detached event entity and set row version before saving

## Testing
- `dotnet test` *(fails: command not found)*
- `dotnet run --project backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898f66133e4832cb6bcff6022ec34b9