### PR TITLE
Handle nullable settlement status and expose document fields

### DIFF
--- a/lib/api/settlements.ts
+++ b/lib/api/settlements.ts
@@ -5,11 +5,19 @@ const settlementSchema = z.object({
   id: z.string(),
   eventId: z.string(),
   externalEntity: z.string().nullish(),
+  customExternalEntity: z.string().nullish(),
   transferDate: z.string().nullish(),
+  status: z.string().nullish(),
   settlementDate: z.string().nullish(),
   settlementAmount: z.number().nullish(),
+  amount: z.number().nullish(),
   currency: z.string().nullish(),
-  status: z.string().optional(),
+  description: z.string().nullish(),
+  documentPath: z.string().nullish(),
+  documentName: z.string().nullish(),
+  documentDescription: z.string().nullish(),
+  settlementNumber: z.string().nullish(),
+  settlementType: z.string().nullish(),
 });
 
 const settlementUpsertSchema = z.object({

--- a/types/index.ts
+++ b/types/index.ts
@@ -209,15 +209,17 @@ export interface Settlement {
   externalEntity?: string
   customExternalEntity?: string
   transferDate?: string
-  settlementDate: string
-  settlementType: string
-  description: string
-  settlementAmount?: number
-  currency?: string
-  amount?: number
   status?: string
+  settlementDate?: string
+  settlementAmount?: number
+  amount?: number
+  currency?: string
+  description?: string
+  settlementNumber?: string
+  settlementType?: string
   documentPath?: string
   documentName?: string
+  documentDescription?: string
 }
 
 export type Service = "policja" | "pogotowie" | "straz" | "holownik"


### PR DESCRIPTION
## Summary
- expand settlement schema with document and metadata fields
- allow settlement status to be null to avoid fetch failures
- update shared Settlement type with new optional fields

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689ce4622268832ca648cf04caa6cb5d