### PR TITLE
Use API_BASE_URL for decision file endpoints

### DIFF
--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -18,6 +18,7 @@ import {
   updateDecision as apiUpdateDecision,
   deleteDecision as apiDeleteDecision,
 } from "@/lib/api/decisions"
+import { API_BASE_URL } from "@/lib/api"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -325,7 +326,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
 
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/decisions/${decision.id}/download`,
+        `${API_BASE_URL}/decisions/${decision.id}/download`,
         {
           method: "GET",
           credentials: "include",
@@ -366,7 +367,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
 
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/decisions/${decision.id}/preview`,
+        `${API_BASE_URL}/decisions/${decision.id}/preview`,
         {
           method: "GET",
           credentials: "include",


### PR DESCRIPTION
## Summary
- import API_BASE_URL in decision section component
- use API_BASE_URL for decision file download and preview requests

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(fails: requires interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689c64f2999c832c8c44e8f0f8ec9c97