### PR TITLE
feat: show document description in preview

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -1620,6 +1620,11 @@ export const DocumentsSection = ({
                   </div>
                 )}
               </div>
+              {previewDocument.description && (
+                <div className="p-4">
+                  <p className="text-sm text-gray-600">{previewDocument.description}</p>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -54,8 +54,23 @@ export interface EventDto extends EventListItemDto {
 }
 
 export interface DocumentDto {
-  id?: string
-  filePath?: string
+  id: string
+  eventId?: string
+  fileName: string
+  originalFileName?: string
+  filePath: string
+  fileSize: number
+  contentType: string
+  category?: string
+  description?: string
+  uploadedBy?: string
+  status?: string
+  isActive?: boolean
+  createdAt?: string
+  updatedAt?: string
+  downloadUrl?: string
+  previewUrl?: string
+  canPreview?: boolean
 }
 
 export interface EventUpsertDto {


### PR DESCRIPTION
## Summary
- display document description in preview modal
- add description and related metadata to `DocumentDto`

## Testing
- `pnpm lint` *(fails: requires interactive ESLint setup)*
- `pnpm test` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_689cd1d7ec74832cb26282ad3403b31f