### PR TITLE
feat: enhance user management form

### DIFF
--- a/app/api/roles/route.ts
+++ b/app/api/roles/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json([
+    { value: 'user', label: 'Użytkownik' },
+    { value: 'admin', label: 'Administrator' },
+  ])
+}
+

--- a/components/user-form.tsx
+++ b/components/user-form.tsx
@@ -6,6 +6,9 @@ import { useRouter } from 'next/navigation'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
+import { SearchableSelect } from '@/components/ui/searchable-select'
+import { Switch } from '@/components/ui/switch'
+import { Badge } from '@/components/ui/badge'
 
 interface UserFormProps {
   userId?: string
@@ -13,26 +16,88 @@ interface UserFormProps {
 
 export default function UserForm({ userId }: UserFormProps) {
   const isEdit = !!userId
+  const router = useRouter()
   const [userName, setUserName] = useState('')
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const router = useRouter()
+  const [phone, setPhone] = useState('')
+  const [status, setStatus] = useState(true)
+  const [roles, setRoles] = useState<string[]>([])
+  const [roleValue, setRoleValue] = useState('')
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [originalEmail, setOriginalEmail] = useState('')
 
   useEffect(() => {
     if (isEdit && userId) {
       apiService.getUser(userId).then((u) => {
         setUserName(u.userName)
+        setFirstName(u.firstName ?? '')
+        setLastName(u.lastName ?? '')
         setEmail(u.email ?? '')
+        setPhone(u.phone ?? '')
+        setStatus(u.status !== 'inactive')
+        setRoles(u.roles ?? [])
+        setOriginalEmail(u.email ?? '')
       })
     }
   }, [isEdit, userId])
 
+  const handleRoleSelect = (value: string) => {
+    if (value && !roles.includes(value)) {
+      setRoles([...roles, value])
+    }
+    setRoleValue('')
+  }
+
+  const handleEmailBlur = async () => {
+    if (!email || email === originalEmail) return
+    const unique = await apiService.checkEmail(email)
+    setErrors((prev) => {
+      const newErrors = { ...prev }
+      if (unique) {
+        delete newErrors.email
+      } else {
+        newErrors.email = 'Email jest już używany'
+      }
+      return newErrors
+    })
+  }
+
+  const validate = async () => {
+    const newErrors: Record<string, string> = {}
+    if (!userName.trim()) newErrors.userName = 'Nazwa użytkownika jest wymagana'
+    if (!firstName.trim()) newErrors.firstName = 'Imię jest wymagane'
+    if (!lastName.trim()) newErrors.lastName = 'Nazwisko jest wymagane'
+    if (!email.trim()) newErrors.email = 'Email jest wymagany'
+    if (!isEdit && !password.trim()) newErrors.password = 'Hasło jest wymagane'
+    if (!phone.trim()) newErrors.phone = 'Telefon jest wymagany'
+    if (roles.length === 0) newErrors.roles = 'Wybierz co najmniej jedną rolę'
+    if (email && email !== originalEmail) {
+      const unique = await apiService.checkEmail(email)
+      if (!unique) newErrors.email = 'Email jest już używany'
+    }
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
+    if (!(await validate())) return
+    const payload = {
+      userName,
+      firstName,
+      lastName,
+      email,
+      phone,
+      roles,
+      status: status ? 'active' : 'inactive',
+    }
     if (isEdit && userId) {
-      await apiService.updateUser(userId, { userName, email })
+      await apiService.updateUser(userId, payload)
     } else {
-      await apiService.register(userName, email, password)
+      await apiService.register({ ...payload, password })
     }
     router.push('/')
   }
@@ -41,18 +106,69 @@ export default function UserForm({ userId }: UserFormProps) {
     <form onSubmit={handleSubmit} className="max-w-md space-y-4 p-4">
       <div>
         <Label htmlFor="userName">Nazwa użytkownika</Label>
-        <Input id="userName" value={userName} onChange={(e) => setUserName(e.target.value)} required />
+        <Input id="userName" value={userName} onChange={(e) => setUserName(e.target.value)} />
+        {errors.userName && <p className="text-sm text-red-500">{errors.userName}</p>}
+      </div>
+      <div>
+        <Label htmlFor="firstName">Imię</Label>
+        <Input id="firstName" value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+        {errors.firstName && <p className="text-sm text-red-500">{errors.firstName}</p>}
+      </div>
+      <div>
+        <Label htmlFor="lastName">Nazwisko</Label>
+        <Input id="lastName" value={lastName} onChange={(e) => setLastName(e.target.value)} />
+        {errors.lastName && <p className="text-sm text-red-500">{errors.lastName}</p>}
       </div>
       <div>
         <Label htmlFor="email">Email</Label>
-        <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+        <Input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          onBlur={handleEmailBlur}
+        />
+        {errors.email && <p className="text-sm text-red-500">{errors.email}</p>}
       </div>
       {!isEdit && (
         <div>
           <Label htmlFor="password">Hasło</Label>
-          <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          {errors.password && <p className="text-sm text-red-500">{errors.password}</p>}
         </div>
       )}
+      <div>
+        <Label htmlFor="phone">Telefon</Label>
+        <Input id="phone" value={phone} onChange={(e) => setPhone(e.target.value)} />
+        {errors.phone && <p className="text-sm text-red-500">{errors.phone}</p>}
+      </div>
+      <div className="flex items-center gap-2">
+        <Label htmlFor="status">Status</Label>
+        <Switch id="status" checked={status} onCheckedChange={setStatus} />
+        <span>{status ? 'Aktywowany' : 'Zablokowany'}</span>
+      </div>
+      <div>
+        <Label htmlFor="roles">Role</Label>
+        <SearchableSelect
+          apiEndpoint="/api/roles"
+          value={roleValue}
+          onValueChange={handleRoleSelect}
+          placeholder="Wybierz rolę..."
+        />
+        {errors.roles && <p className="text-sm text-red-500">{errors.roles}</p>}
+        {roles.length > 0 && (
+          <div className="flex flex-wrap gap-2 mt-2">
+            {roles.map((r) => (
+              <Badge key={r}>{r}</Badge>
+            ))}
+          </div>
+        )}
+      </div>
       <Button type="submit">{isEdit ? 'Zapisz' : 'Utwórz'} użytkownika</Button>
     </form>
   )

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -611,10 +611,19 @@ class ApiService {
     return text as unknown as T
   }
 
-  async register(username: string, email: string, password: string): Promise<void> {
+  async register(data: {
+    userName: string
+    email: string
+    password: string
+    firstName: string
+    lastName: string
+    roles: string[]
+    status: "active" | "inactive"
+    phone?: string
+  }): Promise<void> {
     await this.request<void>("/auth/register", {
       method: "POST",
-      body: JSON.stringify({ userName: username, email, password }),
+      body: JSON.stringify(data),
     })
   }
 
@@ -637,15 +646,56 @@ class ApiService {
     return { username: data.userName, email: data.email, roles: data.roles }
   }
 
-  async getUser(id: string): Promise<{ id: string; userName: string; email?: string }> {
-    return await this.request<{ id: string; userName: string; email?: string }>(`/auth/users/${id}`)
+  async getUser(
+    id: string,
+  ): Promise<{
+    id: string
+    userName: string
+    email?: string
+    firstName?: string
+    lastName?: string
+    roles?: string[]
+    status?: "active" | "inactive"
+    phone?: string
+  }> {
+    return await this.request<{
+      id: string
+      userName: string
+      email?: string
+      firstName?: string
+      lastName?: string
+      roles?: string[]
+      status?: "active" | "inactive"
+      phone?: string
+    }>(`/auth/users/${id}`)
   }
 
-  async updateUser(id: string, data: { userName?: string; email?: string }): Promise<void> {
+  async updateUser(
+    id: string,
+    data: {
+      userName?: string
+      email?: string
+      firstName?: string
+      lastName?: string
+      roles?: string[]
+      status?: "active" | "inactive"
+      phone?: string
+    },
+  ): Promise<void> {
     await this.request<void>(`/auth/users/${id}`, {
       method: "PUT",
       body: JSON.stringify(data),
     })
+  }
+
+  async checkEmail(email: string): Promise<boolean> {
+    const result = await this.request<{ isUnique?: boolean; exists?: boolean }>(
+      `/auth/users/check-email?email=${encodeURIComponent(email)}`,
+    )
+    if (result == null) return false
+    if (typeof result.isUnique === "boolean") return result.isUnique
+    if (typeof result.exists === "boolean") return !result.exists
+    return true
   }
   async getUsers(
     params: {


### PR DESCRIPTION
## Summary
- expand user form with first/last name, phone, status switch, multi-role selection
- add sync and async validation including unique email check
- expose roles API for searchable select

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689da3b9a510832c87b1176f2602b227