### PR TITLE
Remove antiforgery token handling

### DIFF
--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Identity;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Antiforgery;
 using AutomotiveClaimsApi.Models;
 using AutomotiveClaimsApi.DTOs;
 using AutomotiveClaimsApi.Services;
@@ -17,20 +16,17 @@ namespace AutomotiveClaimsApi.Controllers
     {
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly SignInManager<ApplicationUser> _signInManager;
-        private readonly IAntiforgery _antiforgery;
         private readonly IEmailSender? _emailSender;
         private readonly ILogger<AuthController> _logger;
 
         public AuthController(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
-            IAntiforgery antiforgery,
             ILogger<AuthController> logger,
             IEmailSender? emailSender = null)
         {
             _userManager = userManager;
             _signInManager = signInManager;
-            _antiforgery = antiforgery;
             _logger = logger;
             _emailSender = emailSender;
         }
@@ -127,15 +123,6 @@ namespace AutomotiveClaimsApi.Controllers
             if (user == null) return Unauthorized();
             var roles = await _userManager.GetRolesAsync(user);
             return new UserDto { Id = user.Id, UserName = user.UserName, Email = user.Email, Roles = roles };
-        }
-
-        [AllowAnonymous]
-        [HttpGet("antiforgery")]
-        public IActionResult Antiforgery()
-        {
-            var tokens = _antiforgery.GetAndStoreTokens(HttpContext);
-            Response.Cookies.Append("XSRF-TOKEN", tokens.RequestToken!, new CookieOptions { HttpOnly = false });
-            return Ok(new { message = "Antiforgery token generated", token = tokens.RequestToken });
         }
 
         [Authorize]

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -3,7 +3,6 @@ using AutomotiveClaimsApi.Data;
 using AutomotiveClaimsApi.Services;
 using AutomotiveClaimsApi.Models;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Authorization;
@@ -17,7 +16,6 @@ builder.Services.AddControllersWithViews(options =>
         .RequireAuthenticatedUser()
         .Build();
     options.Filters.Add(new AuthorizeFilter(policy));
-    options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
 });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -49,13 +47,6 @@ builder.Services.ConfigureApplicationCookie(options =>
         context.Response.StatusCode = 403;
         return Task.CompletedTask;
     };
-});
-
-builder.Services.AddAntiforgery(options =>
-{
-    options.HeaderName = "X-XSRF-TOKEN";
-    options.Cookie.Name = "XSRF-TOKEN";
-    options.Cookie.HttpOnly = true;
 });
 
 // Configure SMTP settings
@@ -97,16 +88,6 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 app.UseCors("Frontend");
-app.Use(async (context, next) =>
-{
-    if (string.Equals(context.Request.Method, "GET", StringComparison.OrdinalIgnoreCase))
-    {
-        var antiforgery = context.RequestServices.GetRequiredService<IAntiforgery>();
-        var tokens = antiforgery.GetAndStoreTokens(context);
-        context.Response.Headers["X-XSRF-TOKEN"] = tokens.RequestToken!;
-    }
-    await next();
-});
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();

--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -25,7 +25,6 @@ export function useAuth() {
   useEffect(() => {
     const initialize = async () => {
       try {
-        await apiService.fetchAntiforgery()
         const user = await apiService.getCurrentUser()
         setAuthState({
           user: user || null,
@@ -40,7 +39,6 @@ export function useAuth() {
   }, [])
 
   const login = async (username: string, password: string) => {
-    await apiService.fetchAntiforgery()
     await apiService.login(username, password)
     const user = await apiService.getCurrentUser()
     setAuthState({


### PR DESCRIPTION
## Summary
- drop antiforgery token configuration and middleware from backend
- eliminate antiforgery token usage in auth controller and client code

## Testing
- `dotnet test backend/AutomotiveClaimsApi.Tests/AutomotiveClaimsApi.Tests.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b8ae0f0b0832c8edd20be2a7c4731