### PR TITLE
refactor: use server api base url in damages init

### DIFF
--- a/app/api/damages/init/route.ts
+++ b/app/api/damages/init/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost:5200/api"
+const API_BASE_URL = process.env.API_BASE_URL || "https://localhost:5200/api"
+
+if (API_BASE_URL.startsWith("/api")) {
+  console.error("API_BASE_URL is misconfigured. It should be an absolute URL to the backend and not begin with '/api'.")
+  throw new Error("Invalid API_BASE_URL configuration")
+}
 
 export async function POST() {
   try {
@@ -17,7 +22,7 @@ export async function POST() {
     }
 
     const data = await response.json()
-    return NextResponse.json(data)
+    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Initialize damage API error:", error)
     return NextResponse.json({ error: "Failed to initialize damage" }, { status: 500 })


### PR DESCRIPTION
## Summary
- use server-only API_BASE_URL with fallback to backend URL
- guard against misconfigured base URLs that point to internal `/api`
- forward backend initialization response and status

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1)*
- `pnpm test` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_689b99eb6330832c89596b4446b9db0e