### PR TITLE
Validate appeal document uploads

### DIFF
--- a/backend/Controllers/AppealsController.cs
+++ b/backend/Controllers/AppealsController.cs
@@ -93,7 +93,7 @@ namespace AutomotiveClaimsApi.Controllers
                     UpdatedAt = DateTime.UtcNow
                 };
 
-                if (createDto.Document != null)
+                if (createDto.Document != null && createDto.Document.Length > 0)
                 {
                     var documentResult = await _documentService.SaveDocumentAsync(
                         createDto.Document,
@@ -104,6 +104,10 @@ namespace AutomotiveClaimsApi.Controllers
                     appeal.DocumentPath = documentResult.FilePath;
                     appeal.DocumentName = documentResult.OriginalFileName;
                     appeal.DocumentDescription = createDto.DocumentDescription;
+                }
+                else if (createDto.Document != null)
+                {
+                    return BadRequest(new { error = "Document file is empty" });
                 }
 
                 _context.Appeals.Add(appeal);
@@ -137,7 +141,7 @@ namespace AutomotiveClaimsApi.Controllers
                 appeal.DecisionDate = updateDto.DecisionDate;
                 appeal.UpdatedAt = DateTime.UtcNow;
 
-                if (updateDto.Document != null)
+                if (updateDto.Document != null && updateDto.Document.Length > 0)
                 {
                     if (!string.IsNullOrEmpty(appeal.DocumentPath))
                     {
@@ -153,6 +157,10 @@ namespace AutomotiveClaimsApi.Controllers
                     appeal.DocumentPath = documentResult.FilePath;
                     appeal.DocumentName = documentResult.OriginalFileName;
                     appeal.DocumentDescription = updateDto.DocumentDescription;
+                }
+                else if (updateDto.Document != null)
+                {
+                    return BadRequest(new { error = "Document file is empty" });
                 }
                 else if (!string.IsNullOrEmpty(updateDto.DocumentDescription))
                 {


### PR DESCRIPTION
## Summary
- ensure appeal documents are only processed when a file is provided and non-empty
- return a 400 response when an empty document upload is attempted

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d473bd088832c9ed9e2f8d3b077c5