### PR TITLE
refactor: use env API URL for decision file requests

### DIFF
--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -324,10 +324,13 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
     }
 
     try {
-      const response = await fetch(`/api/decisions/${decision.id}/download`, {
-        method: "GET",
-        credentials: "include",
-      })
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/decisions/${decision.id}/download`,
+        {
+          method: "GET",
+          credentials: "include",
+        },
+      )
       if (response.ok) {
         const blob = await response.blob()
         const url = window.URL.createObjectURL(blob)
@@ -362,10 +365,13 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
     }
 
     try {
-      const response = await fetch(`/api/decisions/${decision.id}/preview`, {
-        method: "GET",
-        credentials: "include",
-      })
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/decisions/${decision.id}/preview`,
+        {
+          method: "GET",
+          credentials: "include",
+        },
+      )
       if (response.ok) {
         const blob = await response.blob()
         const url = window.URL.createObjectURL(blob)


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_API_URL` for decision file downloads and previews

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*
- `pnpm test` *(fails: Error [ERR_REQUIRE_CYCLE_MODULE]: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c7a1398832cb2d1af527f81faac