### PR TITLE
feat: integrate note management into claims

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -20,7 +20,16 @@ import { ClientClaimsSection } from "./client-claims-section"
 import { RecourseSection } from "./recourse-section"
 import { SettlementsSection } from "./settlements-section"
 import { CLAIM_STATUSES } from "@/lib/constants"
-import type { Claim, Service, ParticipantInfo, DriverInfo, UploadedFile, RequiredDocument, Decision } from "@/types"
+import type {
+  Claim,
+  Service,
+  ParticipantInfo,
+  DriverInfo,
+  UploadedFile,
+  RequiredDocument,
+  Decision,
+  Note,
+} from "@/types"
 import { EmailSection } from "../email/email-section-compact"
 import { DependentSelect } from "@/components/ui/dependent-select"
 import { useToast } from "@/hooks/use-toast"
@@ -37,18 +46,6 @@ import VehicleTypeDropdown from "@/components/vehicle-type-dropdown"
 import type { VehicleTypeSelectionEvent } from "@/types/vehicle-type"
 import { RepairScheduleSection } from "./repair-schedule-section"
 import { RepairDetailsSection } from "./repair-details-section"
-
-interface Note {
-  id: string
-  type: "note" | "task" | "internal" | "status"
-  title: string
-  description: string
-  user: string
-  createdAt: string
-  status?: "active" | "completed" | "cancelled"
-  priority?: "low" | "medium" | "high"
-  dueDate?: string
-}
 
 interface RiskType {
   value: string
@@ -209,9 +206,6 @@ export const ClaimMainContent = ({
   const [caseHandlers, setCaseHandlers] = useState<any[]>([])
   const [loadingHandlers, setLoadingHandlers] = useState(false)
 
-  // Notes state
-  const [notes, setNotes] = useState<Note[]>([])
-
   // Form states
   const [showNoteForm, setShowNoteForm] = useState<string | null>(null)
   const [noteForm, setNoteForm] = useState({
@@ -246,37 +240,7 @@ export const ClaimMainContent = ({
     loadDamages()
   }, [claimFormData.id])
 
-  useEffect(() => {
-    if (!eventId) return
-
-    const loadNotes = async () => {
-      try {
-        const response = await fetch(`/api/notes?eventId=${eventId}`)
-        if (!response.ok) throw new Error()
-        const data = await response.json()
-        const mappedNotes: Note[] = data.map((note: any) => ({
-          id: note.id,
-          type: (note.category as Note["type"]) || "note",
-          title: note.title,
-          description: note.content,
-          user: note.createdBy || "",
-          createdAt: note.createdAt,
-          priority: note.priority,
-          status: note.status,
-          dueDate: note.dueDate,
-        }))
-        setNotes(mappedNotes)
-      } catch (error) {
-        toast({
-          title: "Błąd",
-          description: "Nie udało się pobrać notatek.",
-          variant: "destructive",
-        })
-      }
-    }
-
-    loadNotes()
-  }, [eventId])
+  // Notes are managed via claimFormData
 
   // State for expanded sections in teczka-szkodowa
   const [expandedSections, setExpandedSections] = useState({
@@ -484,7 +448,7 @@ export const ClaimMainContent = ({
   }
 
   // Notes functions
-  const addNote = async (type: Note["type"]) => {
+  const addNote = (type: Note["type"]) => {
     if (!noteForm.title.trim() || !noteForm.description.trim()) {
       toast({
         title: "Błąd",
@@ -494,109 +458,53 @@ export const ClaimMainContent = ({
       return
     }
 
-    const eid = eventId
-    if (!eid) {
-      toast({
-        title: "Błąd",
-        description: "Brak identyfikatora zdarzenia.",
-        variant: "destructive",
-      })
-      return
+    const newNote: Note = {
+      id: `temp-${Date.now()}`,
+      type,
+      title: noteForm.title,
+      description: noteForm.description,
+      user: "",
+      createdAt: new Date().toISOString(),
+      priority: noteForm.priority,
+      status: type === "task" ? "active" : undefined,
+      dueDate: noteForm.dueDate || undefined,
     }
 
-    try {
-      const response = await fetch("/api/notes", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          eventId: eid,
-          category: type,
-          title: noteForm.title,
-          content: noteForm.description,
-          priority: noteForm.priority,
-          dueDate: noteForm.dueDate || undefined,
-        }),
-      })
-      if (!response.ok) throw new Error()
-      const data = await response.json()
+    const updatedNotes = [newNote, ...(claimFormData.notes ?? [])]
+    handleFormChange("notes", updatedNotes)
+    setNoteForm({ title: "", description: "", priority: "medium", dueDate: "" })
+    setShowNoteForm(null)
 
-      const newNote: Note = {
-        id: data.id,
-        type: (data.category as Note["type"]) || type,
-        title: data.title,
-        description: data.content,
-        user: data.createdBy || "",
-        createdAt: data.createdAt,
-        priority: data.priority,
-        status: data.status,
-        dueDate: data.dueDate,
-      }
-
-      setNotes((prev) => [newNote, ...prev])
-      setNoteForm({ title: "", description: "", priority: "medium", dueDate: "" })
-      setShowNoteForm(null)
-
-      toast({
-        title: "Sukces",
-        description: `${getTypeLabel(type)} została dodana pomyślnie.`,
-      })
-    } catch (error) {
-      toast({
-        title: "Błąd",
-        description: "Nie udało się dodać notatki.",
-        variant: "destructive",
-      })
-    }
+    toast({
+      title: "Sukces",
+      description: `${getTypeLabel(type)} została dodana pomyślnie.`,
+    })
   }
 
-  const updateTaskStatus = async (
+  const updateTaskStatus = (
     noteId: string,
     status: "active" | "completed" | "cancelled",
   ) => {
-    try {
-      const response = await fetch(`/api/notes/${noteId}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status }),
-      })
-      if (!response.ok) throw new Error()
+    const updatedNotes = (claimFormData.notes ?? []).map((note) =>
+      note.id === noteId ? { ...note, status } : note,
+    )
+    handleFormChange("notes", updatedNotes)
 
-      setNotes((prev) =>
-        prev.map((note) => (note.id === noteId ? { ...note, status } : note)),
-      )
-
-      toast({
-        title: "Zaktualizowano",
-        description: "Status zadania został zmieniony.",
-      })
-    } catch (error) {
-      toast({
-        title: "Błąd",
-        description: "Nie udało się zaktualizować statusu.",
-        variant: "destructive",
-      })
-    }
+    toast({
+      title: "Zaktualizowano",
+      description: "Status zadania został zmieniony.",
+    })
   }
 
-  const deleteNote = async (noteId: string) => {
-    try {
-      const response = await fetch(`/api/notes/${noteId}`, {
-        method: "DELETE",
-      })
-      if (!response.ok) throw new Error()
-
-      setNotes((prev) => prev.filter((note) => note.id !== noteId))
-      toast({
-        title: "Usunięto",
-        description: "Notatka została usunięta.",
-      })
-    } catch (error) {
-      toast({
-        title: "Błąd",
-        description: "Nie udało się usunąć notatki.",
-        variant: "destructive",
-      })
-    }
+  const deleteNote = (noteId: string) => {
+    const updatedNotes = (claimFormData.notes ?? []).filter(
+      (note) => note.id !== noteId,
+    )
+    handleFormChange("notes", updatedNotes)
+    toast({
+      title: "Usunięto",
+      description: "Notatka została usunięta.",
+    })
   }
 
   const cancelNoteForm = () => {
@@ -646,6 +554,8 @@ export const ClaimMainContent = ({
         return "text-gray-600"
     }
   }
+
+  const notes = (claimFormData.notes ?? []) as Note[]
 
   const filteredNotes = notes.filter((note) => {
     const matchesSearch =

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -7,7 +7,7 @@ import {
   type ClaimDto,
   type ParticipantUpsertDto,
 } from "@/lib/api"
-import type { Claim, ParticipantInfo, DriverInfo } from "@/types"
+import type { Claim, ParticipantInfo, DriverInfo, Note } from "@/types"
 
 export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
   const injuredParty = apiClaim.participants?.find((p: any) => p.role === "Poszkodowany")
@@ -44,6 +44,16 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
       description: d.description,
       detail: d.detail,
     })) || [],
+    notes:
+      apiClaim.notes?.map((n: any) => ({
+        id: n.id,
+        type: (n.category as Note["type"]) || "note",
+        title: n.title,
+        description: n.content,
+        user: n.createdBy,
+        createdAt: n.createdAt,
+        priority: n.priority as Note["priority"],
+      })) || [],
     decisions: apiClaim.decisions || [],
     appeals: apiClaim.appeals,
     clientClaims: apiClaim.clientClaims || [],
@@ -66,6 +76,7 @@ export const transformFrontendClaimToApiPayload = (
     recourses,
     settlements,
     damages,
+    notes,
     injuredParty,
     perpetrator,
     servicesCalled,
@@ -180,6 +191,18 @@ export const transformFrontendClaimToApiPayload = (
       description: d.description,
       detail: d.detail,
     })),
+    ...(Array.isArray(notes) && notes.length > 0
+      ? {
+          notes: notes.map((n: Note) => ({
+            id: n.id && n.id.startsWith("temp-") ? undefined : n.id,
+            category: n.type,
+            title: n.title,
+            content: n.description,
+            createdBy: n.user,
+            priority: n.priority,
+          })),
+        }
+      : {}),
     ...(Array.isArray(decisions) && decisions.length > 0
       ? {
           decisions: decisions.map((d) => ({

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -102,8 +102,12 @@ export interface EventUpsertDto {
 }
 
 export interface ClaimListItemDto extends EventListItemDto {}
-export interface ClaimDto extends EventDto {}
-export interface ClaimUpsertDto extends EventUpsertDto {}
+export interface ClaimDto extends EventDto {
+  notes?: NoteDto[]
+}
+export interface ClaimUpsertDto extends EventUpsertDto {
+  notes?: NoteUpsertDto[]
+}
 
 export interface NoteDto {
   id: string

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,6 +1,18 @@
 import type React from "react"
 import type { ClaimDto } from "@/lib/api"
 
+export interface Note {
+  id?: string
+  type?: "note" | "task" | "internal" | "status"
+  title?: string
+  description: string
+  user?: string
+  createdAt?: string
+  priority?: "low" | "medium" | "high"
+  status?: "active" | "completed" | "cancelled"
+  dueDate?: string
+}
+
 export interface Claim
   extends Omit<
     ClaimDto,
@@ -48,6 +60,7 @@ export interface Claim
   vehicleTypeCode?: string
   damageDescription?: string
   damages?: DamageItem[]
+  notes?: Note[]
   injuredParty?: ParticipantInfo
   perpetrator?: ParticipantInfo
   decisions?: Decision[]


### PR DESCRIPTION
## Summary
- expose claim notes via shared types and API DTOs
- map claim notes to API payload and from API response
- manage claim notes within claim form state instead of separate fetches

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689a7856e0a8832cbb540e3fe9f15c9a