### PR TITLE
Fix settlement transfer date retention

### DIFF
--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -254,9 +254,9 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
     setFormData({
       externalEntity: isCustom ? "custom" : settlement.externalEntity ?? "",
       customExternalEntity: settlement.customExternalEntity ?? "",
-      transferDate: settlement.transferDate ?? "",
+      transferDate: settlement.transferDate?.slice(0, 10) ?? "",
       status: settlement.status ?? "",
-      settlementDate: settlement.settlementDate ?? "",
+      settlementDate: settlement.settlementDate?.slice(0, 10) ?? "",
       settlementAmount: settlement.settlementAmount ?? 0,
       currency: settlement.currency ?? "PLN",
       documentDescription: settlement.documentDescription ?? "",


### PR DESCRIPTION
## Summary
- ensure settlement transfer and resolution dates retain when editing by trimming ISO timestamps to date-only format

## Testing
- `pnpm lint` *(fails: Next.js asks to configure ESLint)*
- `pnpm test` *(fails: one test failing)*

------
https://chatgpt.com/codex/tasks/task_e_689d37690ac4832ca72cfec625753073