### PR TITLE
Validate API URL at runtime

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Base URL for backend API used by both the server and browser
-# NEXT_PUBLIC_API_URL=http://localhost:5200/api
+NEXT_PUBLIC_API_URL=http://localhost:5200/api
 
 # Optional: number of times to retry requests to the backend
 # FETCH_RETRY_COUNT=1

--- a/lib/server-fetch.ts
+++ b/lib/server-fetch.ts
@@ -1,0 +1,14 @@
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+
+if (!API_BASE_URL) {
+  throw new Error(
+    'NEXT_PUBLIC_API_URL is not defined. Please set NEXT_PUBLIC_API_URL in your environment variables.'
+  );
+}
+
+export async function serverFetch(path: string, options: RequestInit = {}) {
+  return fetch(`${API_BASE_URL}${path}`, {
+    credentials: 'include',
+    ...options,
+  });
+}


### PR DESCRIPTION
## Summary
- define NEXT_PUBLIC_API_URL in `.env`
- add server fetch helper that throws when NEXT_PUBLIC_API_URL is missing

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)*

------
https://chatgpt.com/codex/tasks/task_e_689c4e102dc4832c9b210cb6a161ebe5