### PR TITLE
feat: forward auth token in claims API

### DIFF
--- a/app/api/claims/route.ts
+++ b/app/api/claims/route.ts
@@ -10,12 +10,22 @@ export async function GET(request: NextRequest) {
 
     console.log(`Fetching claims from backend: ${url}`)
 
+    // Retrieve auth token from cookies (adjust cookie name as needed)
+    const token = request.cookies.get("token")?.value
+
     const response = await fetch(url, {
       headers: {
         "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
+      // Include cookies for session-based authentication
+      credentials: "include",
       cache: "no-store",
     })
+
+    if (response.status === 401) {
+      return NextResponse.redirect(new URL("/login", request.url))
+    }
 
     if (!response.ok) {
       const errorText = await response.text()


### PR DESCRIPTION
## Summary
- forward auth token from cookies in claims API route
- include credentials and handle unauthorized responses

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689b92a82bac832c811252a611c1d25e