### PR TITLE
Use env API URL for reset password

### DIFF
--- a/app/reset-password/[token]/page.tsx
+++ b/app/reset-password/[token]/page.tsx
@@ -20,7 +20,7 @@ export default function ResetPasswordPage() {
     setError("")
 
     try {
-      const res = await fetch("/api/auth/reset-password", {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/reset-password`, {
         method: "POST",
         credentials: "include",
         headers: {


### PR DESCRIPTION
## Summary
- use public API URL env var for reset password endpoint

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c911118832cb4fccb5792a05b0c