### PR TITLE
Use GUIDs for client claim identifiers

### DIFF
--- a/components/claim-form/client-claims-section.tsx
+++ b/components/claim-form/client-claims-section.tsx
@@ -160,7 +160,7 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
 
     try {
       const claimData: ClientClaim = {
-        id: editingClaim?.id || Date.now().toString(),
+        id: editingClaim?.id || crypto.randomUUID(),
         eventId: claimId,
         claimDate: formData.claimDate,
         claimType: formData.claimType,
@@ -171,7 +171,7 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
         documentDescription: formData.documentDescription,
         document: selectedFile
           ? {
-              id: Date.now().toString(),
+              id: crypto.randomUUID(),
               name: selectedFile.name,
               size: selectedFile.size,
               type: selectedFile.type,

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -193,10 +193,14 @@ export const transformFrontendClaimToApiPayload = (
         }
       : {}),
 
-    clientClaims: clientClaims?.map((c) => ({
-      ...c,
-      claimDate: c.claimDate ? new Date(c.claimDate).toISOString() : undefined,
-    })),
+    clientClaims: clientClaims?.map((c) => {
+      const { id, claimDate, ...rest } = c
+      return {
+        ...rest,
+        ...(id && isGuid(id) ? { id } : {}),
+        claimDate: claimDate ? new Date(claimDate).toISOString() : undefined,
+      }
+    }),
     recourses: recourses?.map((r) => ({
       ...r,
       recourseDate: r.recourseDate ? new Date(r.recourseDate).toISOString() : undefined,


### PR DESCRIPTION
## Summary
- Replace timestamp-based client claim IDs with `crypto.randomUUID`
- Validate client claim IDs as GUIDs when transforming payloads

## Testing
- `pnpm lint` *(fails: requires ESLint configuration)*
- `pnpm test` *(fails: Cannot require() ES Module in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689a19ba638c832cb32d3a8d9509f1b0