### PR TITLE
Add labels for settlement transfer and agreement dates

### DIFF
--- a/components/settlements-section.tsx
+++ b/components/settlements-section.tsx
@@ -11,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Label } from "@/components/ui/label"
 import { useToast } from "@/hooks/use-toast"
 import {
   getSettlements,
@@ -233,16 +234,24 @@ export function SettlementsSection({ eventId }: SettlementsSectionProps) {
                 }
               />
             )}
-            <Input
-              type="date"
-              value={formData.transferDate}
-              onChange={(e) => setFormData({ ...formData, transferDate: e.target.value })}
-            />
-            <Input
-              type="date"
-              value={formData.settlementDate}
-              onChange={(e) => setFormData({ ...formData, settlementDate: e.target.value })}
-            />
+            <div className="space-y-1">
+              <Label htmlFor="transferDate">Data przekazania do podmiotu zewnętrznego:</Label>
+              <Input
+                id="transferDate"
+                type="date"
+                value={formData.transferDate}
+                onChange={(e) => setFormData({ ...formData, transferDate: e.target.value })}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="settlementDate">Data zawarcia ugody:</Label>
+              <Input
+                id="settlementDate"
+                type="date"
+                value={formData.settlementDate}
+                onChange={(e) => setFormData({ ...formData, settlementDate: e.target.value })}
+              />
+            </div>
             <Input
               type="number"
               step="0.01"


### PR DESCRIPTION
## Summary
- add a Label import to settlements section
- display transfer and agreement date fields with text labels

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689d3ca06b68832c828f3eff98a0ccf1