### PR TITLE
Fix syntax errors in edit claim page

### DIFF
--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -155,10 +155,9 @@ export default function EditClaimPage() {
           title: "Szkoda zaktualizowana",
           description: `Szkoda ${updatedClaim.spartaNumber || updatedClaim.claimNumber} została pomyślnie zaktualizowana.`,
         })
-
-
-      if (exitAfterSave) {
-        router.push("/claims")
+        if (exitAfterSave) {
+          router.push("/claims")
+        }
       }
     } catch (error) {
       console.error("Error updating claim:", error)


### PR DESCRIPTION
## Summary
- fix missing braces and reorder exit-after-save logic in edit claim page

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: tests 1 fail 1)*

------
https://chatgpt.com/codex/tasks/task_e_689bac916180832caebd688310114bbe