### PR TITLE
chore: standardize API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Base URL for backend API used by both the server and browser
-# NEXT_PUBLIC_API_URL=http://localhost:5200/api
+NEXT_PUBLIC_API_URL=http://localhost:5200/api
 
 # Optional: number of times to retry requests to the backend
 # FETCH_RETRY_COUNT=1

--- a/app/api/claim-statuses/route.ts
+++ b/app/api/claim-statuses/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {

--- a/app/api/claims/route.ts
+++ b/app/api/claims/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/contract-types/route.ts
+++ b/app/api/contract-types/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {

--- a/app/api/countries/route.ts
+++ b/app/api/countries/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {

--- a/app/api/currencies/route.ts
+++ b/app/api/currencies/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {

--- a/app/api/damages/[id]/route.ts
+++ b/app/api/damages/[id]/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {

--- a/app/api/damages/event/[eventId]/route.ts
+++ b/app/api/damages/event/[eventId]/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(request: NextRequest, { params }: { params: { eventId: string } }) {
   try {

--- a/app/api/damages/init/route.ts
+++ b/app/api/damages/init/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "https://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 if (API_BASE_URL.startsWith("/api")) {
   console.error("API_BASE_URL is misconfigured. It should be an absolute URL to the backend and not begin with '/api'.")

--- a/app/api/damages/route.ts
+++ b/app/api/damages/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {

--- a/app/api/damages/save/route.ts
+++ b/app/api/damages/save/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/decisions/[id]/download/route.ts
+++ b/app/api/decisions/[id]/download/route.ts
@@ -5,7 +5,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
     const id = params.id
 
     // TODO: Replace with actual file download from backend
-    // const response = await fetch(`${process.env.API_BASE_URL}/api/decisions/${id}/download`)
+    // const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/decisions/${id}/download`)
     //
     // if (!response.ok) {
     //   throw new Error('Failed to download file')

--- a/app/api/decisions/[id]/preview/route.ts
+++ b/app/api/decisions/[id]/preview/route.ts
@@ -5,7 +5,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
     const id = params.id
 
     // TODO: Replace with actual file preview from backend
-    // const response = await fetch(`${process.env.API_BASE_URL}/api/decisions/${id}/preview`)
+    // const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/decisions/${id}/preview`)
     //
     // if (!response.ok) {
     //   throw new Error('Failed to preview file')

--- a/app/api/document-statuses/route.ts
+++ b/app/api/document-statuses/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {

--- a/app/api/event-statuses/route.ts
+++ b/app/api/event-statuses/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {

--- a/app/api/payment-methods/route.ts
+++ b/app/api/payment-methods/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {

--- a/app/api/priorities/route.ts
+++ b/app/api/priorities/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {

--- a/app/api/settlements/route.ts
+++ b/app/api/settlements/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 const RETRY_COUNT = Number(process.env.FETCH_RETRY_COUNT || "1")
 
 async function fetchWithRetry(

--- a/app/api/vehicle-types/route.ts
+++ b/app/api/vehicle-types/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:5200/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET() {
   try {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,8 +1,5 @@
 // API Configuration
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  process.env.API_BASE_URL ||
-  "https://claim-work-backend.azurewebsites.net/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 // Types for API responses
 export interface EventListItemDto {

--- a/lib/api/appeals.ts
+++ b/lib/api/appeals.ts
@@ -1,9 +1,6 @@
 import { AppealDto } from "../api";
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  process.env.API_BASE_URL ||
-  "https://claim-work-backend.azurewebsites.net/api";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api";
 
 export interface Appeal {
   id: string;

--- a/lib/api/decisions.ts
+++ b/lib/api/decisions.ts
@@ -1,9 +1,6 @@
 import { z } from "zod";
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  process.env.API_BASE_URL ||
-  "https://claim-work-backend.azurewebsites.net/api";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api";
 
 export const decisionSchema = z.object({
   id: z.string(),

--- a/lib/api/recourses.ts
+++ b/lib/api/recourses.ts
@@ -1,9 +1,6 @@
 import { z } from "zod"
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  process.env.API_BASE_URL ||
-  "https://claim-work-backend.azurewebsites.net/api"
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 const recourseSchema = z.object({
   id: z.string(),

--- a/lib/api/repair-details.ts
+++ b/lib/api/repair-details.ts
@@ -1,9 +1,6 @@
 import { z } from "zod";
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  process.env.API_BASE_URL ||
-  "https://claim-work-backend.azurewebsites.net/api";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api";
 
 const repairDetailSchema = z.object({
   id: z.string(),

--- a/lib/api/settlements.ts
+++ b/lib/api/settlements.ts
@@ -1,9 +1,6 @@
 import { z } from "zod";
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  process.env.API_BASE_URL ||
-  "https://claim-work-backend.azurewebsites.net/api";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api";
 
 const settlementSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_API_URL` for all frontend API calls
- document backend URL in `.env.example`

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: tests 1, fail 1)*

------
https://chatgpt.com/codex/tasks/task_e_689bbea8a304832c9328fb8c2b27f2bf