### PR TITLE
feat: add user management endpoints

### DIFF
--- a/app/settings/users/page.tsx
+++ b/app/settings/users/page.tsx
@@ -87,7 +87,7 @@ export default function UsersPage() {
     action: "activate" | "deactivate" | "assignRole" | "delete",
     roleValue?: string,
   ) => {
-    await apiService.updateUsersBulk({
+    await apiService.bulkUpdateUsers({
       action,
       userIds: selected,
       role: roleValue,

--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Identity;
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using AutomotiveClaimsApi.Models;
@@ -101,6 +102,14 @@ namespace AutomotiveClaimsApi.Controllers
             {
                 return Unauthorized();
             }
+
+            var user = await _userManager.FindByNameAsync(dto.UserName);
+            if (user != null)
+            {
+                user.LastLogin = DateTime.UtcNow;
+                await _userManager.UpdateAsync(user);
+            }
+
             return Ok();
         }
 
@@ -120,29 +129,6 @@ namespace AutomotiveClaimsApi.Controllers
             if (user == null) return Unauthorized();
             var roles = await _userManager.GetRolesAsync(user);
             return new UserDto { Id = user.Id, UserName = user.UserName, Email = user.Email, Roles = roles };
-        }
-
-        [Authorize]
-        [HttpGet("users/{id}")]
-        public async Task<ActionResult<UserDto>> GetUser(string id)
-        {
-            var user = await _userManager.FindByIdAsync(id);
-            if (user == null) return NotFound();
-            var roles = await _userManager.GetRolesAsync(user);
-            return new UserDto { Id = user.Id, UserName = user.UserName, Email = user.Email, Roles = roles };
-        }
-
-        [Authorize]
-        [HttpPut("users/{id}")]
-        public async Task<IActionResult> UpdateUser(string id, [FromBody] UpdateUserDto dto)
-        {
-            var user = await _userManager.FindByIdAsync(id);
-            if (user == null) return NotFound();
-            if (dto.UserName != null) user.UserName = dto.UserName;
-            if (dto.Email != null) user.Email = dto.Email;
-            var result = await _userManager.UpdateAsync(user);
-            if (!result.Succeeded) return BadRequest(result.Errors);
-            return NoContent();
         }
 
     }

--- a/backend/Controllers/UsersController.cs
+++ b/backend/Controllers/UsersController.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using AutomotiveClaimsApi.Data;
+using AutomotiveClaimsApi.DTOs;
+using AutomotiveClaimsApi.Models;
+
+namespace AutomotiveClaimsApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize(Roles = "admin")]
+    public class UsersController : ControllerBase
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly RoleManager<IdentityRole> _roleManager;
+        private readonly ApplicationDbContext _context;
+
+        public UsersController(
+            UserManager<ApplicationUser> userManager,
+            RoleManager<IdentityRole> roleManager,
+            ApplicationDbContext context)
+        {
+            _userManager = userManager;
+            _roleManager = roleManager;
+            _context = context;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<UserListItemDto>>> GetUsers(
+            [FromQuery] string? search,
+            [FromQuery] string? role,
+            [FromQuery] string? status,
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 10,
+            [FromQuery] string? sortBy = null,
+            [FromQuery] string sortOrder = "asc")
+        {
+            var query = _userManager.Users.AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(search))
+            {
+                query = query.Where(u =>
+                    (u.UserName != null && u.UserName.Contains(search)) ||
+                    (u.Email != null && u.Email.Contains(search)) ||
+                    (u.FirstName != null && u.FirstName.Contains(search)) ||
+                    (u.LastName != null && u.LastName.Contains(search)));
+            }
+
+            if (!string.IsNullOrWhiteSpace(status))
+            {
+                bool active = status.ToLower() == "active";
+                query = query.Where(u => u.IsActive == active);
+            }
+
+            if (!string.IsNullOrWhiteSpace(role))
+            {
+                var roleEntity = await _roleManager.FindByNameAsync(role);
+                if (roleEntity != null)
+                {
+                    var userIds = _context.UserRoles
+                        .Where(ur => ur.RoleId == roleEntity.Id)
+                        .Select(ur => ur.UserId);
+                    query = query.Where(u => userIds.Contains(u.Id));
+                }
+            }
+
+            query = sortBy?.ToLower() switch
+            {
+                "firstname" => sortOrder == "desc" ? query.OrderByDescending(u => u.FirstName) : query.OrderBy(u => u.FirstName),
+                "lastname" => sortOrder == "desc" ? query.OrderByDescending(u => u.LastName) : query.OrderBy(u => u.LastName),
+                "email" => sortOrder == "desc" ? query.OrderByDescending(u => u.Email) : query.OrderBy(u => u.Email),
+                _ => sortOrder == "desc" ? query.OrderByDescending(u => u.UserName) : query.OrderBy(u => u.UserName)
+            };
+
+            var totalCount = await query.CountAsync();
+            var users = await query.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
+
+            var result = new List<UserListItemDto>();
+            foreach (var u in users)
+            {
+                var roles = await _userManager.GetRolesAsync(u);
+                result.Add(new UserListItemDto
+                {
+                    Id = u.Id,
+                    FirstName = u.FirstName,
+                    LastName = u.LastName,
+                    Email = u.Email,
+                    Role = roles.FirstOrDefault(),
+                    Status = u.IsActive ? "active" : "inactive"
+                });
+            }
+
+            Response.Headers["X-Total-Count"] = totalCount.ToString();
+            return result;
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<UserDto>> GetUser(string id)
+        {
+            var user = await _userManager.FindByIdAsync(id);
+            if (user == null) return NotFound();
+            var roles = await _userManager.GetRolesAsync(user);
+            return new UserDto
+            {
+                Id = user.Id,
+                UserName = user.UserName,
+                Email = user.Email,
+                FirstName = user.FirstName,
+                LastName = user.LastName,
+                PhoneNumber = user.PhoneNumber,
+                Roles = roles,
+                IsActive = user.IsActive
+            };
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateUser([FromBody] CreateUserDto dto)
+        {
+            var user = new ApplicationUser
+            {
+                UserName = dto.UserName,
+                Email = dto.Email,
+                FirstName = dto.FirstName,
+                LastName = dto.LastName,
+                PhoneNumber = dto.PhoneNumber,
+                IsActive = dto.IsActive,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            var result = await _userManager.CreateAsync(user, dto.Password!);
+            if (!result.Succeeded) return BadRequest(result.Errors);
+
+            if (dto.Roles != null && dto.Roles.Any())
+            {
+                await _userManager.AddToRolesAsync(user, dto.Roles);
+            }
+
+            return CreatedAtAction(nameof(GetUser), new { id = user.Id }, null);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateUser(string id, [FromBody] UpdateUserDto dto)
+        {
+            var user = await _userManager.FindByIdAsync(id);
+            if (user == null) return NotFound();
+
+            if (dto.UserName != null) user.UserName = dto.UserName;
+            if (dto.Email != null) user.Email = dto.Email;
+            if (dto.FirstName != null) user.FirstName = dto.FirstName;
+            if (dto.LastName != null) user.LastName = dto.LastName;
+            if (dto.PhoneNumber != null) user.PhoneNumber = dto.PhoneNumber;
+            if (dto.IsActive.HasValue) user.IsActive = dto.IsActive.Value;
+
+            var updateResult = await _userManager.UpdateAsync(user);
+            if (!updateResult.Succeeded) return BadRequest(updateResult.Errors);
+
+            if (dto.Roles != null)
+            {
+                var currentRoles = await _userManager.GetRolesAsync(user);
+                var rolesToAdd = dto.Roles.Except(currentRoles);
+                var rolesToRemove = currentRoles.Except(dto.Roles);
+                if (rolesToAdd.Any()) await _userManager.AddToRolesAsync(user, rolesToAdd);
+                if (rolesToRemove.Any()) await _userManager.RemoveFromRolesAsync(user, rolesToRemove);
+            }
+
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteUser(string id)
+        {
+            var user = await _userManager.FindByIdAsync(id);
+            if (user == null) return NotFound();
+            var result = await _userManager.DeleteAsync(user);
+            if (!result.Succeeded) return BadRequest(result.Errors);
+            return NoContent();
+        }
+
+        [HttpPost("bulk")]
+        public async Task<IActionResult> Bulk([FromBody] BulkUpdateUsersDto dto)
+        {
+            foreach (var userId in dto.UserIds)
+            {
+                var user = await _userManager.FindByIdAsync(userId);
+                if (user == null) continue;
+
+                switch (dto.Action)
+                {
+                    case "activate":
+                        user.IsActive = true;
+                        await _userManager.UpdateAsync(user);
+                        break;
+                    case "deactivate":
+                        user.IsActive = false;
+                        await _userManager.UpdateAsync(user);
+                        break;
+                    case "assignRole":
+                        if (!string.IsNullOrEmpty(dto.Role) && !await _userManager.IsInRoleAsync(user, dto.Role))
+                        {
+                            await _userManager.AddToRoleAsync(user, dto.Role);
+                        }
+                        break;
+                    case "delete":
+                        await _userManager.DeleteAsync(user);
+                        break;
+                }
+            }
+
+            return NoContent();
+        }
+    }
+}

--- a/backend/DTOs/AuthDtos.cs
+++ b/backend/DTOs/AuthDtos.cs
@@ -25,17 +25,4 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Password { get; set; }
     }
 
-    public class UpdateUserDto
-    {
-        public string? UserName { get; set; }
-        public string? Email { get; set; }
-    }
-
-    public class UserDto
-    {
-        public string? Id { get; set; }
-        public string? UserName { get; set; }
-        public string? Email { get; set; }
-        public IEnumerable<string>? Roles { get; set; }
-    }
 }

--- a/backend/DTOs/UserDtos.cs
+++ b/backend/DTOs/UserDtos.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class UserListItemDto
+    {
+        public string? Id { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? Email { get; set; }
+        public string? Role { get; set; }
+        public string Status { get; set; } = "inactive";
+    }
+
+    public class UserDto
+    {
+        public string? Id { get; set; }
+        public string? UserName { get; set; }
+        public string? Email { get; set; }
+        public IEnumerable<string>? Roles { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public bool IsActive { get; set; }
+        public string? PhoneNumber { get; set; }
+    }
+
+    public class CreateUserDto
+    {
+        [Required]
+        public string? UserName { get; set; }
+
+        [Required, EmailAddress]
+        public string? Email { get; set; }
+
+        [Required]
+        public string? Password { get; set; }
+
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? PhoneNumber { get; set; }
+        public IList<string>? Roles { get; set; }
+        public bool IsActive { get; set; } = true;
+    }
+
+    public class UpdateUserDto
+    {
+        public string? UserName { get; set; }
+        [EmailAddress]
+        public string? Email { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? PhoneNumber { get; set; }
+        public IList<string>? Roles { get; set; }
+        public bool? IsActive { get; set; }
+    }
+
+    public class BulkUpdateUsersDto
+    {
+        [Required]
+        public IEnumerable<string> UserIds { get; set; } = new List<string>();
+
+        [Required]
+        public string Action { get; set; } = string.Empty;
+
+        public string? Role { get; set; }
+    }
+}

--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -46,6 +46,14 @@ namespace AutomotiveClaimsApi.Data
         {
             base.OnModelCreating(modelBuilder);
 
+            modelBuilder.Entity<ApplicationUser>(entity =>
+            {
+                entity.Property(u => u.FirstName).HasMaxLength(100);
+                entity.Property(u => u.LastName).HasMaxLength(100);
+                entity.Property(u => u.IsActive).HasDefaultValue(true);
+                entity.Property(u => u.CreatedAt).HasDefaultValueSql("GETUTCDATE()");
+            });
+
             // Event is the central aggregate root
             modelBuilder.Entity<Event>(entity =>
             {

--- a/backend/Migrations/20240130000018_AddUserFields.cs
+++ b/backend/Migrations/20240130000018_AddUserFields.cs
@@ -1,0 +1,73 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FirstName",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LastName",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "AspNetUsers",
+                type: "bit",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                table: "AspNetUsers",
+                type: "datetime2",
+                nullable: false,
+                defaultValueSql: "GETUTCDATE()");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastLogin",
+                table: "AspNetUsers",
+                type: "datetime2",
+                nullable: true);
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FirstName",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LastName",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LastLogin",
+                table: "AspNetUsers");
+
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -67,6 +67,23 @@ namespace AutomotiveClaimsApi.Migrations
                     b.Property<bool>("EmailConfirmed")
                         .HasColumnType("bit");
 
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("datetime2")
+                        .HasDefaultValueSql("GETUTCDATE()");
+
+                    b.Property<string>("FirstName")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<bool>("IsActive")
+                        .HasColumnType("bit")
+                        .HasDefaultValue(true);
+
+                    b.Property<string>("LastName")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTime?>("LastLogin")
+                        .HasColumnType("datetime2");
+
                     b.Property<bool>("LockoutEnabled")
                         .HasColumnType("bit");
 

--- a/backend/Models/ApplicationUser.cs
+++ b/backend/Models/ApplicationUser.cs
@@ -4,5 +4,11 @@ namespace AutomotiveClaimsApi.Models
 {
     public class ApplicationUser : IdentityUser
     {
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public override string? PhoneNumber { get; set; }
+        public bool IsActive { get; set; } = true;
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime? LastLogin { get; set; }
     }
 }

--- a/components/user-form.tsx
+++ b/components/user-form.tsx
@@ -6,6 +6,8 @@ import { useRouter } from 'next/navigation'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select'
+import { Checkbox } from '@/components/ui/checkbox'
 
 interface UserFormProps {
   userId?: string
@@ -16,6 +18,11 @@ export default function UserForm({ userId }: UserFormProps) {
   const [userName, setUserName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [phoneNumber, setPhoneNumber] = useState('')
+  const [role, setRole] = useState('user')
+  const [isActive, setIsActive] = useState(true)
   const router = useRouter()
 
   useEffect(() => {
@@ -23,6 +30,11 @@ export default function UserForm({ userId }: UserFormProps) {
       apiService.getUser(userId).then((u) => {
         setUserName(u.userName)
         setEmail(u.email ?? '')
+        setFirstName(u.firstName ?? '')
+        setLastName(u.lastName ?? '')
+        setPhoneNumber(u.phoneNumber ?? '')
+        setRole(u.roles[0] ?? 'user')
+        setIsActive(u.isActive)
       })
     }
   }, [isEdit, userId])
@@ -30,11 +42,35 @@ export default function UserForm({ userId }: UserFormProps) {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     if (isEdit && userId) {
-      await apiService.updateUser(userId, { userName, email })
+      await apiService.updateUser(userId, {
+        userName,
+        email,
+        firstName,
+        lastName,
+        phoneNumber,
+        roles: [role],
+        isActive,
+      })
     } else {
-      await apiService.register(userName, email, password)
+      await apiService.createUser({
+        userName,
+        email,
+        password,
+        firstName,
+        lastName,
+        phoneNumber,
+        roles: [role],
+        isActive,
+      })
     }
-    router.push('/')
+    router.push('/settings/users')
+  }
+
+  const handleDelete = async () => {
+    if (userId) {
+      await apiService.deleteUser(userId)
+      router.push('/settings/users')
+    }
   }
 
   return (
@@ -43,17 +79,60 @@ export default function UserForm({ userId }: UserFormProps) {
         <Label htmlFor="userName">Nazwa użytkownika</Label>
         <Input id="userName" value={userName} onChange={(e) => setUserName(e.target.value)} required />
       </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <Label htmlFor="firstName">Imię</Label>
+          <Input id="firstName" value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+        </div>
+        <div>
+          <Label htmlFor="lastName">Nazwisko</Label>
+          <Input id="lastName" value={lastName} onChange={(e) => setLastName(e.target.value)} />
+        </div>
+      </div>
       <div>
         <Label htmlFor="email">Email</Label>
         <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
       </div>
+      <div>
+        <Label htmlFor="phone">Telefon</Label>
+        <Input id="phone" value={phoneNumber} onChange={(e) => setPhoneNumber(e.target.value)} />
+      </div>
       {!isEdit && (
         <div>
           <Label htmlFor="password">Hasło</Label>
-          <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
         </div>
       )}
-      <Button type="submit">{isEdit ? 'Zapisz' : 'Utwórz'} użytkownika</Button>
+      <div>
+        <Label>Rola</Label>
+        <Select value={role} onValueChange={setRole}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder="Rola" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="user">Użytkownik</SelectItem>
+            <SelectItem value="admin">Administrator</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="flex items-center space-x-2">
+        <Checkbox id="active" checked={isActive} onCheckedChange={(c) => setIsActive(!!c)} />
+        <Label htmlFor="active">Aktywny</Label>
+      </div>
+      <div className="flex gap-2">
+        <Button type="submit">{isEdit ? 'Zapisz' : 'Utwórz'} użytkownika</Button>
+        {isEdit && (
+          <Button type="button" variant="destructive" onClick={handleDelete}>
+            Usuń
+          </Button>
+        )}
+      </div>
     </form>
   )
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -131,7 +131,18 @@ export interface UserListItemDto {
   status: "active" | "inactive"
 }
 
-export interface UpdateUsersBulkDto {
+export interface UserDto {
+  id: string
+  userName: string
+  email: string
+  firstName?: string
+  lastName?: string
+  phoneNumber?: string
+  roles: string[]
+  isActive: boolean
+}
+
+export interface BulkUpdateUsersDto {
   userIds: string[]
   action: "activate" | "deactivate" | "assignRole" | "delete"
   role?: string
@@ -637,16 +648,48 @@ class ApiService {
     return { username: data.userName, email: data.email, roles: data.roles }
   }
 
-  async getUser(id: string): Promise<{ id: string; userName: string; email?: string }> {
-    return await this.request<{ id: string; userName: string; email?: string }>(`/auth/users/${id}`)
+  async getUser(id: string): Promise<UserDto> {
+    return await this.request<UserDto>(`/users/${id}`)
   }
 
-  async updateUser(id: string, data: { userName?: string; email?: string }): Promise<void> {
-    await this.request<void>(`/auth/users/${id}`, {
+  async createUser(data: {
+    userName: string
+    email: string
+    password: string
+    firstName?: string
+    lastName?: string
+    phoneNumber?: string
+    roles?: string[]
+    isActive?: boolean
+  }): Promise<void> {
+    await this.request<void>("/users", {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+  }
+
+  async updateUser(
+    id: string,
+    data: {
+      userName?: string
+      email?: string
+      firstName?: string
+      lastName?: string
+      phoneNumber?: string
+      roles?: string[]
+      isActive?: boolean
+    },
+  ): Promise<void> {
+    await this.request<void>(`/users/${id}`, {
       method: "PUT",
       body: JSON.stringify(data),
     })
   }
+
+  async deleteUser(id: string): Promise<void> {
+    await this.request<void>(`/users/${id}`, { method: "DELETE" })
+  }
+
   async getUsers(
     params: {
       search?: string
@@ -665,7 +708,7 @@ class ApiService {
       }
     })
 
-    const url = `/auth/users${searchParams.toString() ? `?${searchParams.toString()}` : ""}`
+    const url = `/users${searchParams.toString() ? `?${searchParams.toString()}` : ""}`
 
     const token = this.getToken()
     const response = await fetch(`${API_BASE_URL}${url}`, {
@@ -693,8 +736,8 @@ class ApiService {
     return { items: data ?? [], totalCount }
   }
 
-  async updateUsersBulk(data: UpdateUsersBulkDto): Promise<void> {
-    await this.request<void>("/auth/users/bulk", {
+  async bulkUpdateUsers(data: BulkUpdateUsersDto): Promise<void> {
+    await this.request<void>("/users/bulk", {
       method: "POST",
       body: JSON.stringify(data),
     })


### PR DESCRIPTION
## Summary
- extend `ApplicationUser` with profile and status fields
- add admin `UsersController` with CRUD and bulk operations
- expose user management APIs and UI hooks in frontend

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*
- `npm test` *(fails: Cannot find module 'tsconfig-paths/register')*


------
https://chatgpt.com/codex/tasks/task_e_689da40822c8832cbe6339a49d1592e1