### PR TITLE
Fix closing curly brace in repair details map

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -1249,7 +1249,7 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
                                 )}
                               </div>
                             </div>
-                            ))
+                            ))}
                           </div>
                         )}
 


### PR DESCRIPTION
## Summary
- fix missing closing curly brace in claim main content repair details snippet

## Testing
- `pnpm test` (fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)
- `pnpm lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_689bb8ccecb0832cb027ebf22a634946