### PR TITLE
feat: handle event time ISO

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -686,9 +686,9 @@ namespace AutomotiveClaimsApi.Controllers
             entity.HandlerEmail = dto.HandlerEmail;
             entity.HandlerPhone = dto.HandlerPhone;
 
-            if (DateTime.TryParse(dto.EventTime, out var eventTime))
+            if (!string.IsNullOrEmpty(dto.EventTime))
             {
-                entity.EventTime = eventTime;
+                entity.EventTime = DateTime.Parse(dto.EventTime);
             }
 
             entity.EventLocation = dto.EventLocation;

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -40,6 +40,8 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
     payout: apiClaim.payout ?? 0,
     currency: apiClaim.currency ?? "PLN",
 
+    eventTime: apiClaim.eventTime?.split("T")[1]?.slice(0, 5),
+
     servicesCalled: Array.isArray(apiClaim.servicesCalled)
       ? apiClaim.servicesCalled
       : (apiClaim.servicesCalled?.split(",").filter(Boolean) ?? []),
@@ -207,7 +209,10 @@ export const transformFrontendClaimToApiPayload = (
     damageDate: rest.damageDate ? new Date(rest.damageDate).toISOString() : undefined,
     reportDate: rest.reportDate ? new Date(rest.reportDate).toISOString() : undefined,
     reportDateToInsurer: rest.reportDateToInsurer ? new Date(rest.reportDateToInsurer).toISOString() : undefined,
-    eventTime: rest.eventTime,
+    eventTime:
+      rest.damageDate && rest.eventTime
+        ? new Date(`${rest.damageDate}T${rest.eventTime}`).toISOString()
+        : undefined,
     servicesCalled: servicesCalled?.join(","),
     participants: participants,
 

--- a/hooks/use-events.ts
+++ b/hooks/use-events.ts
@@ -31,7 +31,7 @@ const transformApiEvent = (apiEvent: EventDto): Event => ({
   id: apiEvent.id?.toString() || "",
   claimNumber: apiEvent.claimNumber || "",
   eventDate: apiEvent.damageDate ? new Date(apiEvent.damageDate).toLocaleDateString("pl-PL") : "",
-  eventTime: apiEvent.eventTime || "",
+  eventTime: apiEvent.eventTime?.split("T")[1]?.slice(0, 5) || "",
   location: apiEvent.location || "",
   city: apiEvent.location || "",
   postalCode: "",
@@ -54,7 +54,10 @@ const transformApiEvent = (apiEvent: EventDto): Event => ({
 const transformToApiEvent = (event: Partial<Event>): Partial<EventDto> => ({
   claimNumber: event.claimNumber || "",
   damageDate: event.eventDate || new Date().toISOString().split("T")[0],
-  eventTime: event.eventTime || "",
+  eventTime:
+    event.eventDate && event.eventTime
+      ? new Date(`${event.eventDate}T${event.eventTime}`).toISOString()
+      : undefined,
   location: event.location || "",
   description: event.eventDescription,
   servicesCalled: event.policeInvolved ? ["policja"] : [],


### PR DESCRIPTION
## Summary
- parse and send event time as HH:MM on frontend and ISO when talking to API
- accept full ISO event time on the backend

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: test suite failed)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689c80939ce0832c888cdd08efb0115b