### PR TITLE
refactor: use env API URL for document requests

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -155,7 +155,7 @@ export const DocumentsSection = ({
     setLoading(true)
     try {
       console.log("Loading documents for eventId:", eventId)
-      const response = await fetch(`/api/documents?eventId=${eventId}`, {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents?eventId=${eventId}`, {
         method: "GET",
         credentials: "include",
       })
@@ -312,7 +312,7 @@ export const DocumentsSection = ({
 
       try {
         console.log(`Making upload request for ${file.name}...`)
-        const response = await fetch("/api/documents/upload", {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents/upload`, {
           method: "POST",
           credentials: "include",
           body: formData,
@@ -487,7 +487,7 @@ export const DocumentsSection = ({
     }
 
     try {
-      const response = await fetch(`/api/documents/${documentId}`, {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents/${documentId}`, {
         method: "DELETE",
         credentials: "include",
       })
@@ -524,7 +524,7 @@ export const DocumentsSection = ({
     }
 
     try {
-      const response = await fetch(`/api/documents/${documentId}`, {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents/${documentId}`, {
         method: "PUT",
         credentials: "include",
         headers: {
@@ -552,7 +552,7 @@ export const DocumentsSection = ({
         description: `Rozpoczęto generowanie opisu dla pliku: ${document.originalFileName}`,
       })
 
-      const response = await fetch(`/api/documents/${documentId}/generate-description`, {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents/${documentId}/generate-description`, {
         method: "POST",
         credentials: "include",
       })


### PR DESCRIPTION
## Summary
- use `process.env.NEXT_PUBLIC_API_URL` for document loading
- use env-based API URL for document uploads, deletions, and description updates
- use env-based API URL for AI description generation

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c795194832c865848647596452c