### PR TITLE
Use env API URL for forgot password request

### DIFF
--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -16,7 +16,7 @@ export default function ForgotPasswordPage() {
     setError("")
 
     try {
-      const res = await fetch("/api/auth/forgot-password", {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/forgot-password`, {
         method: "POST",
         credentials: "include",
         headers: {


### PR DESCRIPTION
## Summary
- call the external API for password reset using `NEXT_PUBLIC_API_URL`

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c90f580832c8e19932027c346c0