### PR TITLE
Fix participant policy date mapping

### DIFF
--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -16,6 +16,12 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
   const mapParticipantDto = (p: any): ParticipantInfo => ({
     ...p,
     id: p.id?.toString() || "",
+    policyDealDate: p.policyDealDate ? p.policyDealDate.split("T")[0] : undefined,
+    policyStartDate: p.policyStartDate ? p.policyStartDate.split("T")[0] : undefined,
+    policyEndDate: p.policyEndDate ? p.policyEndDate.split("T")[0] : undefined,
+    firstRegistrationDate: p.firstRegistrationDate
+      ? p.firstRegistrationDate.split("T")[0]
+      : undefined,
     drivers: p.drivers?.map((d: any) => ({
       ...d,
       id: d.id?.toString() || "",
@@ -130,11 +136,16 @@ export const transformFrontendClaimToApiPayload = (
     policyEndDate: p.policyEndDate
       ? new Date(p.policyEndDate).toISOString()
       : undefined,
+    firstRegistrationDate: p.firstRegistrationDate
+      ? new Date(p.firstRegistrationDate).toISOString()
+      : undefined,
+    policySumAmount: p.policySumAmount,
     vehicleRegistration: p.vehicleRegistration,
     vehicleVin: p.vehicleVin,
     vehicleType: p.vehicleType,
     vehicleBrand: p.vehicleBrand,
     vehicleModel: p.vehicleModel,
+    inspectionNotes: p.inspectionNotes,
     inspectionContactName: p.inspectionContactName,
     inspectionContactPhone: p.inspectionContactPhone,
     inspectionContactEmail: p.inspectionContactEmail,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -188,6 +188,9 @@ export interface ParticipantDto {
   policyDealDate?: string
   policyStartDate?: string
   policyEndDate?: string
+  firstRegistrationDate?: string
+  policySumAmount?: number
+  inspectionNotes?: string
   vehicleRegistration?: string
   vehicleVin?: string
   vehicleType?: string
@@ -214,6 +217,9 @@ export interface ParticipantUpsertDto {
   policyDealDate?: string
   policyStartDate?: string
   policyEndDate?: string
+  firstRegistrationDate?: string
+  policySumAmount?: number
+  inspectionNotes?: string
   vehicleRegistration?: string
   vehicleVin?: string
   vehicleType?: string


### PR DESCRIPTION
## Summary
- Normalize participant policy and registration dates when transforming API data
- Include additional participant fields in API payload mapping

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689a7f04c0f0832cb9c90939bb458a51