### PR TITLE
refactor: centralize claim form api base url

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -47,6 +47,7 @@ import type { VehicleTypeSelectionEvent } from "@/types/vehicle-type"
 import { RepairScheduleSection } from "./repair-schedule-section"
 import { RepairDetailsSection } from "./repair-details-section"
 import type { RepairDetail } from "@/lib/repair-details-store"
+import { API_BASE_URL } from "@/lib/api"
 
 interface RiskType {
   value: string
@@ -202,7 +203,7 @@ export const ClaimMainContent = ({
     const loadRepairDetails = async () => {
       if (!eventId) return
       try {
-        const response = await fetch(`/api/repair-details?eventId=${eventId}`, {
+        const response = await fetch(`${API_BASE_URL}/repair-details?eventId=${eventId}`, {
           method: "GET",
           credentials: "include",
         })
@@ -296,7 +297,7 @@ export const ClaimMainContent = ({
     setLoadingRiskTypes(true)
     try {
       const response = await fetch(
-        `/api/dictionaries/risk-types?claimObjectTypeId=${claimObjectType}`,
+        `${API_BASE_URL}/dictionaries/risk-types?claimObjectTypeId=${claimObjectType}`,
         {
           method: "GET",
           credentials: "include",
@@ -353,7 +354,7 @@ export const ClaimMainContent = ({
   const loadClaimStatuses = async () => {
     setLoadingStatuses(true)
     try {
-      const response = await fetch("/api/dictionaries/claim-statuses", {
+      const response = await fetch(`${API_BASE_URL}/dictionaries/claim-statuses`, {
         method: "GET",
         credentials: "include",
       })
@@ -390,7 +391,7 @@ export const ClaimMainContent = ({
   const loadCaseHandlers = async () => {
     setLoadingHandlers(true)
     try {
-      const response = await fetch("/api/dictionaries/case-handlers", {
+      const response = await fetch(`${API_BASE_URL}/dictionaries/case-handlers`, {
         method: "GET",
         credentials: "include",
       })
@@ -1414,7 +1415,7 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
                       value={claimFormData.damageType || ""}
                       onValueChange={(value) => handleFormChange("damageType", value)}
                       placeholder="Wybierz rodzaj szkody..."
-                      apiUrl="/api/damage-types"
+                      apiUrl={`${API_BASE_URL}/damage-types`}
                       dependsOn={claimFormData.riskType}
                       disabled={!claimFormData.riskType}
                     />


### PR DESCRIPTION
## Summary
- import and use API_BASE_URL for claim form API calls
- update damage type dropdown to use API_BASE_URL

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)*

------
https://chatgpt.com/codex/tasks/task_e_689c64f0e568832caf72108f1c1e40c1