### PR TITLE
Validate participant and driver IDs before sending claim payload

### DIFF
--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -29,18 +29,27 @@ test('maps damageType object to its code value', () => {
   assert.equal(payload.damageType, 'DT')
 })
 
-test('participant and driver ids are numeric', () => {
+test('participant and driver ids include only GUID strings', () => {
+  const guid = '123e4567-e89b-12d3-a456-426614174000'
   const payload = transformFrontendClaimToApiPayload({
     injuredParty: {
+      id: guid,
+      drivers: [{ id: guid }, { id: '456' }],
+    },
+    perpetrator: {
       id: '123',
-      drivers: [{ id: '456' }],
+      drivers: [{ id: guid }],
     },
   } as any)
 
-  const participant = payload.participants?.[0]
-  const driver = participant?.drivers?.[0]
-  assert.equal(participant?.id, 123)
-  assert.equal(driver?.id, 456)
+  const [injured, perpetrator] = payload.participants || []
+  const [validDriver, invalidDriver] = injured.drivers || []
+
+  assert.equal(injured.id, guid)
+  assert.equal(validDriver?.id, guid)
+  assert.equal(invalidDriver?.id, undefined)
+  assert.equal(perpetrator?.id, undefined)
+  assert.equal(perpetrator?.drivers?.[0]?.id, guid)
 })
 
 test('settlement ids are validated and converted', () => {

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -132,7 +132,7 @@ export const transformFrontendClaimToApiPayload = (
 
   const mapParticipant = (p: ParticipantInfo, role: string): ParticipantUpsertDto => ({
 
-    id: p.id ? Number(p.id) : undefined,
+    id: p.id && isGuid(p.id) ? p.id : undefined,
     role,
 
     name: p.name,
@@ -168,7 +168,7 @@ export const transformFrontendClaimToApiPayload = (
     inspectionContactEmail: p.inspectionContactEmail,
     drivers: p.drivers?.map((d: DriverInfo) => ({
 
-      id: d.id ? Number(d.id) : undefined,
+      id: d.id && isGuid(d.id) ? d.id : undefined,
 
       name: d.name,
       licenseNumber: d.licenseNumber,


### PR DESCRIPTION
## Summary
- ensure `mapParticipant` only includes GUID participant IDs
- only include GUID driver IDs when building claim payload
- update tests to reflect GUID ID requirements

## Testing
- `pnpm test hooks/__tests__/use-claims.test.ts` *(fails: Cannot require() ES Module in a cycle)*
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689aa517cc38832c8cd86933be20d573