### PR TITLE
Fix incorrect document deletion calls

### DIFF
--- a/backend/Controllers/ClientClaimsController.cs
+++ b/backend/Controllers/ClientClaimsController.cs
@@ -145,7 +145,7 @@ namespace AutomotiveClaimsApi.Controllers
                 {
                     if (!string.IsNullOrEmpty(clientClaim.DocumentPath))
                     {
-                        await _documentService.DeleteDocumentAsync(clientClaim.Id);
+                        await _documentService.DeleteDocumentAsync(clientClaim.DocumentPath);
                     }
 
                     var documentResult = await _documentService.SaveDocumentAsync(
@@ -187,7 +187,7 @@ namespace AutomotiveClaimsApi.Controllers
 
                 if (!string.IsNullOrEmpty(clientClaim.DocumentPath))
                 {
-                    await _documentService.DeleteDocumentAsync(clientClaim.Id);
+                    await _documentService.DeleteDocumentAsync(clientClaim.DocumentPath);
                 }
 
                 _context.ClientClaims.Remove(clientClaim);

--- a/backend/Controllers/SettlementsController.cs
+++ b/backend/Controllers/SettlementsController.cs
@@ -108,7 +108,7 @@ namespace AutomotiveClaimsApi.Controllers
             {
                 if (!string.IsNullOrEmpty(settlement.DocumentPath))
                 {
-                    await _documentService.DeleteDocumentAsync(settlement.Id);
+                    await _documentService.DeleteDocumentAsync(settlement.DocumentPath);
                 }
                 var docResult = await _documentService.SaveDocumentAsync(updateDto.Document, "settlements", updateDto.DocumentDescription);
                 settlement.DocumentPath = docResult.FilePath;
@@ -136,7 +136,7 @@ namespace AutomotiveClaimsApi.Controllers
 
             if (!string.IsNullOrEmpty(settlement.DocumentPath))
             {
-                await _documentService.DeleteDocumentAsync(settlement.Id);
+                await _documentService.DeleteDocumentAsync(settlement.DocumentPath);
             }
 
             _context.Settlements.Remove(settlement);


### PR DESCRIPTION
## Summary
- remove wrong usage of `DeleteDocumentAsync` in settlements controller
- fix document deletion in client claims controller

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c9759d4b8832cba92fc47a785c169