### PR TITLE
Use NEXT_PUBLIC_API_URL for claim fetch

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -96,7 +96,7 @@ export default function ClaimPage() {
       setIsLoading(true)
       setLoadError(null)
 
-      const response = await fetch(`/api/claims/${claimId}`, {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/claims/${claimId}`, {
         method: "GET",
         credentials: "include",
       })


### PR DESCRIPTION
## Summary
- use NEXT_PUBLIC_API_URL when loading claim data on claims param page

## Testing
- `pnpm lint` *(fails: prompts for configuration)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c91194c832ca5313c9ade06a1b8