### PR TITLE
feat: allow marking tasks as done

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -2366,6 +2366,17 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
                           <div className="flex items-start justify-between">
                             <div className="flex-1">
                               <div className="flex items-center space-x-2 mb-2">
+                                <Checkbox
+                                  checked={task.status === "completed"}
+                                  onCheckedChange={(checked) =>
+                                    updateTaskStatus(
+                                      task.id,
+                                      checked ? "completed" : "active",
+                                    )
+                                  }
+                                  disabled={task.status === "cancelled"}
+                                  className="mr-1"
+                                />
                                 {getStatusIcon(task.status)}
                                 <h4 className="font-medium text-gray-900">{task.title}</h4>
                                 {task.priority && (


### PR DESCRIPTION
## Summary
- add checkbox to task list to toggle completion status

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689a803777d8832c91dbf63628e77093