### PR TITLE
feat: add appeal reminders and days-since-submission

### DIFF
--- a/backend/Controllers/AppealsController.cs
+++ b/backend/Controllers/AppealsController.cs
@@ -260,6 +260,7 @@ namespace AutomotiveClaimsApi.Controllers
                 AppealAmount = a.AppealAmount,
                 DecisionDate = a.DecisionDate,
                 DecisionReason = a.DecisionReason,
+                DaysSinceSubmission = (int?)(DateTime.UtcNow - a.SubmissionDate).TotalDays,
                 DocumentPath = a.DocumentPath,
                 DocumentName = a.DocumentName,
                 DocumentDescription = a.DocumentDescription,

--- a/backend/DTOs/AppealDto.cs
+++ b/backend/DTOs/AppealDto.cs
@@ -16,6 +16,7 @@ namespace AutomotiveClaimsApi.DTOs
         public decimal? AppealAmount { get; set; }
         public DateTime? DecisionDate { get; set; }
         public string? DecisionReason { get; set; }
+        public int? DaysSinceSubmission { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
         public string? DocumentPath { get; set; }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -64,6 +64,7 @@ builder.Services.AddScoped<IGoogleCloudStorageService, GoogleCloudStorageService
 
 // Add background services
 builder.Services.AddHostedService<EmailBackgroundService>();
+builder.Services.AddHostedService<AppealReminderService>();
 
 // Add CORS
 builder.Services.AddCors(options =>

--- a/backend/Services/AppealReminderService.cs
+++ b/backend/Services/AppealReminderService.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Linq;
+using AutomotiveClaimsApi.Data;
+using AutomotiveClaimsApi.DTOs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace AutomotiveClaimsApi.Services
+{
+    public class AppealReminderService : BackgroundService
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<AppealReminderService> _logger;
+
+        public AppealReminderService(IServiceProvider serviceProvider, ILogger<AppealReminderService> logger)
+        {
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using var scope = _serviceProvider.CreateScope();
+                    var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                    var emailService = scope.ServiceProvider.GetRequiredService<IEmailService>();
+
+                    var appeals = await context.Appeals
+                        .Where(a => a.DecisionDate == null)
+                        .ToListAsync(stoppingToken);
+
+                    foreach (var appeal in appeals)
+                    {
+                        var days = (DateTime.UtcNow - appeal.SubmissionDate).Days;
+
+                        if (days == 30 || days == 60)
+                        {
+                            var level = days == 30 ? "first" : "second";
+                            try
+                            {
+                                await emailService.SendEmailAsync(new SendEmailDto
+                                {
+                                    To = "admin@example.com",
+                                    Subject = $"Appeal reminder ({level} alert)",
+                                    Body = $"Appeal {appeal.Id} has been pending for {days} days."
+                                });
+                                _logger.LogInformation("Sent {Level} alert for appeal {Id}", level, appeal.Id);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(ex, "Error sending {Level} alert for appeal {Id}", level, appeal.Id);
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error processing appeal reminders");
+                }
+
+                await Task.Delay(TimeSpan.FromDays(1), stoppingToken);
+            }
+        }
+    }
+}
+

--- a/components/claim-form/appeals-section.tsx
+++ b/components/claim-form/appeals-section.tsx
@@ -28,14 +28,10 @@ import {
   createAppeal,
   updateAppeal,
   deleteAppeal as apiDeleteAppeal,
-  Appeal as ApiAppeal,
+  Appeal,
   AppealPayload,
 } from "@/lib/api/appeals"
 import { API_BASE_URL } from "@/lib/api"
-
-interface Appeal extends ApiAppeal {
-  alertDays?: number
-}
 
 interface AppealsSectionProps {
   claimId: string
@@ -338,27 +334,25 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
   }
 
   const getAlertBadge = (alertDays?: number) => {
-    if (!alertDays || alertDays === 0) {
+    if (!alertDays || alertDays < 30) {
       return (
         <Badge variant="secondary" className="bg-gray-100 text-gray-800">
           Brak
         </Badge>
       )
-    } else if (alertDays > 30) {
-      return <Badge variant="destructive">MONIT ({alertDays} dni)</Badge>
-    } else if (alertDays > 20) {
+    }
+
+    if (alertDays >= 60) {
       return (
-        <Badge variant="secondary" className="bg-orange-100 text-orange-800">
-          {alertDays} dni
-        </Badge>
-      )
-    } else {
-      return (
-        <Badge variant="secondary" className="bg-yellow-100 text-yellow-800">
-          {alertDays} dni
-        </Badge>
+        <Badge variant="destructive">MONIT ({alertDays} dni)</Badge>
       )
     }
+
+    return (
+      <Badge variant="secondary" className="bg-orange-100 text-orange-800">
+        MONIT ({alertDays} dni)
+      </Badge>
+    )
   }
 
   const getTotalFileSize = () => {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -362,6 +362,7 @@ export interface AppealDto {
   documentDescription?: string
   createdAt?: string
   updatedAt?: string
+  daysSinceSubmission?: number
 }
 
 export interface AppealUpsertDto {

--- a/lib/api/appeals.ts
+++ b/lib/api/appeals.ts
@@ -10,6 +10,7 @@ export interface Appeal {
   documentPath?: string;
   documentName?: string;
   documentDescription?: string;
+  alertDays?: number;
 }
 
 export interface AppealPayload {
@@ -36,6 +37,7 @@ function mapDtoToAppeal(dto: AppealDto): Appeal {
     documentPath: dto.documentPath,
     documentName: dto.documentName,
     documentDescription: dto.documentDescription,
+    alertDays: dto.daysSinceSubmission,
   };
 }
 


### PR DESCRIPTION
## Summary
- add `DaysSinceSubmission` to appeal DTO and map in controller
- send daily alerts via new `AppealReminderService`
- expose `daysSinceSubmission` in API and use for UI badges

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cb584036c832cb8b967683e1eb809