### PR TITLE
Add claim object type filtering for risk types

### DIFF
--- a/backend/Controllers/RiskTypesController.cs
+++ b/backend/Controllers/RiskTypesController.cs
@@ -17,12 +17,19 @@ namespace AutomotiveClaimsApi.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<RiskTypeDto>>> GetRiskTypes()
+        public async Task<ActionResult<IEnumerable<RiskTypeDto>>> GetRiskTypes([FromQuery] int? claimObjectTypeId)
         {
             try
             {
-                var riskTypes = await _context.RiskTypes
-                    .Where(rt => rt.IsActive)
+                var query = _context.RiskTypes
+                    .Where(rt => rt.IsActive);
+
+                if (claimObjectTypeId.HasValue)
+                {
+                    query = query.Where(rt => rt.ClaimObjectTypeId == claimObjectTypeId);
+                }
+
+                var riskTypes = await query
                     .OrderBy(rt => rt.Name)
                     .Select(rt => new RiskTypeDto
                     {

--- a/backend/Migrations/20240130000017_AddClaimObjectTypeIdToRiskTypes.cs
+++ b/backend/Migrations/20240130000017_AddClaimObjectTypeIdToRiskTypes.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClaimObjectTypeIdToRiskTypes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ClaimObjectTypeId",
+                table: "RiskTypes",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ClaimObjectTypeId",
+                table: "RiskTypes");
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -533,6 +533,48 @@ namespace AutomotiveClaimsApi.Migrations
                     b.ToTable("Documents");
                 });
 
+            modelBuilder.Entity("AutomotiveClaimsApi.Models.RiskType", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasDefaultValueSql("gen_random_uuid()");
+
+                    b.Property<string>("Code")
+                        .IsRequired()
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("Description")
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)");
+
+                    b.Property<int?>("ClaimObjectTypeId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<bool>("IsActive")
+                        .HasColumnType("boolean");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("NOW()");
+
+                    b.Property<DateTime>("UpdatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("NOW()");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("RiskTypes");
+                });
+
             modelBuilder.Entity("AutomotiveClaimsApi.Models.Driver", b =>
                 {
                     b.Property<Guid>("Id")

--- a/backend/Models/RiskType.cs
+++ b/backend/Models/RiskType.cs
@@ -16,7 +16,9 @@ namespace AutomotiveClaimsApi.Models
         
         [MaxLength(500)]
         public string? Description { get; set; }
-        
+
+        public int? ClaimObjectTypeId { get; set; }
+
         public bool IsActive { get; set; } = true;
         
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;


### PR DESCRIPTION
## Summary
- allow filtering risk types by optional claimObjectTypeId query parameter
- track ClaimObjectTypeId on RiskType model and database schema

## Testing
- `npm test` *(fails: Cannot require() ES Module ...)*

------
https://chatgpt.com/codex/tasks/task_e_689cd4e12dd8832ca0e173545c20d072