### PR TITLE
Fix decision date mapping in appeals API

### DIFF
--- a/lib/api/appeals.ts
+++ b/lib/api/appeals.ts
@@ -71,12 +71,9 @@ export async function createAppeal(
   if (appeal.extensionDate) {
     formData.append("ExtensionDate", appeal.extensionDate);
   }
-  if (appeal.responseDate) {
-    formData.append("DecisionDate", appeal.responseDate);
   const decisionDate = appeal.decisionDate ?? appeal.responseDate;
   if (decisionDate) {
     formData.append("DecisionDate", decisionDate);
-
   }
   if (appeal.status) {
     formData.append("Status", appeal.status);
@@ -109,13 +106,9 @@ export async function updateAppeal(
   if (appeal.extensionDate) {
     formData.append("ExtensionDate", appeal.extensionDate);
   }
-  if (appeal.responseDate) {
-    formData.append("DecisionDate", appeal.responseDate);
-
   const decisionDateUpdate = appeal.decisionDate ?? appeal.responseDate;
   if (decisionDateUpdate) {
     formData.append("DecisionDate", decisionDateUpdate);
-
   }
   if (appeal.status) {
     formData.append("Status", appeal.status);


### PR DESCRIPTION
## Summary
- ensure `DecisionDate` is only appended once when creating or updating appeals

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689a81832dc8832ca7132bdb99075768