### PR TITLE
Use submissionDate for appeals

### DIFF
--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -186,8 +186,8 @@ export const transformFrontendClaimToApiPayload = (
       ? {
           appeals: appeals.map((a) => ({
             ...a,
-            appealDate: a.appealDate
-              ? new Date(a.appealDate).toISOString()
+            submissionDate: a.submissionDate
+              ? new Date(a.submissionDate).toISOString()
               : undefined,
           })),
         }


### PR DESCRIPTION
## Summary
- map appeal submissionDate to ISO strings in API payload

## Testing
- `pnpm test` *(fails: Cannot find module '/workspace/claimWork/app/api/appeals/route')*

------
https://chatgpt.com/codex/tasks/task_e_6899303009b0832c92e6296676920d17