### PR TITLE
fix: return detailed bad request for invalid login

### DIFF
--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -19,16 +19,19 @@ namespace AutomotiveClaimsApi.Controllers
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly IAntiforgery _antiforgery;
         private readonly IEmailSender? _emailSender;
+        private readonly ILogger<AuthController> _logger;
 
         public AuthController(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
             IAntiforgery antiforgery,
+            ILogger<AuthController> logger,
             IEmailSender? emailSender = null)
         {
             _userManager = userManager;
             _signInManager = signInManager;
             _antiforgery = antiforgery;
+            _logger = logger;
             _emailSender = emailSender;
         }
 
@@ -95,7 +98,10 @@ namespace AutomotiveClaimsApi.Controllers
         public async Task<IActionResult> Login([FromBody] LoginDto dto)
         {
             if (dto.UserName == null || dto.Password == null)
-                return BadRequest();
+            {
+                _logger.LogWarning("Login attempt with missing username or password");
+                return BadRequest(new { message = "Username and password are required." });
+            }
 
             var result = await _signInManager.PasswordSignInAsync(dto.UserName, dto.Password, true, true);
             if (!result.Succeeded)


### PR DESCRIPTION
## Summary
- log and clarify bad request when login fields missing

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b8757ddc8832ca68ef7c520f97e0d