### PR TITLE
Ensure login uses fresh antiforgery token

### DIFF
--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -40,6 +40,7 @@ export function useAuth() {
   }, [])
 
   const login = async (username: string, password: string) => {
+    await apiService.fetchAntiforgery()
     await apiService.login(username, password)
     const user = await apiService.getCurrentUser()
     setAuthState({


### PR DESCRIPTION
## Summary
- refresh XSRF token by fetching antiforgery token before each login attempt

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)*
- `pnpm lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689b8755a470832c90d1e8b5cbc98e0d