### PR TITLE
fix: update claim fetch URL to env API URL

### DIFF
--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -106,7 +106,7 @@ export default function EditClaimPage() {
       setLoadError(null)
 
       // Direct API call instead of using the hook to avoid loops
-      const response = await fetch(`/api/claims/${id}`, {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/claims/${id}`, {
         method: "GET",
         credentials: "include",
       })


### PR DESCRIPTION
## Summary
- use public API URL env var for claim fetch in edit page

## Testing
- `pnpm test` *(fails: Cannot require() ES Module ...)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c913c2c832ca91d243723f0f418