### PR TITLE
Fix missing external entity and transfer date for settlements

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -982,6 +982,9 @@ namespace AutomotiveClaimsApi.Controllers
             var existing = hasId ? entity.Settlements.FirstOrDefault(s => s.Id == settlementId) : null;
             if (existing != null)
             {
+                existing.ExternalEntity = sDto.ExternalEntity;
+                existing.CustomExternalEntity = sDto.CustomExternalEntity;
+                existing.TransferDate = sDto.TransferDate;
                 existing.Status = sDto.Status;
                 existing.SettlementDate = sDto.SettlementDate;
                 existing.Amount = sDto.Amount;
@@ -1004,6 +1007,9 @@ namespace AutomotiveClaimsApi.Controllers
                 {
                     Id = hasId ? settlementId : Guid.NewGuid(),
                     EventId = entity.Id,
+                    ExternalEntity = sDto.ExternalEntity,
+                    CustomExternalEntity = sDto.CustomExternalEntity,
+                    TransferDate = sDto.TransferDate,
                     Status = sDto.Status,
                     SettlementDate = sDto.SettlementDate,
                     Amount = sDto.Amount,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -409,11 +409,19 @@ export interface RecourseUpsertDto {
 export interface SettlementDto {
   id?: number
   eventId?: number
+  externalEntity?: string
+  customExternalEntity?: string
+  transferDate?: string
   settlementDate?: string
   settlementType?: string
   description?: string
   amount?: number
+  settlementAmount?: number
+  currency?: string
   status?: string
+  documentPath?: string
+  documentName?: string
+  documentDescription?: string
 }
 
 export interface SettlementUpsertDto {

--- a/types/index.ts
+++ b/types/index.ts
@@ -195,11 +195,18 @@ export interface Recourse {
 export interface Settlement {
   id?: string
   eventId?: string
+  externalEntity?: string
+  customExternalEntity?: string
+  transferDate?: string
   settlementDate: string
   settlementType: string
   description: string
+  settlementAmount?: number
+  currency?: string
   amount?: number
   status?: string
+  documentPath?: string
+  documentName?: string
 }
 
 export type Service = "policja" | "pogotowie" | "straz" | "holownik"


### PR DESCRIPTION
## Summary
- Ensure `ClaimsController` saves `externalEntity`, `customExternalEntity`, and `transferDate` when persisting settlements
- Extend settlement DTO and TypeScript types with external entity and transfer date fields

## Testing
- `dotnet test` *(fails: command not found)*
- `pnpm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*
- `pnpm lint` *(fails: interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689a83a16bc8832c8efcf223b4e403e3