### PR TITLE
refactor: use env api url for repair endpoints

### DIFF
--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -283,7 +283,7 @@ export default function NewClaimPage() {
 
       // Save repair schedules sequentially
       for (const schedule of repairSchedules) {
-        const response = await fetch("/api/repair-schedules", {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/repair-schedules`, {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
@@ -298,7 +298,7 @@ export default function NewClaimPage() {
 
       // Save repair details sequentially
       for (const detail of repairDetails) {
-        const response = await fetch("/api/repair-details", {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/repair-details`, {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
@@ -326,7 +326,7 @@ export default function NewClaimPage() {
     } catch (error) {
       // rollback
       for (const id of savedDetailIds) {
-        await fetch(`/api/repair-details/${id}`, {
+        await fetch(`${process.env.NEXT_PUBLIC_API_URL}/repair-details/${id}`, {
           method: "DELETE",
           credentials: "include",
         }).catch(
@@ -334,7 +334,7 @@ export default function NewClaimPage() {
         )
       }
       for (const id of savedScheduleIds) {
-        await fetch(`/api/repair-schedules/${id}`, {
+        await fetch(`${process.env.NEXT_PUBLIC_API_URL}/repair-schedules/${id}`, {
           method: "DELETE",
           credentials: "include",
         }).catch(


### PR DESCRIPTION
## Summary
- refactor new claim page to call repair endpoints via `NEXT_PUBLIC_API_URL`

## Testing
- `pnpm lint app/claims/new/page.tsx` *(fails: Couldn't find any `pages` or `app` directory. Please create one under the project root)*
- `pnpm test` *(fails: Cannot require() ES Module app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c9a1450832cac5a6e175df044bc