### PR TITLE
refactor client-claims routes to use backend

### DIFF
--- a/app/api/client-claims/[id]/download/route.ts
+++ b/app/api/client-claims/[id]/download/route.ts
@@ -1,19 +1,33 @@
 import { type NextRequest, NextResponse } from "next/server"
 
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
+
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const { id } = params
 
-    // TODO: Get client claim from database and return file
-    // This is a mock implementation
-    const mockPdfContent = Buffer.from("Mock PDF content for client claim " + id)
+    const response = await fetch(`${API_BASE_URL}/client-claims/${id}/download`)
 
-    return new NextResponse(mockPdfContent, {
-      headers: {
-        "Content-Type": "application/pdf",
-        "Content-Disposition": `attachment; filename="client-claim-${id}.pdf"`,
-      },
-    })
+    if (!response.ok) {
+      const errorText = await response.text()
+      console.error("Backend error downloading client claim document:", errorText)
+      return NextResponse.json(
+        { error: "Failed to download document", details: errorText },
+        { status: response.status },
+      )
+    }
+
+    const headers = new Headers()
+    headers.set(
+      "Content-Type",
+      response.headers.get("Content-Type") || "application/pdf",
+    )
+    headers.set(
+      "Content-Disposition",
+      response.headers.get("Content-Disposition") || `attachment; filename="client-claim-${id}.pdf"`,
+    )
+
+    return new NextResponse(response.body, { headers })
   } catch (error) {
     console.error("Error downloading client claim document:", error)
     return NextResponse.json({ error: "Failed to download document" }, { status: 500 })

--- a/app/api/client-claims/[id]/preview/route.ts
+++ b/app/api/client-claims/[id]/preview/route.ts
@@ -1,19 +1,33 @@
 import { type NextRequest, NextResponse } from "next/server"
 
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
+
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const { id } = params
 
-    // TODO: Get client claim from database and return file for preview
-    // This is a mock implementation
-    const mockPdfContent = Buffer.from("Mock PDF content for client claim preview " + id)
+    const response = await fetch(`${API_BASE_URL}/client-claims/${id}/preview`)
 
-    return new NextResponse(mockPdfContent, {
-      headers: {
-        "Content-Type": "application/pdf",
-        "Content-Disposition": "inline",
-      },
-    })
+    if (!response.ok) {
+      const errorText = await response.text()
+      console.error("Backend error previewing client claim document:", errorText)
+      return NextResponse.json(
+        { error: "Failed to preview document", details: errorText },
+        { status: response.status },
+      )
+    }
+
+    const headers = new Headers()
+    headers.set(
+      "Content-Type",
+      response.headers.get("Content-Type") || "application/pdf",
+    )
+    headers.set(
+      "Content-Disposition",
+      response.headers.get("Content-Disposition") || "inline",
+    )
+
+    return new NextResponse(response.body, { headers })
   } catch (error) {
     console.error("Error previewing client claim document:", error)
     return NextResponse.json({ error: "Failed to preview document" }, { status: 500 })


### PR DESCRIPTION
## Summary
- replace mock client claim data with backend service calls
- stream file preview and download responses from backend
- handle client claim updates and deletions via backend

## Testing
- `pnpm lint` (fails: How would you like to configure ESLint?)
- `pnpm test` (fails: Test failed. See above for more details.)

------
https://chatgpt.com/codex/tasks/task_e_689cdd7540c4832c81f4cdf7bcc735c7