### PR TITLE
feat: forward claim notes in client claim API

### DIFF
--- a/app/api/client-claims/__tests__/route.test.mjs
+++ b/app/api/client-claims/__tests__/route.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+// Verify that notes sent in a POST request are returned on subsequent fetches
+
+test('roundtrips claim notes through client-claims API', async () => {
+  const { POST, GET } = await import('../route.ts')
+
+  const fd = new FormData()
+  fd.append('eventId', '1')
+  fd.append('claimDate', '2024-01-01')
+  fd.append('claimType', 'Type')
+  fd.append('claimAmount', '100')
+  fd.append('status', 'Pending')
+  fd.append('claimNotes', 'Initial note')
+
+  let storedNotes
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async (_url, init) => {
+    if (init && init.method === 'POST') {
+      const body = init.body
+      storedNotes = body.get('ClaimNotes')
+      return new Response(JSON.stringify({ id: '1', claimNotes: storedNotes }), { status: 201 })
+    }
+    return new Response(JSON.stringify([{ id: '1', claimNotes: storedNotes }]), { status: 200 })
+  }
+
+  await POST(new Request('http://localhost/api/client-claims', { method: 'POST', body: fd }))
+  const res = await GET(new Request('http://localhost/api/client-claims?eventId=1'))
+  const data = await res.json()
+
+  globalThis.fetch = originalFetch
+
+  assert.equal(storedNotes, 'Initial note')
+  assert.equal(Array.isArray(data), true)
+  assert.equal(data[0].claimNotes, 'Initial note')
+})
+

--- a/app/api/client-claims/route.ts
+++ b/app/api/client-claims/route.ts
@@ -45,6 +45,7 @@ export async function POST(request: NextRequest) {
     const currency = (formData.get("currency") as string) || "PLN"
     const status = formData.get("status") as string
     const description = formData.get("description") as string
+    const claimNotes = formData.get("claimNotes") as string
     const documentDescription = formData.get("documentDescription") as string
     const document = formData.get("document") as File
 
@@ -60,6 +61,7 @@ export async function POST(request: NextRequest) {
     backendFormData.append("Currency", currency)
     backendFormData.append("Status", status)
     if (description) backendFormData.append("Description", description)
+    if (claimNotes) backendFormData.append("ClaimNotes", claimNotes)
     if (documentDescription) backendFormData.append("DocumentDescription", documentDescription)
     if (document) backendFormData.append("Document", document)
 


### PR DESCRIPTION
## Summary
- forward claim notes from the client-claims API route to the backend
- add test covering client-claims note round trip

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689a9ed49388832ca5cae7e920b147fb