### PR TITLE
Allow removing empty document categories

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -734,6 +734,30 @@ export const DocumentsSection = ({
     })
   }
 
+  const handleRemoveCategory = (category: string) => {
+    setRequiredDocuments((prev) =>
+      prev.map((doc) => (doc.name === category ? { ...doc, uploaded: false } : doc)),
+    )
+
+    setOpenCategories((prev) => {
+      const { [category]: _, ...rest } = prev
+      return rest
+    })
+
+    setSelectedDocumentIds((prev) =>
+      prev.filter((id) => {
+        const doc = allDocuments.find((d) => d.id === id)
+        return doc?.documentType !== category
+      }),
+    )
+
+    toast({
+      title: "Kategoria usunięta",
+      description: `Kategoria "${category}" została usunięta.`,
+      variant: "destructive",
+    })
+  }
+
   // Preview navigation functions
   const goToPreviousDocument = () => {
     if (currentPreviewIndex > 0) {
@@ -969,7 +993,7 @@ export const DocumentsSection = ({
                   <Badge variant="secondary" className="bg-green-100 text-green-800">
                     {documentsForCategory.length}
                   </Badge>
-                  {category !== "Inne dokumenty" && (
+                  {category !== "Inne dokumenty" && documentsForCategory.length === 0 && (
                     <Button
                       variant="ghost"
                       size="icon"
@@ -977,11 +1001,7 @@ export const DocumentsSection = ({
                       onClick={(e) => {
                         e.stopPropagation()
                         if (window.confirm(`Czy na pewno chcesz usunąć kategorię "${category}"?`)) {
-                          toast({
-                            title: "Kategoria usunięta",
-                            description: `Kategoria "${category}" została usunięta.`,
-                            variant: "destructive",
-                          })
+                          handleRemoveCategory(category)
                         }
                       }}
                     >


### PR DESCRIPTION
## Summary
- Add handleRemoveCategory to revert a required document category and close it
- Hide delete button when category has files and remove category on confirmation

## Testing
- `pnpm lint` *(fails: requires interactive ESLint config)*
- `pnpm test` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_689cd4b9e6b0832c9b0971a3c55b9a9e