### PR TITLE
Use env API URL for document upload

### DIFF
--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -167,7 +167,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
               formDataFile.append('eventId', saved!.id.toString())
               formDataFile.append('category', file.categoryCode || mapCategoryNameToCode(file.category || 'Inne dokumenty'))
               formDataFile.append('uploadedBy', 'Current User')
-              await fetch('/api/documents/upload', {
+              await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents/upload`, {
                 method: 'POST',
                 credentials: 'include',
                 body: formDataFile,


### PR DESCRIPTION
## Summary
- point file upload requests to NEXT_PUBLIC_API_URL instead of hardcoded path

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c7ae0f4832c860c2aedae67ae8e