### PR TITLE
feat: add document category codes

### DIFF
--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -165,7 +165,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
               const formDataFile = new FormData()
               formDataFile.append('file', file.file)
               formDataFile.append('eventId', saved!.id.toString())
-              formDataFile.append('category', mapCategoryNameToCode(file.category || 'Inne dokumenty'))
+              formDataFile.append('category', file.categoryCode || mapCategoryNameToCode(file.category || 'Inne dokumenty'))
               formDataFile.append('uploadedBy', 'Current User')
               await fetch('/api/documents/upload', {
                 method: 'POST',

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -26,7 +26,10 @@ interface Document {
   canPreview: boolean
   previewUrl?: string
   downloadUrl: string
+  /** Human readable category name */
   documentType: string
+  /** Machine readable category code */
+  categoryCode?: string
 }
 
 export const DocumentsSection = ({
@@ -83,6 +86,7 @@ export const DocumentsSection = ({
     previewUrl: file.url,
     downloadUrl: file.url,
     documentType: file.category || "Inne dokumenty",
+    categoryCode: file.categoryCode,
   })
 
   const allDocuments = React.useMemo(
@@ -124,6 +128,7 @@ export const DocumentsSection = ({
         const mappedDocs: Document[] = data.map((d: any) => ({
           ...d,
           documentType: mapCategoryCodeToName(d.documentType || d.category),
+          categoryCode: d.documentType || d.category,
         }))
         setDocuments(mappedDocs)
       } else {
@@ -209,6 +214,7 @@ export const DocumentsSection = ({
           uploadedAt: new Date().toISOString(),
           url: URL.createObjectURL(file),
           category: categoryName || "Inne dokumenty",
+          categoryCode: mapCategoryNameToCode(categoryName),
           file: file,
         })
       })
@@ -282,6 +288,7 @@ export const DocumentsSection = ({
             documentType: serverCategory
               ? mapCategoryCodeToName(serverCategory)
               : categoryName || "Inne dokumenty",
+            categoryCode: serverCategory || mapCategoryNameToCode(categoryName),
             canPreview:
               documentDto.canPreview ??
               documentDto.contentType?.startsWith("image/") ||
@@ -353,6 +360,7 @@ export const DocumentsSection = ({
             uploadedAt: doc.createdAt,
             url: doc.previewUrl || doc.downloadUrl,
             category: doc.documentType,
+            categoryCode: doc.categoryCode,
             description: doc.description,
           })),
         ])

--- a/types/index.ts
+++ b/types/index.ts
@@ -198,7 +198,10 @@ export interface UploadedFile {
   type: "image" | "pdf" | "doc" | "video" | "other"
   uploadedAt: string // ISO timestamp when the file was uploaded
   url: string
+  /** Human readable category name for UI display */
   category?: string
+  /** Machine readable category code for API communication */
+  categoryCode?: string
   description?: string
   date?: string
   file?: File


### PR DESCRIPTION
## Summary
- track both category code and display name for uploaded files
- send category codes on upload while showing readable category names
- expose new `categoryCode` field on `UploadedFile`

## Testing
- `pnpm test` *(fails: ModuleJob.run internal modules error)*
- `pnpm lint` *(fails: Next.js ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689a0b7099ac832cb0671e3a6b4857f2