### PR TITLE
feat: add API base URL fallbacks

### DIFF
--- a/lib/api/decisions.ts
+++ b/lib/api/decisions.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "/api";
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  process.env.API_BASE_URL ||
+  "https://claim-work-backend.azurewebsites.net/api";
 
 export const decisionSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
## Summary
- add environment and default fallbacks for API base URL in decisions API helper
- ensure requests use the configured base URL and include credentials

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689bb2eebf1c832cb377114bec9291b9