### PR TITLE
feat: track user login and creation timestamps

### DIFF
--- a/app/settings/users/page.tsx
+++ b/app/settings/users/page.tsx
@@ -203,11 +203,25 @@ export default function UsersPage() {
               Rola
               <ArrowUpDown className="inline h-4 w-4 ml-2" />
             </TableHead>
-            <TableHead
+          <TableHead
               onClick={() => toggleSort("status")}
               className="cursor-pointer"
             >
               Status
+              <ArrowUpDown className="inline h-4 w-4 ml-2" />
+            </TableHead>
+            <TableHead
+              onClick={() => toggleSort("createdAt")}
+              className="cursor-pointer"
+            >
+              Utworzono
+              <ArrowUpDown className="inline h-4 w-4 ml-2" />
+            </TableHead>
+            <TableHead
+              onClick={() => toggleSort("lastLogin")}
+              className="cursor-pointer"
+            >
+              Ostatnie logowanie
               <ArrowUpDown className="inline h-4 w-4 ml-2" />
             </TableHead>
           </TableRow>
@@ -231,6 +245,8 @@ export default function UsersPage() {
               <TableCell>
                 {u.status === "active" ? "Aktywny" : "Nieaktywny"}
               </TableCell>
+              <TableCell>{u.createdAt ? new Date(u.createdAt).toLocaleString() : "-"}</TableCell>
+              <TableCell>{u.lastLogin ? new Date(u.lastLogin).toLocaleString() : "-"}</TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Identity;
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using AutomotiveClaimsApi.Models;
@@ -77,7 +78,7 @@ namespace AutomotiveClaimsApi.Controllers
             if (dto.UserName == null || dto.Password == null)
                 return BadRequest();
 
-            var user = new ApplicationUser { UserName = dto.UserName, Email = dto.Email };
+            var user = new ApplicationUser { UserName = dto.UserName, Email = dto.Email, CreatedAt = DateTime.UtcNow };
             var result = await _userManager.CreateAsync(user, dto.Password);
             if (!result.Succeeded)
             {
@@ -101,6 +102,12 @@ namespace AutomotiveClaimsApi.Controllers
             {
                 return Unauthorized();
             }
+            var user = await _userManager.FindByNameAsync(dto.UserName);
+            if (user != null)
+            {
+                user.LastLogin = DateTime.UtcNow;
+                await _userManager.UpdateAsync(user);
+            }
             return Ok();
         }
 
@@ -119,7 +126,7 @@ namespace AutomotiveClaimsApi.Controllers
             var user = await _userManager.GetUserAsync(User);
             if (user == null) return Unauthorized();
             var roles = await _userManager.GetRolesAsync(user);
-            return new UserDto { Id = user.Id, UserName = user.UserName, Email = user.Email, Roles = roles };
+            return new UserDto { Id = user.Id, UserName = user.UserName, Email = user.Email, Roles = roles, CreatedAt = user.CreatedAt, LastLogin = user.LastLogin };
         }
 
         [Authorize]
@@ -129,7 +136,7 @@ namespace AutomotiveClaimsApi.Controllers
             var user = await _userManager.FindByIdAsync(id);
             if (user == null) return NotFound();
             var roles = await _userManager.GetRolesAsync(user);
-            return new UserDto { Id = user.Id, UserName = user.UserName, Email = user.Email, Roles = roles };
+            return new UserDto { Id = user.Id, UserName = user.UserName, Email = user.Email, Roles = roles, CreatedAt = user.CreatedAt, LastLogin = user.LastLogin };
         }
 
         [Authorize]

--- a/backend/DTOs/AuthDtos.cs
+++ b/backend/DTOs/AuthDtos.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace AutomotiveClaimsApi.DTOs
 {
     public class RegisterDto
@@ -37,5 +39,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? UserName { get; set; }
         public string? Email { get; set; }
         public IEnumerable<string>? Roles { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? LastLogin { get; set; }
     }
 }

--- a/backend/Migrations/20240130000018_AddUserAuditFields.cs
+++ b/backend/Migrations/20240130000018_AddUserAuditFields.cs
@@ -1,0 +1,40 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserAuditFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                table: "AspNetUsers",
+                type: "datetime2",
+                nullable: false,
+                defaultValueSql: "GETUTCDATE()");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastLogin",
+                table: "AspNetUsers",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LastLogin",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -100,6 +100,14 @@ namespace AutomotiveClaimsApi.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("datetime2")
+                        .HasDefaultValueSql("GETUTCDATE()");
+
+                    b.Property<DateTime?>("LastLogin")
+                        .HasColumnType("datetime2");
+
                     b.HasKey("Id");
 
                     b.HasIndex("NormalizedEmail")

--- a/backend/Models/ApplicationUser.cs
+++ b/backend/Models/ApplicationUser.cs
@@ -4,5 +4,7 @@ namespace AutomotiveClaimsApi.Models
 {
     public class ApplicationUser : IdentityUser
     {
+        public DateTime CreatedAt { get; set; }
+        public DateTime? LastLogin { get; set; }
     }
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -129,6 +129,8 @@ export interface UserListItemDto {
   email: string
   role: string
   status: "active" | "inactive"
+  createdAt?: string
+  lastLogin?: string
 }
 
 export interface UpdateUsersBulkDto {
@@ -631,14 +633,14 @@ class ApiService {
     this.setToken(null)
   }
 
-  async getCurrentUser(): Promise<{ username: string; email?: string; roles?: string[] } | undefined> {
-    const data = await this.request<{ id: string; userName: string; email: string; roles: string[] }>("/auth/me")
+  async getCurrentUser(): Promise<{ username: string; email?: string; roles?: string[]; createdAt?: string; lastLogin?: string } | undefined> {
+    const data = await this.request<{ id: string; userName: string; email: string; roles: string[]; createdAt: string; lastLogin?: string }>("/auth/me")
     if (!data) return undefined
-    return { username: data.userName, email: data.email, roles: data.roles }
+    return { username: data.userName, email: data.email, roles: data.roles, createdAt: data.createdAt, lastLogin: data.lastLogin }
   }
 
-  async getUser(id: string): Promise<{ id: string; userName: string; email?: string }> {
-    return await this.request<{ id: string; userName: string; email?: string }>(`/auth/users/${id}`)
+  async getUser(id: string): Promise<{ id: string; userName: string; email?: string; createdAt?: string; lastLogin?: string }> {
+    return await this.request<{ id: string; userName: string; email?: string; createdAt?: string; lastLogin?: string }>(`/auth/users/${id}`)
   }
 
   async updateUser(id: string, data: { userName?: string; email?: string }): Promise<void> {


### PR DESCRIPTION
## Summary
- track user creation and last login times
- expose timestamps via API and frontend
- show user creation and last login columns

## Testing
- `npm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `npm run lint` *(fails: next: not found)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689da41c9484832c913dd098708be483