### PR TITLE
feat: surface recourse load errors

### DIFF
--- a/components/claim-form/recourse-section.tsx
+++ b/components/claim-form/recourse-section.tsx
@@ -36,6 +36,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 
 import {
   getRecourses as fetchRecourses,
@@ -59,6 +60,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
   const [recourses, setRecourses] = useState<Recourse[]>([])
   const [formLoading, setFormLoading] = useState(false)
   const [listLoading, setListLoading] = useState(false)
+  const [listError, setListError] = useState<string | null>(null)
   const [isFormVisible, setIsFormVisible] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [editingRecourseId, setEditingRecourseId] = useState<string | null>(null)
@@ -108,6 +110,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
 
   const loadRecourses = async () => {
     setListLoading(true)
+    setListError(null)
     try {
       const data = await fetchRecourses(eventId)
       setRecourses(data)
@@ -120,10 +123,15 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
       })
       setTotalRecourseAmounts(totals)
     } catch (error) {
-      console.error("Error loading recourses:", error)
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      console.error(
+        `Error loading recourses for event ${eventId}: ${errorMessage}`,
+        error,
+      )
+      setListError(errorMessage)
       toast({
         title: "Błąd",
-        description: "Nie udało się załadować regresów",
+        description: `Nie udało się załadować regresów: ${errorMessage}`,
         variant: "destructive",
       })
     } finally {
@@ -715,6 +723,13 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
               )}
             </div>
           </div>
+          {listError && (
+            <Alert variant="destructive" className="m-4">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Błąd</AlertTitle>
+              <AlertDescription>{listError}</AlertDescription>
+            </Alert>
+          )}
           <div className="overflow-x-auto">
             <table className="min-w-full">
               <thead>


### PR DESCRIPTION
## Summary
- log failing event id and error when recourse fetch fails
- include error message in toast
- show error banner above recourse list until load succeeds

## Testing
- `pnpm lint` *(fails: requires ESLint configuration)*
- `pnpm test` *(fails: test suite failing)*

------
https://chatgpt.com/codex/tasks/task_e_689c7f7c3c24832c8496c9369719699a