### PR TITLE
feat: use api url for client claims

### DIFF
--- a/components/claim-form/client-claims-section.tsx
+++ b/components/claim-form/client-claims-section.tsx
@@ -358,10 +358,13 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
     if (!claim.document) return
 
     try {
-      const response = await fetch(`/api/client-claims/${claim.id}/preview`, {
-        method: "GET",
-        credentials: "include",
-      })
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/client-claims/${claim.id}/preview`,
+        {
+          method: "GET",
+          credentials: "include",
+        }
+      )
       const blob = await response.blob()
       const url = URL.createObjectURL(blob)
 
@@ -388,10 +391,13 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
     if (!claim.document) return
 
     try {
-      const response = await fetch(`/api/client-claims/${claim.id}/download`, {
-        method: "GET",
-        credentials: "include",
-      })
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/client-claims/${claim.id}/download`,
+        {
+          method: "GET",
+          credentials: "include",
+        }
+      )
       const blob = await response.blob()
       const url = URL.createObjectURL(blob)
 


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_API_URL` when fetching client claim previews and downloads

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c7bf2d0832c8c7b2915d3765539