### PR TITLE
refactor settlements section to use event id

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -2039,7 +2039,7 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
               <CardTitle className="text-lg font-semibold">Ugoda</CardTitle>
             </CardHeader>
             <CardContent className="p-0 bg-white">
-              <SettlementsSection claimId={claimFormData.id || ""} />
+              <SettlementsSection eventId={eventId || ""} />
             </CardContent>
           </Card>
         </div>

--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -14,7 +14,7 @@ import { getSettlements, createSettlement, updateSettlement, deleteSettlement } 
 import type { Settlement } from "@/types"
 
 interface SettlementsSectionProps {
-  claimId: string
+  eventId: string
 }
 
 interface SettlementFormData {
@@ -39,7 +39,7 @@ const initialFormData: SettlementFormData = {
   documentDescription: "",
 }
 
-export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ claimId }) => {
+export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId }) => {
   const { toast } = useToast()
 
   const [settlements, setSettlements] = useState<Settlement[]>([])
@@ -65,10 +65,10 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ claimId 
   const [currentPreviewSettlement, setCurrentPreviewSettlement] = useState<Settlement | null>(null)
 
   const loadSettlements = useCallback(async () => {
-    if (!claimId) return
+    if (!eventId) return
     setIsListLoading(true)
     try {
-      const data = await getSettlements(claimId)
+      const data = await getSettlements(eventId)
       setSettlements(data)
     } catch (error) {
       console.error("Error fetching settlements:", error)
@@ -80,7 +80,7 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ claimId 
     } finally {
       setIsListLoading(false)
     }
-  }, [claimId, toast])
+  }, [eventId, toast])
 
   useEffect(() => {
     loadSettlements()
@@ -189,7 +189,7 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ claimId 
 
       try {
         const body = new FormData()
-        body.append("eventId", claimId)
+        body.append("eventId", eventId)
         body.append("externalEntity", formData.externalEntity)
         if (formData.customExternalEntity) {
           body.append("customExternalEntity", formData.customExternalEntity)
@@ -241,7 +241,7 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ claimId 
         setIsLoading(false)
       }
     },
-    [formData, selectedFile, isEditing, editingSettlementId, claimId, loadSettlements, toast],
+    [formData, selectedFile, isEditing, editingSettlementId, eventId, loadSettlements, toast],
   )
 
   // Edit settlement


### PR DESCRIPTION
## Summary
- rename settlements section prop to `eventId`
- update usage to fetch and submit data using event IDs
- adjust claim main content to pass `eventId`

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Cannot require() ES Module app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689cf7b1efb8832ca188332f5da60da1