### PR TITLE
Reset memory stream position before returning document

### DIFF
--- a/backend/Services/DocumentService.cs
+++ b/backend/Services/DocumentService.cs
@@ -154,6 +154,7 @@ namespace AutomotiveClaimsApi.Services
             }
 
             var memoryStream = new MemoryStream(await File.ReadAllBytesAsync(fullPath));
+            memoryStream.Position = 0;
 
             return new DocumentDownloadResult
             {


### PR DESCRIPTION
## Summary
- Reset stream position in `DownloadDocumentAsync` to ensure consumers read from start
- Reviewed other stream-returning methods; no additional changes required

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c8c639368832c8cfe70b9fba267a1