### PR TITLE
Remove antiforgery token handling

### DIFF
--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -25,7 +25,6 @@ export function useAuth() {
   useEffect(() => {
     const initialize = async () => {
       try {
-        await apiService.fetchAntiforgery()
         const user = await apiService.getCurrentUser()
         setAuthState({
           user: user || null,
@@ -40,7 +39,6 @@ export function useAuth() {
   }, [])
 
   const login = async (username: string, password: string) => {
-    await apiService.fetchAntiforgery()
     await apiService.login(username, password)
     const user = await apiService.getCurrentUser()
     setAuthState({

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -571,12 +571,6 @@ class ApiService {
     return text as unknown as T
   }
 
-  async fetchAntiforgery(): Promise<void> {
-    await fetch(`${API_BASE_URL}/auth/antiforgery`, {
-      credentials: "include",
-    })
-  }
-
   async register(username: string, email: string, password: string): Promise<void> {
     await this.request<void>("/auth/register", {
       method: "POST",


### PR DESCRIPTION
## Summary
- remove antiforgery fetch helper from API service
- stop calling antiforgery endpoint during auth initialization and login

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `curl -i -X POST https://claim-work-backend.azurewebsites.net/api/auth/login -H 'Content-Type: application/json' -d '{"userName":"test","password":"test"}'` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689b8ae62544832cb2a0cad9578795a9