### PR TITLE
fix: ensure recourse list reloads properly

### DIFF
--- a/components/claim-form/recourse-section.tsx
+++ b/components/claim-form/recourse-section.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, useCallback } from "react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -100,13 +100,8 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
     acceptedTypes: [".pdf", ".doc", ".docx", ".jpg", ".jpeg", ".png"],
   })
 
-  useEffect(() => {
-    if (eventId) {
-      loadRecourses()
-    }
-  }, [eventId])
-
-  const loadRecourses = async () => {
+  const loadRecourses = useCallback(async () => {
+    if (!eventId) return
     setListLoading(true)
     try {
       const data = await fetchRecourses(eventId)
@@ -129,7 +124,11 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
     } finally {
       setListLoading(false)
     }
-  }
+  }, [eventId, toast])
+
+  useEffect(() => {
+    loadRecourses()
+  }, [loadRecourses])
 
 
   const processOutlookAttachment = async (file: File) => {


### PR DESCRIPTION
## Summary
- refactor recourse list loading into a `useCallback` for stable refreshes

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689c8d4e8178832c845d26e95a81a8ec