### PR TITLE
feat: allow renaming documents

### DIFF
--- a/backend/Controllers/DocumentsController.cs
+++ b/backend/Controllers/DocumentsController.cs
@@ -128,6 +128,8 @@ namespace AutomotiveClaimsApi.Controllers
                 return NotFound();
 
             document.Description = updateDto.Description ?? document.Description;
+            document.FileName = updateDto.FileName ?? document.FileName;
+            document.OriginalFileName = updateDto.OriginalFileName ?? document.OriginalFileName;
             // Assuming DocumentStatusId maps to Status string. This might need a lookup table.
             // document.Status = updateDto.DocumentStatusId?.ToString() ?? document.Status;
             document.UpdatedAt = DateTime.UtcNow;

--- a/backend/DTOs/UpdateDocumentDto.cs
+++ b/backend/DTOs/UpdateDocumentDto.cs
@@ -4,5 +4,7 @@ namespace AutomotiveClaimsApi.DTOs
     {
         public string? Description { get; set; }
         public int? DocumentStatusId { get; set; }
+        public string? FileName { get; set; }
+        public string? OriginalFileName { get; set; }
     }
 }

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -536,6 +536,35 @@ export const DocumentsSection = ({
     }
   }
 
+  const handleFileNameChange = async (documentId: string | number, name: string) => {
+    const pendingIndex = pendingFiles.findIndex((f) => f.id === documentId)
+    if (pendingIndex !== -1) {
+      setPendingFiles?.((prev) =>
+        prev.map((f) => (f.id === documentId ? { ...f, name } : f)),
+      )
+      return
+    }
+
+    try {
+      const response = await fetch(`/api/documents/${documentId}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ fileName: name, originalFileName: name }),
+      })
+
+      if (response.ok) {
+        const updatedDocument = await response.json()
+        setDocuments((prev) =>
+          prev.map((doc) => (doc.id === documentId ? updatedDocument : doc)),
+        )
+      }
+    } catch (error) {
+      console.error("Error updating document name:", error)
+    }
+  }
+
   const handleGenerateAIDescription = async (documentId: string | number) => {
     const document = allDocuments.find((d) => d.id === documentId)
     if (!document || document.status === "pending") return
@@ -1079,6 +1108,12 @@ export const DocumentsSection = ({
                               </td>
                               <td className="p-3">
                                 <div className="flex items-center gap-1">
+                                  <Input
+                                    value={document.originalFileName || ""}
+                                    onChange={(e) => handleFileNameChange(document.id, e.target.value)}
+                                    className="text-sm h-8"
+                                    placeholder="Nazwa pliku..."
+                                  />
                                   <Button
                                     variant="ghost"
                                     size="icon"


### PR DESCRIPTION
## Summary
- allow renaming documents from the documents section
- extend update DTO and controller to persist file name changes

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: 1 failing tests)*
- `dotnet test backend` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689aa1097b04832cb206a9bab1032b77