### PR TITLE
Send recourses only when updated

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -166,7 +166,15 @@ export default function ClaimPage() {
           throw new Error("Nie udało się utworzyć szkody")
         }
       } else if (mode === "edit" && claimId) {
-        const updatedClaim = await updateClaim(claimId, claimFormData)
+        const {
+          settlements: _settlements,
+          recourses: _recourses,
+          ...claimWithoutSettlementsRecourses
+        } = claimFormData
+        const updatedClaim = await updateClaim(
+          claimId,
+          claimWithoutSettlementsRecourses,
+        )
         toast({
           title: "Szkoda zaktualizowana",
           description: `Szkoda ${updatedClaim.spartaNumber || updatedClaim.claimNumber} została pomyślnie zaktualizowana.`,

--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -147,12 +147,19 @@ export default function EditClaimPage() {
 
     setIsSaving(true)
     try {
-      // Settlements are managed via their own endpoints; remove them from the
-      // claim payload to avoid unintentionally overwriting existing records.
-      const { settlements: _settlements, ...claimWithoutSettlements } =
-        claimFormData
+      // Settlements and recourses are managed via their own endpoints; remove
+      // them from the claim payload to avoid unintentionally overwriting
+      // existing records.
+      const {
+        settlements: _settlements,
+        recourses: _recourses,
+        ...claimWithoutSettlementsRecourses
+      } = claimFormData
 
-      const updatedClaim = await updateClaim(id, claimWithoutSettlements)
+      const updatedClaim = await updateClaim(
+        id,
+        claimWithoutSettlementsRecourses,
+      )
 
       if (updatedClaim) {
         setClaimFormData(updatedClaim)

--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -143,15 +143,19 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
     e.preventDefault()
 
     try {
-      // Settlements are handled via dedicated endpoints and should not be
-      // included when creating or updating a claim. Exclude them from the
-      // payload to prevent accidental overwrites.
-      const { settlements: _settlements, ...claimWithoutSettlements } = formData
+      // Settlements and recourses are handled via dedicated endpoints and
+      // should not be included when creating or updating a claim. Exclude
+      // them from the payload to prevent accidental overwrites.
+      const {
+        settlements: _settlements,
+        recourses: _recourses,
+        ...claimWithoutSettlementsRecourses
+      } = formData
 
       const payload: Claim = {
-        ...claimWithoutSettlements,
+        ...claimWithoutSettlementsRecourses,
         damages:
-          claimWithoutSettlements.damages?.map((d) => ({
+          claimWithoutSettlementsRecourses.damages?.map((d) => ({
             ...d,
             id: mode === 'create' ? undefined : d.id,
           })) || [],

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -271,10 +271,14 @@ export const transformFrontendClaimToApiPayload = (
         claimDate: toIso(claimDate, "clientClaims.claimDate"),
       }
     }),
-    recourses: recourses?.map((r) => ({
-      ...r,
-      recourseDate: toIso(r.recourseDate, "recourses.recourseDate"),
-    })),
+    ...(Array.isArray(recourses) && recourses.length > 0
+      ? {
+          recourses: recourses.map((r) => ({
+            ...r,
+            recourseDate: toIso(r.recourseDate, "recourses.recourseDate"),
+          })),
+        }
+      : {}),
 
     // Settlements may be managed through dedicated endpoints. When included
     // in the claim payload, ensure IDs are valid GUID strings; otherwise omit


### PR DESCRIPTION
## Summary
- include recourses in payload only when array is non-empty
- skip recourses in claim update requests to avoid unintended updates

## Testing
- `pnpm lint` (fails: ? How would you like to configure ESLint?)
- `pnpm test` (fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)

------
https://chatgpt.com/codex/tasks/task_e_689d30fb3c70832ca4ccdca75980d667