### PR TITLE
Allow null compensation title in decision schema

### DIFF
--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -242,7 +242,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
         status: formData.status,
         amount: formData.amount ? Number(formData.amount) : undefined,
         currency: formData.currency,
-        compensationTitle: formData.compensationTitle || undefined,
+        compensationTitle: formData.compensationTitle ?? undefined,
         documentDescription: formData.documentDescription || undefined,
         document: selectedFiles[0],
       }
@@ -286,7 +286,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
       status: decision.status,
       amount: decision.amount?.toString() || "",
       currency: decision.currency || "PLN",
-      compensationTitle: decision.compensationTitle || "",
+      compensationTitle: decision.compensationTitle ?? "",
       documentDescription: decision.documentDescription || "",
     })
 
@@ -790,7 +790,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
                       {decision.amount ? formatCurrency(decision.amount, decision.currency) : "-"}
                     </td>
                     <td className="py-3 px-4 text-sm">{decision.currency || "PLN"}</td>
-                    <td className="py-3 px-4 text-sm">{decision.compensationTitle || "-"}</td>
+                    <td className="py-3 px-4 text-sm">{decision.compensationTitle ?? "-"}</td>
                     <td className="py-3 px-4">
                       {decision.documentPath ? (
                         <div className="flex items-center gap-2">

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -353,7 +353,7 @@ export interface DecisionDto {
   status?: string
   amount?: number
   currency?: string
-  compensationTitle?: string
+  compensationTitle?: string | null
   documentDescription?: string | null
   documentName?: string | null
   documentPath?: string | null

--- a/lib/api/decisions.ts
+++ b/lib/api/decisions.ts
@@ -8,7 +8,7 @@ export const decisionSchema = z.object({
   status: z.string().optional(),
   amount: z.number().nullable().optional(),
   currency: z.string().optional(),
-  compensationTitle: z.string().optional(),
+  compensationTitle: z.string().nullish(),
   documentDescription: z.string().nullish(),
   documentName: z.string().nullish(),
   documentPath: z.string().nullish(),

--- a/types/index.ts
+++ b/types/index.ts
@@ -146,7 +146,7 @@ export interface Decision {
   status?: string
   amount?: number
   currency?: string
-  compensationTitle?: string
+  compensationTitle?: string | null
   documentDescription?: string | null
   documentName?: string | null
   documentPath?: string | null


### PR DESCRIPTION
## Summary
- Accept null in decision schema and types
- Update UI logic to handle null compensation titles

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `npm run build` *(fails: Unexpected token `div` in `page.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_689cfdf2077c832cb91e005bdbe6114d