### PR TITLE
Integrate Google Cloud Storage client

### DIFF
--- a/backend/AutomotiveClaimsApi.Tests/AutomotiveClaimsApi.Tests.csproj
+++ b/backend/AutomotiveClaimsApi.Tests/AutomotiveClaimsApi.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AutomotiveClaimsApi.csproj" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.10.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">

--- a/backend/AutomotiveClaimsApi.Tests/GoogleCloudStorageServiceTests.cs
+++ b/backend/AutomotiveClaimsApi.Tests/GoogleCloudStorageServiceTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AutomotiveClaimsApi.Models;
+using AutomotiveClaimsApi.Services;
+using Google.Apis.Download;
+using Google.Apis.Storage.v1.Data;
+using Google.Apis.Upload;
+using Google.Cloud.Storage.V1;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace AutomotiveClaimsApi.Tests
+{
+    public class GoogleCloudStorageServiceTests
+    {
+        private class FakeStorageClient : StorageClient
+        {
+            private readonly Dictionary<string, byte[]> _storage = new();
+
+            public override Task<Object> UploadObjectAsync(string bucket, string objectName, string contentType, Stream source, UploadObjectOptions options = null, IProgress<IUploadProgress> progress = null, CancellationToken cancellationToken = default)
+            {
+                using var ms = new MemoryStream();
+                source.CopyTo(ms);
+                _storage[objectName] = ms.ToArray();
+                return Task.FromResult(new Object { Bucket = bucket, Name = objectName, ContentType = contentType });
+            }
+
+            public override Task DownloadObjectAsync(string bucket, string objectName, Stream destination, DownloadObjectOptions options = null, IProgress<IDownloadProgress> progress = null, CancellationToken cancellationToken = default)
+            {
+                if (!_storage.TryGetValue(objectName, out var data))
+                {
+                    throw new KeyNotFoundException();
+                }
+                destination.Write(data, 0, data.Length);
+                destination.Position = 0;
+                return Task.CompletedTask;
+            }
+
+            public override Task DeleteObjectAsync(string bucket, string objectName, DeleteObjectOptions options = null, CancellationToken cancellationToken = default)
+            {
+                _storage.Remove(objectName);
+                return Task.CompletedTask;
+            }
+        }
+
+        [Fact]
+        public async Task UploadDownloadDelete_Works()
+        {
+            var settings = Options.Create(new GoogleCloudStorageSettings
+            {
+                Enabled = true,
+                BucketName = "test-bucket"
+            });
+            var client = new FakeStorageClient();
+            var service = new GoogleCloudStorageService(settings, NullLogger<GoogleCloudStorageService>.Instance, client);
+
+            var content = "hello world";
+            await using var uploadStream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+            var url = await service.UploadFileAsync(uploadStream, "file.txt", "text/plain");
+            Assert.Equal("https://storage.googleapis.com/test-bucket/file.txt", url);
+
+            await using var downloadStream = await service.GetFileStreamAsync(url);
+            using var reader = new StreamReader(downloadStream);
+            var downloaded = await reader.ReadToEndAsync();
+            Assert.Equal(content, downloaded);
+
+            await service.DeleteFileAsync(url);
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => service.GetFileStreamAsync(url));
+        }
+    }
+}

--- a/backend/appsettings.Development.json
+++ b/backend/appsettings.Development.json
@@ -8,5 +8,11 @@
   },
   "ConnectionStrings": {
     "DefaultConnection": "Server=SBLAP54\\MSSQLSERVER02;Database=AutomotiveClaimsDb;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True"
+  },
+  "GoogleCloudStorage": {
+    "Enabled": false,
+    "BucketName": "automotive-claims-documents",
+    "ProjectId": "automotive-claims",
+    "CredentialsPath": ""
   }
 }

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -21,6 +21,7 @@
     "ImapPort": 993
   },
   "GoogleCloudStorage": {
+    "Enabled": true,
     "BucketName": "automotive-claims-documents",
     "ProjectId": "automotive-claims",
     "CredentialsPath": ""


### PR DESCRIPTION
## Summary
- replace stubbed GoogleCloudStorageService with real Google Cloud Storage SDK implementation
- add Google Cloud Storage configuration flags
- test upload, download, and delete operations with in-memory StorageClient

## Testing
- `dotnet test backend/AutomotiveClaimsApi.Tests/AutomotiveClaimsApi.Tests.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68992fd434b0832c81fa8c76fa2f8005