### PR TITLE
feat: integrate settlement CRUD operations

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -2027,11 +2027,7 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
               <CardTitle className="text-lg font-semibold">Ugoda</CardTitle>
             </CardHeader>
             <CardContent className="p-0 bg-white">
-              <SettlementsSection
-                settlements={claimFormData.settlements || []}
-                onSettlementsChange={(settlements) => handleFormChange("settlements", settlements)}
-                claimId={claimFormData.id || undefined}
-              />
+              <SettlementsSection claimId={claimFormData.id || ""} />
             </CardContent>
           </Card>
         </div>


### PR DESCRIPTION
## Summary
- fetch settlements on mount
- send FormData to create, update, and delete settlements
- refresh list after each mutation

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e188b54832caf0571ed47ea08a3