### PR TITLE
feat: add apiFetch helper

### DIFF
--- a/app/api/countries/route.ts
+++ b/app/api/countries/route.ts
@@ -1,10 +1,9 @@
-import { NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server"
+import { apiFetch } from "@/lib/api-fetch"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
-
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${API_BASE_URL}/dictionaries/countries`, {
+    const response = await apiFetch(request, `/dictionaries/countries`, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/lib/api-fetch.ts
+++ b/lib/api-fetch.ts
@@ -1,0 +1,20 @@
+import { NextRequest } from "next/server"
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
+
+export async function apiFetch(
+  request: NextRequest,
+  endpoint: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const url = `${API_BASE_URL}${endpoint}`
+  const headers = new Headers(init.headers)
+  const cookie = request.headers.get("cookie")
+  if (cookie) {
+    headers.set("cookie", cookie)
+  }
+  return fetch(url, {
+    ...init,
+    headers,
+  })
+}


### PR DESCRIPTION
## Summary
- add reusable apiFetch helper to centralize base URL and cookie forwarding
- refactor countries route to use apiFetch instead of manual fetch

## Testing
- `pnpm lint` *(fails: prompts for Next.js ESLint configuration)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*


------
https://chatgpt.com/codex/tasks/task_e_689c4e143050832ca4acd324b7137412