### PR TITLE
Refactor claim updates with helper mapping and tests

### DIFF
--- a/backend/AutomotiveClaimsApi.Tests/ClaimsControllerTests.cs
+++ b/backend/AutomotiveClaimsApi.Tests/ClaimsControllerTests.cs
@@ -41,6 +41,87 @@ namespace AutomotiveClaimsApi.Tests
             Assert.Single(events);
             Assert.True(events[0].UpdatedAt > oldUpdatedAt);
         }
+
+        [Fact]
+        public async Task UpdateClaim_UpdatesDamage_WhenModified()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            await using var context = new ApplicationDbContext(options);
+            var ev = new Event { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+            var damage = new Damage { Id = Guid.NewGuid(), EventId = ev.Id, Description = "old" };
+            ev.Damages.Add(damage);
+            context.Events.Add(ev);
+            await context.SaveChangesAsync();
+
+            var controller = new ClaimsController(context, NullLogger<ClaimsController>.Instance);
+            var dto = new ClaimUpsertDto
+            {
+                Id = ev.Id,
+                Damages = new[] { new DamageUpsertDto { Id = damage.Id, Description = "new" } }
+            };
+
+            await controller.UpdateClaim(ev.Id, dto);
+
+            var updated = await context.Damages.FirstAsync(d => d.Id == damage.Id);
+            Assert.Equal("new", updated.Description);
+        }
+
+        [Fact]
+        public async Task UpdateClaim_UpdatesParticipant_WhenModified()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            await using var context = new ApplicationDbContext(options);
+            var ev = new Event { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+            var participant = new Participant { Id = Guid.NewGuid(), EventId = ev.Id, Name = "old" };
+            ev.Participants.Add(participant);
+            context.Events.Add(ev);
+            await context.SaveChangesAsync();
+
+            var controller = new ClaimsController(context, NullLogger<ClaimsController>.Instance);
+            var dto = new ClaimUpsertDto
+            {
+                Id = ev.Id,
+                Participants = new[] { new ParticipantUpsertDto { Id = participant.Id.ToString(), Name = "new" } }
+            };
+
+            await controller.UpdateClaim(ev.Id, dto);
+
+            var updated = await context.Participants.FirstAsync(p => p.Id == participant.Id);
+            Assert.Equal("new", updated.Name);
+        }
+
+        [Fact]
+        public async Task UpdateClaim_UpdatesDecision_WhenModified()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            await using var context = new ApplicationDbContext(options);
+            var ev = new Event { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+            var decision = new Decision { Id = Guid.NewGuid(), EventId = ev.Id, Status = "old", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+            ev.Decisions.Add(decision);
+            context.Events.Add(ev);
+            await context.SaveChangesAsync();
+
+            var controller = new ClaimsController(context, NullLogger<ClaimsController>.Instance);
+            var dto = new ClaimUpsertDto
+            {
+                Id = ev.Id,
+                Decisions = new[] { new DecisionDto { Id = decision.Id.ToString(), EventId = ev.Id.ToString(), Status = "new" } }
+            };
+
+            await controller.UpdateClaim(ev.Id, dto);
+
+            var updated = await context.Decisions.FirstAsync(d => d.Id == decision.Id);
+            Assert.Equal("new", updated.Status);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Break out claim update mapping into granular helpers for participants, damages, decisions and more
- Iterate through DTO collections in `UpdateClaim` and invoke new helpers for each entity
- Add unit tests ensuring isolated updates for damages, participants, and decisions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689916ac6d4c832cbdc08643b857986b