### PR TITLE
feat: handle custom external entity when editing settlements

### DIFF
--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -250,17 +250,16 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
 
   // Edit settlement
   const editSettlement = useCallback((settlement: Settlement) => {
-    const isCustom =
-      settlement.externalEntity && !["ClaimXpert360"].includes(settlement.externalEntity)
+    const isCustom = !!settlement.customExternalEntity
     setFormData({
-      externalEntity: isCustom ? "custom" : settlement.externalEntity || "",
-      customExternalEntity: isCustom ? settlement.externalEntity || "" : "",
-      transferDate: settlement.transferDate || "",
-      status: settlement.status || "",
-      settlementDate: settlement.settlementDate || "",
-      settlementAmount: settlement.settlementAmount || 0,
-      currency: settlement.currency || "PLN",
-      documentDescription: settlement.documentDescription || "",
+      externalEntity: isCustom ? "custom" : settlement.externalEntity ?? "",
+      customExternalEntity: settlement.customExternalEntity ?? "",
+      transferDate: settlement.transferDate ?? "",
+      status: settlement.status ?? "",
+      settlementDate: settlement.settlementDate ?? "",
+      settlementAmount: settlement.settlementAmount ?? 0,
+      currency: settlement.currency ?? "PLN",
+      documentDescription: settlement.documentDescription ?? "",
     })
     setShowCustomEntityInput(isCustom)
     setIsEditing(true)


### PR DESCRIPTION
## Summary
- populate settlement edit form with custom external entity data
- support custom external entity selection in SettlementsSection with dedicated input

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d0a1e81e8832cb9bbdc2f233a1e26