### PR TITLE
feat: add settings layout and navigation

### DIFF
--- a/app/settings/layout.tsx
+++ b/app/settings/layout.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+import { Header } from '@/components/header'
+import { Sidebar } from '@/components/sidebar'
+
+export default function SettingsLayout({ children }: { children: ReactNode }) {
+  const [activeTab, setActiveTab] = useState('settings')
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+      <div className="ml-16 flex flex-col min-h-screen">
+        <Header onMenuClick={() => {}} />
+        <main className="flex-1">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function SettingsPage() {
+  redirect('/settings/clients')
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -2,7 +2,7 @@
 import Link from "next/link"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import { LayoutDashboard, FileText, Car } from "lucide-react"
+import { LayoutDashboard, FileText, Car, Settings } from "lucide-react"
 
 interface SidebarProps {
   activeTab: string
@@ -21,6 +21,12 @@ const menuItems = [
     label: "Szkody",
     icon: FileText,
     href: "/claims",
+  },
+  {
+    id: "settings",
+    label: "Settings",
+    icon: Settings,
+    href: "/settings",
   },
 ]
 


### PR DESCRIPTION
## Summary
- add Settings menu item to sidebar
- create layout and redirect page for Settings section

## Testing
- `pnpm test` *(fails: ERR_REQUIRE_CYCLE_MODULE in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_689d9d65a82c832ca372c8ebb3f7cc9c