### PR TITLE
Use settlement amount for currency totals

### DIFF
--- a/backend/AutomotiveClaimsApi.Tests/SettlementsControllerTests.cs
+++ b/backend/AutomotiveClaimsApi.Tests/SettlementsControllerTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+using AutomotiveClaimsApi.Controllers;
+using AutomotiveClaimsApi.Data;
+using AutomotiveClaimsApi.Models;
+
+namespace AutomotiveClaimsApi.Tests
+{
+    public class SettlementsControllerTests
+    {
+        [Fact]
+        public async Task GetSettlementsSummary_SumsSettlementAmountByCurrency()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            await using var context = new ApplicationDbContext(options);
+            var eventId = Guid.NewGuid();
+
+            var now = DateTime.UtcNow;
+            context.Settlements.AddRange(
+                new Settlement { Id = Guid.NewGuid(), EventId = eventId, Currency = "USD", Amount = 1m, SettlementAmount = 100m, Status = "paid", CreatedAt = now, UpdatedAt = now },
+                new Settlement { Id = Guid.NewGuid(), EventId = eventId, Currency = "USD", Amount = 1m, SettlementAmount = 50m, Status = "paid", CreatedAt = now, UpdatedAt = now },
+                new Settlement { Id = Guid.NewGuid(), EventId = eventId, Currency = null, Amount = 1m, SettlementAmount = 200m, Status = "pending", CreatedAt = now, UpdatedAt = now }
+            );
+            await context.SaveChangesAsync();
+
+            var controller = new SettlementsController(context, null!, NullLogger<SettlementsController>.Instance);
+
+            var result = await controller.GetSettlementsSummary(eventId);
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            dynamic summary = okResult.Value!;
+            var totalsByCurrency = (IDictionary<string, decimal>)summary.TotalsByCurrency;
+
+            Assert.Equal(150m, totalsByCurrency["USD"]);
+            Assert.Equal(200m, totalsByCurrency["PLN"]);
+            Assert.Equal(3, summary.Count);
+        }
+    }
+}

--- a/backend/Controllers/SettlementsController.cs
+++ b/backend/Controllers/SettlementsController.cs
@@ -184,7 +184,7 @@ namespace AutomotiveClaimsApi.Controllers
 
             var totalsByCurrency = settlements
                 .GroupBy(s => s.Currency ?? "PLN")
-                .ToDictionary(g => g.Key, g => g.Sum(s => s.Amount ?? 0));
+                .ToDictionary(g => g.Key, g => g.Sum(s => s.SettlementAmount ?? 0));
 
             var totalsByStatus = settlements
                 .Where(s => s.Status != null)


### PR DESCRIPTION
## Summary
- Sum settlement amounts by currency in settlement summary
- Add unit test validating settlement amount aggregation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a87dffa80832c8f0c60e7efc5df00