### PR TITLE
Use claim-specific decision download endpoint

### DIFF
--- a/app/api/decisions/[id]/download/route.ts
+++ b/app/api/decisions/[id]/download/route.ts
@@ -4,12 +4,20 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const id = params.id
+    const claimId = request.nextUrl.searchParams.get("claimId")
 
-    const response = await fetch(`${API_BASE_URL}/decisions/${id}/download`, {
-      headers: {
-        cookie: request.headers.get("cookie") ?? "",
+    if (!claimId) {
+      return NextResponse.json({ error: "claimId is required" }, { status: 400 })
+    }
+
+    const response = await fetch(
+      `${API_BASE_URL}/claims/${claimId}/decisions/${id}/download`,
+      {
+        headers: {
+          cookie: request.headers.get("cookie") ?? "",
+        },
       },
-    })
+    )
 
     if (!response.ok || !response.body) {
       throw new Error("Failed to download file")

--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -324,9 +324,18 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
       return
     }
 
+    if (!claimId) {
+      toast({
+        title: "Brak ID roszczenia",
+        description: "Nie można pobrać pliku bez ID roszczenia",
+        variant: "destructive",
+      })
+      return
+    }
+
     try {
       const response = await fetch(
-        `${API_BASE_URL}/decisions/${decision.id}/download`,
+        `${API_BASE_URL}/claims/${claimId}/decisions/${decision.id}/download`,
         {
           method: "GET",
           credentials: "include",


### PR DESCRIPTION
## Summary
- include claim ID when downloading decision documents
- proxy decision download requests to claim-specific backend endpoint

## Testing
- `pnpm test` *(fails: Cannot require() ES Module app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689d4725cdc8832cb1be9b5bf1f9c1b8