### PR TITLE
refactor: use internal API routes

### DIFF
--- a/lib/api/appeals.ts
+++ b/lib/api/appeals.ts
@@ -1,7 +1,5 @@
 import { AppealDto } from "../api";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api";
-
 export interface Appeal {
   id: string;
   filingDate: string;
@@ -48,7 +46,7 @@ function ensureRequiredDates(data: { filingDate?: string }) {
 }
 
 export async function getAppeals(claimId: string): Promise<Appeal[]> {
-  const response = await fetch(`${API_BASE_URL}/appeals/event/${claimId}`, {
+  const response = await fetch(`/api/appeals/event/${claimId}`, {
     method: "GET",
     credentials: "include",
   });
@@ -84,7 +82,7 @@ export async function createAppeal(
   if (appeal.document) {
     formData.append("Document", appeal.document);
   }
-  const response = await fetch(`${API_BASE_URL}/appeals`, {
+  const response = await fetch(`/api/appeals`, {
     method: "POST",
     credentials: "include",
     body: formData,
@@ -120,7 +118,7 @@ export async function updateAppeal(
   if (appeal.document) {
     formData.append("Document", appeal.document);
   }
-  const response = await fetch(`${API_BASE_URL}/appeals/${id}`, {
+  const response = await fetch(`/api/appeals/${id}`, {
     method: "PUT",
     credentials: "include",
     body: formData,
@@ -133,7 +131,7 @@ export async function updateAppeal(
 }
 
 export async function deleteAppeal(id: string): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}/appeals/${id}`, {
+  const response = await fetch(`/api/appeals/${id}`, {
     method: "DELETE",
     credentials: "include",
   });

--- a/lib/api/decisions.ts
+++ b/lib/api/decisions.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api";
-
 export const decisionSchema = z.object({
   id: z.string(),
   eventId: z.string(),
@@ -33,7 +31,7 @@ export type DecisionUpsert = z.infer<typeof decisionUpsertSchema> & {
 };
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
+  const response = await fetch(`/api${url}`, {
     credentials: "include",
     ...options,
   });

--- a/lib/api/recourses.ts
+++ b/lib/api/recourses.ts
@@ -1,7 +1,5 @@
 import { z } from "zod"
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
-
 const recourseSchema = z.object({
   id: z.string(),
   eventId: z.string(),
@@ -30,7 +28,7 @@ export type Recourse = z.infer<typeof recourseSchema>
 export type RecourseUpsert = z.infer<typeof recourseUpsertSchema>
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
+  const response = await fetch(`/api${url}`, {
     credentials: "include",
     ...options,
   })
@@ -79,7 +77,7 @@ export async function deleteRecourse(id: string): Promise<void> {
 }
 
 export async function downloadRecourseDocument(id: string): Promise<Blob> {
-  const response = await fetch(`${API_BASE_URL}/recourses/${id}/download`, {
+  const response = await fetch(`/api/recourses/${id}/download`, {
     method: "GET",
     credentials: "include",
   })
@@ -90,7 +88,7 @@ export async function downloadRecourseDocument(id: string): Promise<Blob> {
 }
 
 export async function previewRecourseDocument(id: string): Promise<Blob> {
-  const response = await fetch(`${API_BASE_URL}/recourses/${id}/preview`, {
+  const response = await fetch(`/api/recourses/${id}/preview`, {
     method: "GET",
     credentials: "include",
   })

--- a/lib/api/repair-details.ts
+++ b/lib/api/repair-details.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api";
-
 const repairDetailSchema = z.object({
   id: z.string(),
   eventId: z.string(),
@@ -39,7 +37,7 @@ export type RepairDetail = z.infer<typeof repairDetailSchema>;
 export type RepairDetailUpsert = z.infer<typeof repairDetailUpsertSchema>;
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
+  const response = await fetch(`/api${url}`, {
     credentials: "include",
     headers: { "Content-Type": "application/json" },
     ...options,

--- a/lib/api/repair-schedules.ts
+++ b/lib/api/repair-schedules.ts
@@ -6,8 +6,6 @@ export interface RepairSchedulePayload {
   [key: string]: any
 }
 
-const BASE_URL = '/api/repair-schedules'
-
 function ensureRequired(data: { vehicleFleetNumber?: string; vehicleRegistration?: string; damageDate?: string }) {
   if (!data.vehicleFleetNumber || !data.vehicleRegistration || !data.damageDate) {
     throw new Error('vehicleFleetNumber, vehicleRegistration and damageDate are required')
@@ -15,7 +13,9 @@ function ensureRequired(data: { vehicleFleetNumber?: string; vehicleRegistration
 }
 
 export async function getRepairSchedules(eventId: string) {
-  const url = eventId ? `${BASE_URL}?eventId=${eventId}` : BASE_URL
+  const url = eventId
+    ? `/api/repair-schedules?eventId=${eventId}`
+    : '/api/repair-schedules'
   const response = await fetch(url, {
     method: 'GET',
     credentials: 'include',
@@ -29,7 +29,7 @@ export async function getRepairSchedules(eventId: string) {
 
 export async function createRepairSchedule(data: RepairSchedulePayload) {
   ensureRequired(data)
-  const response = await fetch(BASE_URL, {
+  const response = await fetch('/api/repair-schedules', {
     method: 'POST',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
@@ -51,7 +51,7 @@ export async function updateRepairSchedule(id: string, data: Partial<RepairSched
   if ('damageDate' in data && !data.damageDate) {
     throw new Error('damageDate is required')
   }
-  const response = await fetch(`${BASE_URL}/${id}`, {
+  const response = await fetch(`/api/repair-schedules/${id}`, {
     method: 'PUT',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
@@ -64,7 +64,7 @@ export async function updateRepairSchedule(id: string, data: Partial<RepairSched
 }
 
 export async function deleteRepairSchedule(id: string) {
-  const response = await fetch(`${BASE_URL}/${id}`, {
+  const response = await fetch(`/api/repair-schedules/${id}`, {
     method: 'DELETE',
     credentials: 'include',
   })

--- a/lib/api/settlements.ts
+++ b/lib/api/settlements.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api";
-
 const settlementSchema = z.object({
   id: z.string(),
   eventId: z.string(),
@@ -27,7 +25,7 @@ export type Settlement = z.infer<typeof settlementSchema>;
 export type SettlementUpsert = z.infer<typeof settlementUpsertSchema>;
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
+  const response = await fetch(`/api${url}`, {
     credentials: "include",
     ...options,
   });


### PR DESCRIPTION
## Summary
- route appeals API calls through internal `/api` endpoints
- reuse Next.js proxy for decisions, recourses, repair details, schedules, and settlements APIs

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: tests 1, fail 1)*

------
https://chatgpt.com/codex/tasks/task_e_689c4e11cf60832c95f5d1fa2dbf2063