### PR TITLE
feat: expand settlement dto fields

### DIFF
--- a/backend/Controllers/SettlementsController.cs
+++ b/backend/Controllers/SettlementsController.cs
@@ -61,13 +61,19 @@ namespace AutomotiveClaimsApi.Controllers
                 Id = Guid.NewGuid(),
                 EventId = createDto.EventId,
                 ClaimId = createDto.ClaimId,
+                SettlementNumber = createDto.SettlementNumber,
+                SettlementType = createDto.SettlementType,
                 ExternalEntity = createDto.ExternalEntity,
                 CustomExternalEntity = createDto.CustomExternalEntity,
                 TransferDate = createDto.TransferDate,
                 Status = createDto.Status,
                 SettlementDate = createDto.SettlementDate,
+                Amount = createDto.Amount,
                 SettlementAmount = createDto.SettlementAmount,
                 Currency = createDto.Currency,
+                PaymentMethod = createDto.PaymentMethod,
+                Notes = createDto.Notes,
+                Description = createDto.Description,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             };
@@ -98,10 +104,16 @@ namespace AutomotiveClaimsApi.Controllers
             settlement.ExternalEntity = updateDto.ExternalEntity;
             settlement.CustomExternalEntity = updateDto.CustomExternalEntity;
             settlement.TransferDate = updateDto.TransferDate;
+            settlement.SettlementNumber = updateDto.SettlementNumber;
+            settlement.SettlementType = updateDto.SettlementType;
             settlement.Status = updateDto.Status;
             settlement.SettlementDate = updateDto.SettlementDate;
+            settlement.Amount = updateDto.Amount;
             settlement.SettlementAmount = updateDto.SettlementAmount;
             settlement.Currency = updateDto.Currency;
+            settlement.PaymentMethod = updateDto.PaymentMethod;
+            settlement.Notes = updateDto.Notes;
+            settlement.Description = updateDto.Description;
             settlement.UpdatedAt = DateTime.UtcNow;
 
             if (updateDto.Document != null)

--- a/backend/DTOs/CreateSettlementDto.cs
+++ b/backend/DTOs/CreateSettlementDto.cs
@@ -17,17 +17,35 @@ namespace AutomotiveClaimsApi.DTOs
 
         public DateTime? TransferDate { get; set; }
 
+        [StringLength(100)]
+        public string? SettlementNumber { get; set; }
+
+        [StringLength(100)]
+        public string? SettlementType { get; set; }
+
         [Required]
         [StringLength(100)]
         public string Status { get; set; } = string.Empty;
 
         public DateTime? SettlementDate { get; set; }
 
+        [Range(0.01, double.MaxValue, ErrorMessage = "Amount must be greater than 0")]
+        public decimal? Amount { get; set; }
+
         [Range(0.01, double.MaxValue, ErrorMessage = "Settlement amount must be greater than 0")]
         public decimal? SettlementAmount { get; set; }
 
         [StringLength(10)]
         public string? Currency { get; set; } = "PLN";
+
+        [StringLength(100)]
+        public string? PaymentMethod { get; set; }
+
+        [StringLength(500)]
+        public string? Notes { get; set; }
+
+        [StringLength(500)]
+        public string? Description { get; set; }
 
         public IFormFile? Document { get; set; }
 

--- a/backend/DTOs/UpdateSettlementDto.cs
+++ b/backend/DTOs/UpdateSettlementDto.cs
@@ -12,17 +12,35 @@ namespace AutomotiveClaimsApi.DTOs
 
         public DateTime? TransferDate { get; set; }
 
+        [StringLength(100)]
+        public string? SettlementNumber { get; set; }
+
+        [StringLength(100)]
+        public string? SettlementType { get; set; }
+
         [Required]
         [StringLength(100)]
         public string Status { get; set; } = string.Empty;
 
         public DateTime? SettlementDate { get; set; }
 
+        [Range(0.01, double.MaxValue, ErrorMessage = "Amount must be greater than 0")]
+        public decimal? Amount { get; set; }
+
         [Range(0.01, double.MaxValue, ErrorMessage = "Settlement amount must be greater than 0")]
         public decimal? SettlementAmount { get; set; }
 
         [StringLength(10)]
         public string? Currency { get; set; } = "PLN";
+
+        [StringLength(100)]
+        public string? PaymentMethod { get; set; }
+
+        [StringLength(500)]
+        public string? Notes { get; set; }
+
+        [StringLength(500)]
+        public string? Description { get; set; }
 
         public IFormFile? Document { get; set; }
 

--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -18,24 +18,36 @@ interface SettlementsSectionProps {
 }
 
 interface SettlementFormData {
+  settlementNumber: string
+  settlementType: string
   externalEntity: string
   customExternalEntity: string
   transferDate: string
   status: string
   settlementDate: string
+  amount: number
   settlementAmount: number
   currency: string
+  paymentMethod: string
+  notes: string
+  description: string
   documentDescription: string
 }
 
 const initialFormData: SettlementFormData = {
+  settlementNumber: "",
+  settlementType: "",
   externalEntity: "",
   customExternalEntity: "",
   transferDate: "",
   status: "",
   settlementDate: "",
+  amount: 0,
   settlementAmount: 0,
   currency: "PLN",
+  paymentMethod: "",
+  notes: "",
+  description: "",
   documentDescription: "",
 }
 
@@ -190,15 +202,24 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
       try {
         const body = new FormData()
         body.append("eventId", eventId)
+        if (formData.settlementNumber)
+          body.append("settlementNumber", formData.settlementNumber)
+        if (formData.settlementType)
+          body.append("settlementType", formData.settlementType)
         body.append("externalEntity", formData.externalEntity)
         if (formData.customExternalEntity) {
           body.append("customExternalEntity", formData.customExternalEntity)
         }
         if (formData.transferDate) body.append("transferDate", formData.transferDate)
         if (formData.settlementDate) body.append("settlementDate", formData.settlementDate)
+        if (formData.amount) body.append("amount", formData.amount.toString())
         if (formData.settlementAmount)
           body.append("settlementAmount", formData.settlementAmount.toString())
         if (formData.currency) body.append("currency", formData.currency)
+        if (formData.paymentMethod)
+          body.append("paymentMethod", formData.paymentMethod)
+        if (formData.notes) body.append("notes", formData.notes)
+        if (formData.description) body.append("description", formData.description)
         if (formData.status) body.append("status", formData.status)
         if (formData.documentDescription)
           body.append("documentDescription", formData.documentDescription)
@@ -249,14 +270,20 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
     const isCustom =
       settlement.externalEntity && !["ClaimXpert360"].includes(settlement.externalEntity)
     setFormData({
+      settlementNumber: settlement.settlementNumber || "",
+      settlementType: settlement.settlementType || "",
       externalEntity: isCustom ? "custom" : settlement.externalEntity || "",
       customExternalEntity: isCustom ? settlement.externalEntity || "" : "",
       transferDate: settlement.transferDate || "",
       status: settlement.status || "",
       settlementDate: settlement.settlementDate || "",
+      amount: settlement.amount || 0,
       settlementAmount: settlement.settlementAmount || 0,
       currency: settlement.currency || "PLN",
-      documentDescription: settlement.description || "",
+      paymentMethod: settlement.paymentMethod || "",
+      notes: settlement.notes || "",
+      description: settlement.description || "",
+      documentDescription: settlement.documentDescription || "",
     })
     setShowCustomEntityInput(isCustom)
     setIsEditing(true)
@@ -398,6 +425,28 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
             <div className="p-5">
               <form onSubmit={onSubmit}>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+                  {/* Settlement Number */}
+                  <div className="grid gap-2">
+                    <Label className="text-[#1a3a6c] text-sm font-medium">Numer ugody:</Label>
+                    <Input
+                      type="text"
+                      className="w-full border border-[#d1d9e6] focus:ring-2 focus:ring-[#1a3a6c]/20 focus:border-[#1a3a6c]"
+                      value={formData.settlementNumber}
+                      onChange={(e) => handleFormChange("settlementNumber", e.target.value)}
+                    />
+                  </div>
+
+                  {/* Settlement Type */}
+                  <div className="grid gap-2">
+                    <Label className="text-[#1a3a6c] text-sm font-medium">Typ ugody:</Label>
+                    <Input
+                      type="text"
+                      className="w-full border border-[#d1d9e6] focus:ring-2 focus:ring-[#1a3a6c]/20 focus:border-[#1a3a6c]"
+                      value={formData.settlementType}
+                      onChange={(e) => handleFormChange("settlementType", e.target.value)}
+                    />
+                  </div>
+
                   {/* External Entity */}
                   <div className="grid gap-2">
                     <Label className="text-[#1a3a6c] text-sm font-medium">Podmiot zewnętrzny:</Label>
@@ -465,6 +514,19 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
                     />
                   </div>
 
+                  {/* Amount */}
+                  <div className="grid gap-2">
+                    <Label className="text-[#1a3a6c] text-sm font-medium">Kwota roszczenia:</Label>
+                    <Input
+                      type="number"
+                      step="0.01"
+                      className="w-full border border-[#d1d9e6] focus:ring-2 focus:ring-[#1a3a6c]/20 focus:border-[#1a3a6c]"
+                      value={formData.amount}
+                      onChange={(e) => handleFormChange("amount", Number.parseFloat(e.target.value) || 0)}
+                      placeholder="0.00"
+                    />
+                  </div>
+
                   {/* Settlement Amount with Currency */}
                   <div className="grid gap-2 md:col-span-2">
                     <Label className="text-[#1a3a6c] text-sm font-medium">Kwota ugody:</Label>
@@ -490,6 +552,39 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
                         </SelectContent>
                       </Select>
                     </div>
+                  </div>
+
+                  {/* Payment Method */}
+                  <div className="grid gap-2">
+                    <Label className="text-[#1a3a6c] text-sm font-medium">Metoda płatności:</Label>
+                    <Input
+                      type="text"
+                      className="w-full border border-[#d1d9e6] focus:ring-2 focus:ring-[#1a3a6c]/20 focus:border-[#1a3a6c]"
+                      value={formData.paymentMethod}
+                      onChange={(e) => handleFormChange("paymentMethod", e.target.value)}
+                    />
+                  </div>
+
+                  {/* Notes */}
+                  <div className="grid gap-2 md:col-span-2">
+                    <Label className="text-[#1a3a6c] text-sm font-medium">Notatki:</Label>
+                    <Textarea
+                      value={formData.notes}
+                      onChange={(e) => handleFormChange("notes", e.target.value)}
+                      className="w-full border border-[#d1d9e6] focus:ring-2 focus:ring-[#1a3a6c]/20 focus:border-[#1a3a6c] text-sm"
+                      rows={2}
+                    />
+                  </div>
+
+                  {/* Description */}
+                  <div className="grid gap-2 md:col-span-2">
+                    <Label className="text-[#1a3a6c] text-sm font-medium">Opis:</Label>
+                    <Textarea
+                      value={formData.description}
+                      onChange={(e) => handleFormChange("description", e.target.value)}
+                      className="w-full border border-[#d1d9e6] focus:ring-2 focus:ring-[#1a3a6c]/20 focus:border-[#1a3a6c] text-sm"
+                      rows={2}
+                    />
                   </div>
                 </div>
 

--- a/components/settlements-section.tsx
+++ b/components/settlements-section.tsx
@@ -29,9 +29,15 @@ export function SettlementsSection({ eventId }: SettlementsSectionProps) {
     externalEntity: "",
     transferDate: "",
     settlementDate: "",
+    settlementNumber: "",
+    settlementType: "",
+    amount: 0,
     settlementAmount: 0,
     currency: "PLN",
     status: "",
+    paymentMethod: "",
+    notes: "",
+    description: "",
   })
 
   const [formData, setFormData] = useState(getInitialForm())
@@ -112,12 +118,18 @@ export function SettlementsSection({ eventId }: SettlementsSectionProps) {
 
   function handleEdit(settlement: Settlement) {
     setFormData({
+      settlementNumber: settlement.settlementNumber ?? "",
+      settlementType: settlement.settlementType ?? "",
       externalEntity: settlement.externalEntity ?? "",
       transferDate: settlement.transferDate?.slice(0, 10) ?? "",
       settlementDate: settlement.settlementDate?.slice(0, 10) ?? "",
+      amount: settlement.amount ?? 0,
       settlementAmount: settlement.settlementAmount ?? 0,
       currency: settlement.currency ?? "PLN",
       status: settlement.status ?? "",
+      paymentMethod: settlement.paymentMethod ?? "",
+      notes: settlement.notes ?? "",
+      description: settlement.description ?? "",
     })
     setEditingId(settlement.id)
     setIsFormVisible(true)
@@ -170,6 +182,16 @@ export function SettlementsSection({ eventId }: SettlementsSectionProps) {
         {isFormVisible ? (
           <form onSubmit={handleSubmit} className="space-y-2">
             <Input
+              placeholder="Numer ugody"
+              value={formData.settlementNumber}
+              onChange={(e) => setFormData({ ...formData, settlementNumber: e.target.value })}
+            />
+            <Input
+              placeholder="Typ ugody"
+              value={formData.settlementType}
+              onChange={(e) => setFormData({ ...formData, settlementType: e.target.value })}
+            />
+            <Input
               placeholder="Podmiot zewnętrzny"
               value={formData.externalEntity}
               onChange={(e) => setFormData({ ...formData, externalEntity: e.target.value })}
@@ -183,6 +205,15 @@ export function SettlementsSection({ eventId }: SettlementsSectionProps) {
               type="date"
               value={formData.settlementDate}
               onChange={(e) => setFormData({ ...formData, settlementDate: e.target.value })}
+            />
+            <Input
+              type="number"
+              step="0.01"
+              placeholder="Kwota"
+              value={formData.amount}
+              onChange={(e) =>
+                setFormData({ ...formData, amount: parseFloat(e.target.value) || 0 })
+              }
             />
             <Input
               type="number"
@@ -202,6 +233,21 @@ export function SettlementsSection({ eventId }: SettlementsSectionProps) {
               placeholder="Status"
               value={formData.status}
               onChange={(e) => setFormData({ ...formData, status: e.target.value })}
+            />
+            <Input
+              placeholder="Metoda płatności"
+              value={formData.paymentMethod}
+              onChange={(e) => setFormData({ ...formData, paymentMethod: e.target.value })}
+            />
+            <Input
+              placeholder="Notatki"
+              value={formData.notes}
+              onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+            />
+            <Input
+              placeholder="Opis"
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
             />
             <div className="space-x-2">
               <Button type="submit">Zapisz</Button>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -481,11 +481,14 @@ export interface SettlementDto {
   customExternalEntity?: string
   transferDate?: string
   settlementDate?: string
+  settlementNumber?: string
   settlementType?: string
-  description?: string
   amount?: number
   settlementAmount?: number
   currency?: string
+  paymentMethod?: string
+  notes?: string
+  description?: string
   status?: string
   documentPath?: string
   documentName?: string

--- a/lib/api/settlements.ts
+++ b/lib/api/settlements.ts
@@ -12,6 +12,8 @@ const settlementSchema = z.object({
   settlementAmount: z.number().nullish(),
   amount: z.number().nullish(),
   currency: z.string().nullish(),
+  paymentMethod: z.string().nullish(),
+  notes: z.string().nullish(),
   description: z.string().nullish(),
   documentPath: z.string().nullish(),
   documentName: z.string().nullish(),
@@ -22,11 +24,17 @@ const settlementSchema = z.object({
 
 const settlementUpsertSchema = z.object({
   eventId: z.string(),
+  settlementNumber: z.string().optional(),
+  settlementType: z.string().optional(),
   externalEntity: z.string().optional(),
   transferDate: z.string().optional(),
   settlementDate: z.string().optional(),
+  amount: z.number().optional(),
   settlementAmount: z.number().optional(),
   currency: z.string().optional(),
+  paymentMethod: z.string().optional(),
+  notes: z.string().optional(),
+  description: z.string().optional(),
   status: z.string().min(1),
 });
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -214,6 +214,8 @@ export interface Settlement {
   settlementAmount?: number
   amount?: number
   currency?: string
+  paymentMethod?: string
+  notes?: string
   description?: string
   settlementNumber?: string
   settlementType?: string


### PR DESCRIPTION
## Summary
- add settlement metadata fields with validation to Create/Update DTOs
- map new fields in settlement controller
- extend frontend forms, API schemas and types to support new fields

## Testing
- `dotnet test` *(fails: command not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*


------
https://chatgpt.com/codex/tasks/task_e_689cfc8b6630832cafb8f52f768e6f3f