### PR TITLE
feat: add dialog to choose claim type and client

### DIFF
--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
@@ -21,6 +21,7 @@ import { ClaimMainContent } from "@/components/claim-form/claim-main-content"
 import { useClaimForm } from "@/hooks/use-claim-form"
 import { useClaims } from "@/hooks/use-claims"
 import { generateId } from "@/lib/constants"
+import { apiService } from "@/lib/api"
 import { pksData, type Employee } from "@/lib/pks-data"
 import type { Claim, UploadedFile, RequiredDocument } from "@/types"
 import type { RepairDetail } from "@/lib/repair-details-store"
@@ -50,6 +51,7 @@ interface RepairSchedule {
 
 export default function NewClaimPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { toast } = useToast()
   const { createClaim, deleteClaim, initializeClaim } = useClaims()
   const [claimId, setClaimId] = useState<string>("")
@@ -110,6 +112,27 @@ export default function NewClaimPage() {
       }
     })
   }, [initializeClaim, setClaimFormData])
+
+  useEffect(() => {
+    const clientId = searchParams.get("clientId")
+    const riskType = searchParams.get("riskType")
+    const damageType = searchParams.get("damageType")
+
+    if (riskType) {
+      setClaimFormData((prev) => ({ ...prev, riskType }))
+    }
+    if (damageType) {
+      setClaimFormData((prev) => ({ ...prev, damageType }))
+    }
+    if (clientId) {
+      apiService
+        .getClient(Number(clientId))
+        .then((client) => {
+          setClaimFormData((prev) => ({ ...prev, client: client.name, clientId: client.id.toString() }))
+        })
+        .catch((e) => console.error(e))
+    }
+  }, [searchParams, setClaimFormData])
 
   const getInitialScheduleData = (): Partial<RepairSchedule> => ({
     eventId: "new",

--- a/app/claims/page.tsx
+++ b/app/claims/page.tsx
@@ -1,5 +1,16 @@
+"use client"
+
+import { useState } from "react"
 import { ClaimsList } from "@/components/claims-list"
+import { NewClaimDialog } from "@/components/new-claim-dialog"
 
 export default function ClaimsPage() {
-  return <ClaimsList />
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <ClaimsList onNewClaim={() => setOpen(true)} />
+      <NewClaimDialog open={open} onOpenChange={setOpen} />
+    </>
+  )
 }

--- a/components/new-claim-dialog.tsx
+++ b/components/new-claim-dialog.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import ClientDropdown from "@/components/client-dropdown"
+import { Button } from "@/components/ui/button"
+import type { ClientSelectionEvent } from "@/types/client"
+
+interface RiskType {
+  value: string
+  label: string
+}
+
+interface DamageType {
+  id: number | string
+  name: string
+}
+
+interface NewClaimDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function NewClaimDialog({ open, onOpenChange }: NewClaimDialogProps) {
+  const router = useRouter()
+  const [riskTypes, setRiskTypes] = useState<RiskType[]>([])
+  const [damageTypes, setDamageTypes] = useState<DamageType[]>([])
+  const [selectedRisk, setSelectedRisk] = useState("")
+  const [selectedDamage, setSelectedDamage] = useState("")
+  const [selectedClientId, setSelectedClientId] = useState<number | undefined>()
+
+  useEffect(() => {
+    if (!open) return
+    const loadRiskTypes = async () => {
+      try {
+        const res = await fetch("/api/risk-types", { credentials: "include" })
+        if (res.ok) {
+          const data = await res.json()
+          setRiskTypes(data.options || [])
+        }
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    loadRiskTypes()
+  }, [open])
+
+  useEffect(() => {
+    if (!selectedRisk) {
+      setDamageTypes([])
+      setSelectedDamage("")
+      return
+    }
+    const loadDamageTypes = async () => {
+      try {
+        const res = await fetch(`/api/damage-types?dependsOn=${selectedRisk}`, {
+          credentials: "include",
+        })
+        if (res.ok) {
+          const data = await res.json()
+          setDamageTypes(data)
+        }
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    loadDamageTypes()
+  }, [selectedRisk])
+
+  const handleContinue = () => {
+    if (!selectedRisk || !selectedDamage || !selectedClientId) return
+    router.push(`/claims/new?riskType=${selectedRisk}&damageType=${selectedDamage}&clientId=${selectedClientId}`)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Nowa szkoda</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <div>
+            <Label className="mb-2 block">Rodzaj ryzyka</Label>
+            <Select value={selectedRisk} onValueChange={(val) => setSelectedRisk(val)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Wybierz ryzyko" />
+              </SelectTrigger>
+              <SelectContent>
+                {riskTypes.map((rt) => (
+                  <SelectItem key={rt.value} value={rt.value}>
+                    {rt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label className="mb-2 block">Typ szkody</Label>
+            <Select
+              value={selectedDamage}
+              onValueChange={(val) => setSelectedDamage(val)}
+              disabled={!selectedRisk}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Wybierz typ szkody" />
+              </SelectTrigger>
+              <SelectContent>
+                {damageTypes.map((dt) => (
+                  <SelectItem key={dt.id} value={String(dt.id)}>
+                    {dt.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label className="mb-2 block">Klient</Label>
+            <ClientDropdown
+              selectedClientId={selectedClientId}
+              onClientSelected={(e: ClientSelectionEvent) => setSelectedClientId(e.clientId)}
+            />
+          </div>
+          <div className="flex justify-end pt-2">
+            <Button onClick={handleContinue} disabled={!selectedRisk || !selectedDamage || !selectedClientId}>
+              Kontynuuj
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default NewClaimDialog


### PR DESCRIPTION
## Summary
- add modal to choose risk type, damage type and client before creating claim
- pass selections via query params to new claim form
- prefill claim form from selected client and damage type

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689c9cdce580832cb78965704dd36d0d