### PR TITLE
Add claim-aware decision preview endpoint

### DIFF
--- a/app/api/claims/[claimId]/decisions/[decisionId]/preview/route.ts
+++ b/app/api/claims/[claimId]/decisions/[decisionId]/preview/route.ts
@@ -1,15 +1,29 @@
 import { type NextRequest, NextResponse } from "next/server"
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
-export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { claimId: string; decisionId: string } },
+) {
   try {
-    const id = params.id
+    const { claimId, decisionId } = params
 
-    const response = await fetch(`${API_BASE_URL}/decisions/${id}/preview`, {
-      headers: {
-        cookie: request.headers.get("cookie") ?? "",
+    if (!claimId || !decisionId) {
+      return NextResponse.json(
+        { error: "claimId and decisionId are required" },
+        { status: 400 },
+      )
+    }
+
+    const response = await fetch(
+      `${API_BASE_URL}/claims/${claimId}/decisions/${decisionId}/preview`,
+      {
+        headers: {
+          cookie: request.headers.get("cookie") ?? "",
+        },
       },
-    })
+    )
 
     if (!response.ok || !response.body) {
       throw new Error("Failed to preview file")
@@ -26,3 +40,4 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
     return NextResponse.json({ error: "Internal server error" }, { status: 500 })
   }
 }
+

--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -373,10 +373,18 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
       })
       return
     }
+    if (!claimId) {
+      toast({
+        title: "Brak ID roszczenia",
+        description: "Nie można wyświetlić podglądu bez ID roszczenia",
+        variant: "destructive",
+      })
+      return
+    }
 
     try {
       const response = await fetch(
-        `${API_BASE_URL}/decisions/${decision.id}/preview`,
+        `${API_BASE_URL}/claims/${claimId}/decisions/${decision.id}/preview`,
         {
           method: "GET",
           credentials: "include",


### PR DESCRIPTION
## Summary
- require claim ID when previewing decision documents and use claim-scoped API path
- expose nested API route that proxies decision previews through claim context

## Testing
- `pnpm test` (fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)
- `pnpm lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_689da0915dfc832c985c7f0ca8878963