### PR TITLE
Include credentials with API fetch requests

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -96,7 +96,10 @@ export default function ClaimPage() {
       setIsLoading(true)
       setLoadError(null)
 
-      const response = await fetch(`/api/claims/${claimId}`)
+      const response = await fetch(`/api/claims/${claimId}`, {
+        method: "GET",
+        credentials: "include",
+      })
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`)
       }

--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -106,7 +106,10 @@ export default function EditClaimPage() {
       setLoadError(null)
 
       // Direct API call instead of using the hook to avoid loops
-      const response = await fetch(`/api/claims/${id}`)
+      const response = await fetch(`/api/claims/${id}`, {
+        method: "GET",
+        credentials: "include",
+      })
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`)
       }

--- a/app/claims/[id]/view/page.tsx
+++ b/app/claims/[id]/view/page.tsx
@@ -115,7 +115,10 @@ export default function ViewClaimPage() {
       setIsLoading(true)
       setLoadError(null)
 
-      const response = await fetch(`/api/claims/${id}`)
+      const response = await fetch(`/api/claims/${id}`, {
+        method: "GET",
+        credentials: "include",
+      })
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`)
       }
@@ -145,7 +148,10 @@ export default function ViewClaimPage() {
 
   const loadRepairSchedules = useCallback(async () => {
     try {
-      const response = await fetch(`/api/repair-schedules?eventId=${id}`)
+      const response = await fetch(`/api/repair-schedules?eventId=${id}`, {
+        method: "GET",
+        credentials: "include",
+      })
       if (response.ok) {
         const data = await response.json()
         setRepairSchedules(data)
@@ -157,7 +163,10 @@ export default function ViewClaimPage() {
 
   const loadRepairDetails = useCallback(async () => {
     try {
-      const response = await fetch(`/api/repair-details?eventId=${id}`)
+      const response = await fetch(`/api/repair-details?eventId=${id}`, {
+        method: "GET",
+        credentials: "include",
+      })
       if (response.ok) {
         const data = await response.json()
         setRepairDetails(data)
@@ -221,6 +230,7 @@ export default function ViewClaimPage() {
 
       const response = await fetch("/api/repair-schedules", {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
         },
@@ -255,6 +265,7 @@ export default function ViewClaimPage() {
     try {
       const response = await fetch("/api/repair-details", {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
         },

--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -285,6 +285,7 @@ export default function NewClaimPage() {
       for (const schedule of repairSchedules) {
         const response = await fetch("/api/repair-schedules", {
           method: "POST",
+          credentials: "include",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ ...schedule, claimId: currentClaimId }),
         })
@@ -299,6 +300,7 @@ export default function NewClaimPage() {
       for (const detail of repairDetails) {
         const response = await fetch("/api/repair-details", {
           method: "POST",
+          credentials: "include",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ ...detail, claimId: currentClaimId }),
         })
@@ -324,12 +326,18 @@ export default function NewClaimPage() {
     } catch (error) {
       // rollback
       for (const id of savedDetailIds) {
-        await fetch(`/api/repair-details/${id}`, { method: "DELETE" }).catch(
+        await fetch(`/api/repair-details/${id}`, {
+          method: "DELETE",
+          credentials: "include",
+        }).catch(
           () => {},
         )
       }
       for (const id of savedScheduleIds) {
-        await fetch(`/api/repair-schedules/${id}`, { method: "DELETE" }).catch(
+        await fetch(`/api/repair-schedules/${id}`, {
+          method: "DELETE",
+          credentials: "include",
+        }).catch(
           () => {},
         )
       }

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -18,6 +18,7 @@ export default function ForgotPasswordPage() {
     try {
       const res = await fetch("/api/auth/forgot-password", {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
         },

--- a/app/reset-password/[token]/page.tsx
+++ b/app/reset-password/[token]/page.tsx
@@ -22,6 +22,7 @@ export default function ResetPasswordPage() {
     try {
       const res = await fetch("/api/auth/reset-password", {
         method: "POST",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
         },

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -261,7 +261,13 @@ export const ClaimMainContent = ({
   const loadRiskTypes = async () => {
     setLoadingRiskTypes(true)
     try {
-      const response = await fetch(`/api/dictionaries/risk-types?claimObjectTypeId=${claimObjectType}`)
+      const response = await fetch(
+        `/api/dictionaries/risk-types?claimObjectTypeId=${claimObjectType}`,
+        {
+          method: "GET",
+          credentials: "include",
+        },
+      )
       if (response.ok) {
         const data = await response.json()
         // Map data according to your database structure
@@ -313,7 +319,10 @@ export const ClaimMainContent = ({
   const loadClaimStatuses = async () => {
     setLoadingStatuses(true)
     try {
-      const response = await fetch("/api/dictionaries/claim-statuses")
+      const response = await fetch("/api/dictionaries/claim-statuses", {
+        method: "GET",
+        credentials: "include",
+      })
       if (response.ok) {
         const data = await response.json()
         setClaimStatuses(data.items ?? [])
@@ -347,7 +356,10 @@ export const ClaimMainContent = ({
   const loadCaseHandlers = async () => {
     setLoadingHandlers(true)
     try {
-      const response = await fetch("/api/dictionaries/case-handlers")
+      const response = await fetch("/api/dictionaries/case-handlers", {
+        method: "GET",
+        credentials: "include",
+      })
       if (response.ok) {
         const data = await response.json()
         setCaseHandlers(data.items ?? [])

--- a/components/claim-form/client-claims-section.tsx
+++ b/components/claim-form/client-claims-section.tsx
@@ -358,7 +358,10 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
     if (!claim.document) return
 
     try {
-      const response = await fetch(`/api/client-claims/${claim.id}/preview`)
+      const response = await fetch(`/api/client-claims/${claim.id}/preview`, {
+        method: "GET",
+        credentials: "include",
+      })
       const blob = await response.blob()
       const url = URL.createObjectURL(blob)
 
@@ -385,7 +388,10 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
     if (!claim.document) return
 
     try {
-      const response = await fetch(`/api/client-claims/${claim.id}/download`)
+      const response = await fetch(`/api/client-claims/${claim.id}/download`, {
+        method: "GET",
+        credentials: "include",
+      })
       const blob = await response.blob()
       const url = URL.createObjectURL(blob)
 

--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -324,7 +324,10 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
     }
 
     try {
-      const response = await fetch(`/api/decisions/${decision.id}/download`)
+      const response = await fetch(`/api/decisions/${decision.id}/download`, {
+        method: "GET",
+        credentials: "include",
+      })
       if (response.ok) {
         const blob = await response.blob()
         const url = window.URL.createObjectURL(blob)
@@ -359,7 +362,10 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
     }
 
     try {
-      const response = await fetch(`/api/decisions/${decision.id}/preview`)
+      const response = await fetch(`/api/decisions/${decision.id}/preview`, {
+        method: "GET",
+        credentials: "include",
+      })
       if (response.ok) {
         const blob = await response.blob()
         const url = window.URL.createObjectURL(blob)

--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -169,6 +169,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
               formDataFile.append('uploadedBy', 'Current User')
               await fetch('/api/documents/upload', {
                 method: 'POST',
+                credentials: 'include',
                 body: formDataFile,
               })
             })

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -155,7 +155,10 @@ export const DocumentsSection = ({
     setLoading(true)
     try {
       console.log("Loading documents for eventId:", eventId)
-      const response = await fetch(`/api/documents?eventId=${eventId}`)
+      const response = await fetch(`/api/documents?eventId=${eventId}`, {
+        method: "GET",
+        credentials: "include",
+      })
 
       if (response.status === 404) {
         setDocuments([])
@@ -311,6 +314,7 @@ export const DocumentsSection = ({
         console.log(`Making upload request for ${file.name}...`)
         const response = await fetch("/api/documents/upload", {
           method: "POST",
+          credentials: "include",
           body: formData,
         })
 
@@ -485,6 +489,7 @@ export const DocumentsSection = ({
     try {
       const response = await fetch(`/api/documents/${documentId}`, {
         method: "DELETE",
+        credentials: "include",
       })
 
       if (response.ok) {
@@ -521,6 +526,7 @@ export const DocumentsSection = ({
     try {
       const response = await fetch(`/api/documents/${documentId}`, {
         method: "PUT",
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
         },
@@ -548,6 +554,7 @@ export const DocumentsSection = ({
 
       const response = await fetch(`/api/documents/${documentId}/generate-description`, {
         method: "POST",
+        credentials: "include",
       })
 
       if (response.ok) {
@@ -615,7 +622,10 @@ export const DocumentsSection = ({
       const zip = new JSZip()
 
       for (const document of documentsForCategory) {
-        const response = await fetch(document.downloadUrl)
+        const response = await fetch(document.downloadUrl, {
+          method: "GET",
+          credentials: "include",
+        })
         const blob = await response.blob()
         zip.file(document.originalFileName, blob)
       }
@@ -660,7 +670,10 @@ export const DocumentsSection = ({
       const zip = new JSZip()
 
       for (const document of documentsForCategory) {
-        const response = await fetch(document.downloadUrl)
+        const response = await fetch(document.downloadUrl, {
+          method: "GET",
+          credentials: "include",
+        })
         const blob = await response.blob()
         zip.file(document.originalFileName, blob)
       }

--- a/components/ui/dependent-select.tsx
+++ b/components/ui/dependent-select.tsx
@@ -43,7 +43,10 @@ export function DependentSelect({
 
       try {
         const url = dependsOn ? `${apiUrl}?dependsOn=${dependsOn}` : apiUrl
-        const response = await fetch(url)
+        const response = await fetch(url, {
+          method: "GET",
+          credentials: "include",
+        })
 
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`)

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -35,7 +35,10 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             url.searchParams.set("sortable", "true")
           }
 
-          const response = await fetch(url.toString())
+          const response = await fetch(url.toString(), {
+            method: "GET",
+            credentials: "include",
+          })
           if (response.ok) {
             const data = await response.json()
             let fetchedOptions = Array.isArray(data) ? data : data.options || []

--- a/components/ui/searchable-select.tsx
+++ b/components/ui/searchable-select.tsx
@@ -39,7 +39,10 @@ export function SearchableSelect({
     const fetchOptions = async () => {
       setLoading(true)
       try {
-        const response = await fetch(apiEndpoint)
+        const response = await fetch(apiEndpoint, {
+          method: "GET",
+          credentials: "include",
+        })
         if (response.ok) {
           const data = await response.json()
           // Handle both array format and object format with options property

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -165,7 +165,10 @@ const DependentSelect = React.forwardRef<React.ElementRef<typeof SelectPrimitive
             url += `?${dependsOnParam}=${encodeURIComponent(dependsOn)}`
           }
 
-          const response = await fetch(url)
+          const response = await fetch(url, {
+            method: "GET",
+            credentials: "include",
+          })
 
           if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`)

--- a/hooks/use-damages.ts
+++ b/hooks/use-damages.ts
@@ -31,6 +31,7 @@ export function useDamages(eventId?: string) {
   const initDamage = useCallback(async (): Promise<DamageInit> => {
     const response = await fetch(API_ENDPOINTS.DAMAGES_INIT, {
       method: "POST",
+      credentials: "include",
     })
 
     if (!response.ok) {
@@ -50,6 +51,7 @@ export function useDamages(eventId?: string) {
 
       const response = await fetch(
         `${API_ENDPOINTS.DAMAGES}/event/${targetId}`,
+        { method: "GET", credentials: "include" },
       )
 
       if (!response.ok) {
@@ -70,10 +72,12 @@ export function useDamages(eventId?: string) {
 
       const response = await fetch(API_ENDPOINTS.DAMAGES, {
         method: "POST",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
-
-        body: JSON.stringify({ ...damage, eventId: (damage as any).eventId || eventId }),
-
+        body: JSON.stringify({
+          ...damage,
+          eventId: (damage as any).eventId || eventId,
+        }),
       })
 
       if (!response.ok) {
@@ -90,6 +94,7 @@ export function useDamages(eventId?: string) {
     async (id: string, damage: Partial<Damage>): Promise<void> => {
       const response = await fetch(`${API_ENDPOINTS.DAMAGES}/${id}`, {
         method: "PUT",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ ...damage, eventId }),
       })
@@ -105,6 +110,7 @@ export function useDamages(eventId?: string) {
   const deleteDamage = useCallback(async (id: string): Promise<void> => {
     const response = await fetch(`${API_ENDPOINTS.DAMAGES}/${id}`, {
       method: "DELETE",
+      credentials: "include",
     })
 
     if (!response.ok) {

--- a/lib/api/appeals.ts
+++ b/lib/api/appeals.ts
@@ -51,7 +51,10 @@ function ensureRequiredDates(data: { filingDate?: string }) {
 }
 
 export async function getAppeals(claimId: string): Promise<Appeal[]> {
-  const response = await fetch(`${API_BASE_URL}/appeals/event/${claimId}`);
+  const response = await fetch(`${API_BASE_URL}/appeals/event/${claimId}`, {
+    method: "GET",
+    credentials: "include",
+  });
   if (!response.ok) {
     throw new Error("Failed to fetch appeals");
   }
@@ -86,6 +89,7 @@ export async function createAppeal(
   }
   const response = await fetch(`${API_BASE_URL}/appeals`, {
     method: "POST",
+    credentials: "include",
     body: formData,
   });
   if (!response.ok) {
@@ -121,6 +125,7 @@ export async function updateAppeal(
   }
   const response = await fetch(`${API_BASE_URL}/appeals/${id}`, {
     method: "PUT",
+    credentials: "include",
     body: formData,
   });
   if (!response.ok) {
@@ -133,6 +138,7 @@ export async function updateAppeal(
 export async function deleteAppeal(id: string): Promise<void> {
   const response = await fetch(`${API_BASE_URL}/appeals/${id}`, {
     method: "DELETE",
+    credentials: "include",
   });
   if (!response.ok) {
     throw new Error("Failed to delete appeal");

--- a/lib/api/decisions.ts
+++ b/lib/api/decisions.ts
@@ -33,7 +33,10 @@ export type DecisionUpsert = z.infer<typeof decisionUpsertSchema> & {
 };
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, options);
+  const response = await fetch(`${API_BASE_URL}${url}`, {
+    credentials: "include",
+    ...options,
+  });
   const text = await response.text();
   const data = text ? JSON.parse(text) : undefined;
   if (!response.ok) {

--- a/lib/api/recourses.ts
+++ b/lib/api/recourses.ts
@@ -33,7 +33,10 @@ export type Recourse = z.infer<typeof recourseSchema>
 export type RecourseUpsert = z.infer<typeof recourseUpsertSchema>
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, options)
+  const response = await fetch(`${API_BASE_URL}${url}`, {
+    credentials: "include",
+    ...options,
+  })
   const text = await response.text()
   const data = text ? JSON.parse(text) : undefined
   if (!response.ok) {
@@ -79,7 +82,10 @@ export async function deleteRecourse(id: string): Promise<void> {
 }
 
 export async function downloadRecourseDocument(id: string): Promise<Blob> {
-  const response = await fetch(`${API_BASE_URL}/recourses/${id}/download`)
+  const response = await fetch(`${API_BASE_URL}/recourses/${id}/download`, {
+    method: "GET",
+    credentials: "include",
+  })
   if (!response.ok) {
     throw new Error("Failed to download document")
   }
@@ -87,7 +93,10 @@ export async function downloadRecourseDocument(id: string): Promise<Blob> {
 }
 
 export async function previewRecourseDocument(id: string): Promise<Blob> {
-  const response = await fetch(`${API_BASE_URL}/recourses/${id}/preview`)
+  const response = await fetch(`${API_BASE_URL}/recourses/${id}/preview`, {
+    method: "GET",
+    credentials: "include",
+  })
   if (!response.ok) {
     throw new Error("Failed to preview document")
   }

--- a/lib/api/repair-details.ts
+++ b/lib/api/repair-details.ts
@@ -43,6 +43,7 @@ export type RepairDetailUpsert = z.infer<typeof repairDetailUpsertSchema>;
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${url}`, {
+    credentials: "include",
     headers: { "Content-Type": "application/json" },
     ...options,
   });

--- a/lib/api/repair-schedules.ts
+++ b/lib/api/repair-schedules.ts
@@ -16,7 +16,11 @@ function ensureRequired(data: { vehicleFleetNumber?: string; vehicleRegistration
 
 export async function getRepairSchedules(eventId: string) {
   const url = eventId ? `${BASE_URL}?eventId=${eventId}` : BASE_URL
-  const response = await fetch(url, { cache: 'no-store' })
+  const response = await fetch(url, {
+    method: 'GET',
+    credentials: 'include',
+    cache: 'no-store',
+  })
   if (!response.ok) {
     throw new Error('Failed to fetch repair schedules')
   }
@@ -27,6 +31,7 @@ export async function createRepairSchedule(data: RepairSchedulePayload) {
   ensureRequired(data)
   const response = await fetch(BASE_URL, {
     method: 'POST',
+    credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   })
@@ -48,6 +53,7 @@ export async function updateRepairSchedule(id: string, data: Partial<RepairSched
   }
   const response = await fetch(`${BASE_URL}/${id}`, {
     method: 'PUT',
+    credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   })
@@ -58,7 +64,10 @@ export async function updateRepairSchedule(id: string, data: Partial<RepairSched
 }
 
 export async function deleteRepairSchedule(id: string) {
-  const response = await fetch(`${BASE_URL}/${id}`, { method: 'DELETE' })
+  const response = await fetch(`${BASE_URL}/${id}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  })
   if (!response.ok) {
     throw new Error('Failed to delete repair schedule')
   }

--- a/lib/api/settlements.ts
+++ b/lib/api/settlements.ts
@@ -30,7 +30,10 @@ export type Settlement = z.infer<typeof settlementSchema>;
 export type SettlementUpsert = z.infer<typeof settlementUpsertSchema>;
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, options);
+  const response = await fetch(`${API_BASE_URL}${url}`, {
+    credentials: "include",
+    ...options,
+  });
   const text = await response.text();
   const data = text ? JSON.parse(text) : undefined;
   if (!response.ok) {

--- a/lib/dictionary-service.ts
+++ b/lib/dictionary-service.ts
@@ -19,7 +19,10 @@ class DictionaryService {
   private readonly CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
 
   private async fetchFromAPI(endpoint: string): Promise<DictionaryItem[]> {
-    const response = await fetch(`/api/dictionaries/${endpoint}`)
+    const response = await fetch(`/api/dictionaries/${endpoint}`, {
+      method: "GET",
+      credentials: "include",
+    })
     if (!response.ok) {
       throw new Error(`Failed to fetch ${endpoint}`)
     }

--- a/lib/email-service.ts
+++ b/lib/email-service.ts
@@ -39,7 +39,10 @@ class EmailService {
 
   async getAllEmails(): Promise<EmailDto[]> {
     try {
-      const response = await fetch(this.apiUrl)
+      const response = await fetch(this.apiUrl, {
+        method: "GET",
+        credentials: "include",
+      })
       if (!response.ok) throw new Error("Failed to fetch emails")
       return await response.json()
     } catch (error) {
@@ -50,7 +53,10 @@ class EmailService {
 
   async getEmailById(id: number): Promise<EmailDto | undefined> {
     try {
-      const response = await fetch(`${this.apiUrl}/${id}`)
+      const response = await fetch(`${this.apiUrl}/${id}`, {
+        method: "GET",
+        credentials: "include",
+      })
       if (!response.ok) throw new Error("Failed to fetch email")
       return await response.json()
     } catch (error) {
@@ -63,6 +69,7 @@ class EmailService {
     try {
       const response = await fetch(`${this.apiUrl}/${emailId}`, {
         method: "DELETE",
+        credentials: "include",
       })
       return response.ok
     } catch (error) {
@@ -78,7 +85,10 @@ class EmailService {
     }
 
     try {
-      const response = await fetch(`${this.apiUrl}/folder/${folder}`)
+      const response = await fetch(`${this.apiUrl}/folder/${folder}`, {
+        method: "GET",
+        credentials: "include",
+      })
       if (!response.ok) throw new Error("Failed to fetch emails by folder")
       return await response.json()
     } catch (error) {
@@ -94,7 +104,13 @@ class EmailService {
     }
 
     try {
-      const response = await fetch(`${this.apiUrl}/folder/${folder}/assigned/${claimId}`)
+      const response = await fetch(
+        `${this.apiUrl}/folder/${folder}/assigned/${claimId}`,
+        {
+          method: "GET",
+          credentials: "include",
+        },
+      )
       if (!response.ok) throw new Error("Failed to fetch assigned emails")
       return await response.json()
     } catch (error) {
@@ -105,7 +121,10 @@ class EmailService {
 
   async getUnassignedEmails(): Promise<EmailDto[]> {
     try {
-      const response = await fetch(`${this.apiUrl}/unassigned`)
+      const response = await fetch(`${this.apiUrl}/unassigned`, {
+        method: "GET",
+        credentials: "include",
+      })
       if (!response.ok) throw new Error("Failed to fetch unassigned emails")
       return await response.json()
     } catch (error) {
@@ -116,7 +135,10 @@ class EmailService {
 
   async getEmailsByClaimId(claimId: string): Promise<EmailDto[]> {
     try {
-      const response = await fetch(`${this.apiUrl}/by-claim/${claimId}`)
+      const response = await fetch(`${this.apiUrl}/by-claim/${claimId}`, {
+        method: "GET",
+        credentials: "include",
+      })
       if (!response.ok) throw new Error("Failed to fetch emails by claim")
       return await response.json()
     } catch (error) {
@@ -129,6 +151,7 @@ class EmailService {
     try {
       const response = await fetch(`${this.apiUrl}/${emailId}/read`, {
         method: "POST",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
       })
       return response.ok
@@ -160,6 +183,7 @@ class EmailService {
 
       const response = await fetch(url, {
         method: "POST",
+        credentials: "include",
         body: formData,
       })
 
@@ -172,7 +196,10 @@ class EmailService {
 
   async downloadAttachment(attachmentId: number): Promise<Blob | undefined> {
     try {
-      const response = await fetch(`${this.apiUrl}/attachment/${attachmentId}`)
+      const response = await fetch(`${this.apiUrl}/attachment/${attachmentId}`, {
+        method: "GET",
+        credentials: "include",
+      })
       if (!response.ok) throw new Error("Failed to download attachment")
       return await response.blob()
     } catch (error) {
@@ -185,6 +212,7 @@ class EmailService {
     try {
       const response = await fetch(`${this.apiUrl}/assign-to-claim`, {
         method: "POST",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ emailId, claimId }),
       })

--- a/lib/vehicle-types.ts
+++ b/lib/vehicle-types.ts
@@ -13,7 +13,10 @@ export const vehicleTypeService = {
       const url = `${API_BASE_URL}${params.toString() ? `?${params.toString()}` : ""}`
       console.log("Fetching vehicle types from:", url)
 
-      const response = await fetch(url)
+      const response = await fetch(url, {
+        method: "GET",
+        credentials: "include",
+      })
 
 
       if (!response.ok) {
@@ -36,7 +39,10 @@ export const vehicleTypeService = {
   async getVehicleTypeById(id: string): Promise<VehicleType | null> {
     try {
 
-      const response = await fetch(`${API_BASE_URL}/${id}`)
+      const response = await fetch(`${API_BASE_URL}/${id}`, {
+        method: "GET",
+        credentials: "include",
+      })
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`)


### PR DESCRIPTION
## Summary
- Ensure frontend and utility fetch calls send cookies by adding `credentials: "include"`
- Support cookie-authenticated API access across claim, document, email, and dictionary flows
- Confirm backend CORS policy allows credentialed requests from `http://localhost:3000`

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*

------
https://chatgpt.com/codex/tasks/task_e_689ba896aff0832c9e1a7dac088c44cb