### PR TITLE
Add services for risk and damage types

### DIFF
--- a/backend/Controllers/DamageTypesController.cs
+++ b/backend/Controllers/DamageTypesController.cs
@@ -1,12 +1,6 @@
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using AutomotiveClaimsApi.Data;
 using AutomotiveClaimsApi.DTOs;
-using AutomotiveClaimsApi.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using AutomotiveClaimsApi.Services;
+using Microsoft.AspNetCore.Mvc;
 
 namespace AutomotiveClaimsApi.Controllers
 {
@@ -14,191 +8,72 @@ namespace AutomotiveClaimsApi.Controllers
     [Route("api/[controller]")]
     public class DamageTypesController : ControllerBase
     {
-        private readonly ApplicationDbContext _context;
-        private readonly ILogger<DamageTypesController> _logger;
+        private readonly IDamageTypeService _service;
 
-        public DamageTypesController(ApplicationDbContext context, ILogger<DamageTypesController> logger)
+        public DamageTypesController(IDamageTypeService service)
         {
-            _context = context;
-            _logger = logger;
+            _service = service;
         }
 
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<DamageTypeDto>>> GetDamageTypes([FromQuery] Guid? riskTypeId = null)
+        public async Task<IActionResult> GetDamageTypes([FromQuery] Guid? riskTypeId = null)
         {
-            try
+            var result = await _service.GetDamageTypesAsync(riskTypeId);
+            if (!result.Success)
             {
-                var query = _context.DamageTypes
-                    .Include(dt => dt.RiskType)
-                    .Where(dt => dt.IsActive);
-
-                if (riskTypeId.HasValue)
-                {
-                    query = query.Where(dt => dt.RiskTypeId == riskTypeId.Value);
-                }
-
-                var damageTypes = await query
-                    .OrderBy(dt => dt.Name)
-                    .Select(dt => new DamageTypeDto
-                    {
-                        Id = dt.Id,
-                        Name = dt.Name,
-                        Code = dt.Code,
-                        Description = dt.Description,
-                        RiskTypeId = dt.RiskTypeId,
-                        RiskTypeName = dt.RiskType != null ? dt.RiskType.Name : null,
-                        IsActive = dt.IsActive,
-                        CreatedAt = dt.CreatedAt,
-                        UpdatedAt = dt.UpdatedAt
-                    })
-                    .ToListAsync();
-
-                return Ok(damageTypes);
+                return StatusCode(result.StatusCode, new { error = result.Error });
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error retrieving damage types");
-                return StatusCode(500, "Internal server error");
-            }
+
+            return Ok(result.Data);
         }
 
         [HttpGet("{id}")]
-        public async Task<ActionResult<DamageTypeDto>> GetDamageType(Guid id)
+        public async Task<IActionResult> GetDamageType(Guid id)
         {
-            try
+            var result = await _service.GetDamageTypeAsync(id);
+            if (!result.Success)
             {
-                var damageType = await _context.DamageTypes
-                    .Include(dt => dt.RiskType)
-                    .FirstOrDefaultAsync(dt => dt.Id == id);
-
-                if (damageType == null)
-                {
-                    return NotFound($"Damage type with ID {id} not found");
-                }
-
-                var damageTypeDto = new DamageTypeDto
-                {
-                    Id = damageType.Id,
-                    Name = damageType.Name,
-                    Code = damageType.Code,
-                    Description = damageType.Description,
-                    RiskTypeId = damageType.RiskTypeId,
-                    RiskTypeName = damageType.RiskType?.Name,
-                    IsActive = damageType.IsActive,
-                    CreatedAt = damageType.CreatedAt,
-                    UpdatedAt = damageType.UpdatedAt
-                };
-
-                return Ok(damageTypeDto);
+                return StatusCode(result.StatusCode, new { error = result.Error });
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error retrieving damage type with ID {Id}", id);
-                return StatusCode(500, "Internal server error");
-            }
+
+            return Ok(result.Data);
         }
 
         [HttpPost]
-        public async Task<ActionResult<DamageTypeDto>> CreateDamageType(DamageTypeDto damageTypeDto)
+        public async Task<IActionResult> CreateDamageType(DamageTypeDto dto)
         {
-            try
+            var result = await _service.CreateDamageTypeAsync(dto);
+            if (!result.Success)
             {
-                if (!ModelState.IsValid)
-                {
-                    return BadRequest(ModelState);
-                }
-
-                var riskTypeExists = await _context.RiskTypes
-                    .AnyAsync(rt => rt.Id == damageTypeDto.RiskTypeId && rt.IsActive);
-
-                if (!riskTypeExists)
-                {
-                    return BadRequest($"Risk type with ID {damageTypeDto.RiskTypeId} not found or inactive");
-                }
-
-                var damageType = new DamageType
-                {
-                    Id = Guid.NewGuid(),
-                    Name = damageTypeDto.Name,
-                    Code = damageTypeDto.Code,
-                    Description = damageTypeDto.Description,
-                    RiskTypeId = damageTypeDto.RiskTypeId,
-                    IsActive = damageTypeDto.IsActive,
-                    CreatedAt = DateTime.UtcNow,
-                    UpdatedAt = DateTime.UtcNow
-                };
-
-                _context.DamageTypes.Add(damageType);
-                await _context.SaveChangesAsync();
-
-                damageTypeDto.Id = damageType.Id;
-                damageTypeDto.CreatedAt = damageType.CreatedAt;
-                damageTypeDto.UpdatedAt = damageType.UpdatedAt;
-
-                return CreatedAtAction(nameof(GetDamageType), new { id = damageType.Id }, damageTypeDto);
+                return StatusCode(result.StatusCode, new { error = result.Error });
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error creating damage type");
-                return StatusCode(500, "Internal server error");
-            }
+
+            return CreatedAtAction(nameof(GetDamageType), new { id = result.Data!.Id }, result.Data);
         }
 
         [HttpPut("{id}")]
-        public async Task<IActionResult> UpdateDamageType(Guid id, DamageTypeDto damageTypeDto)
+        public async Task<IActionResult> UpdateDamageType(Guid id, DamageTypeDto dto)
         {
-            try
+            var result = await _service.UpdateDamageTypeAsync(id, dto);
+            if (!result.Success)
             {
-                if (id != damageTypeDto.Id)
-                {
-                    return BadRequest("ID mismatch");
-                }
-
-                var damageType = await _context.DamageTypes.FindAsync(id);
-                if (damageType == null)
-                {
-                    return NotFound($"Damage type with ID {id} not found");
-                }
-
-                damageType.Name = damageTypeDto.Name;
-                damageType.Code = damageTypeDto.Code;
-                damageType.Description = damageTypeDto.Description;
-                damageType.RiskTypeId = damageTypeDto.RiskTypeId;
-                damageType.IsActive = damageTypeDto.IsActive;
-                damageType.UpdatedAt = DateTime.UtcNow;
-
-                await _context.SaveChangesAsync();
-                return NoContent();
+                return StatusCode(result.StatusCode, new { error = result.Error });
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error updating damage type with ID {Id}", id);
-                return StatusCode(500, "Internal server error");
-            }
+
+            return NoContent();
         }
 
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteDamageType(Guid id)
         {
-            try
+            var result = await _service.DeleteDamageTypeAsync(id);
+            if (!result.Success)
             {
-                var damageType = await _context.DamageTypes.FindAsync(id);
-                if (damageType == null)
-                {
-                    return NotFound($"Damage type with ID {id} not found");
-                }
-
-                damageType.IsActive = false;
-                damageType.UpdatedAt = DateTime.UtcNow;
-
-                await _context.SaveChangesAsync();
-                return NoContent();
+                return StatusCode(result.StatusCode, new { error = result.Error });
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error deleting damage type with ID {Id}", id);
-                return StatusCode(500, "Internal server error");
-            }
+
+            return NoContent();
         }
     }
 }
+

--- a/backend/DTOs/RiskTypeDto.cs
+++ b/backend/DTOs/RiskTypeDto.cs
@@ -16,5 +16,11 @@ namespace AutomotiveClaimsApi.DTOs
         
         [MaxLength(500)]
         public string? Description { get; set; }
+
+        public bool IsActive { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+
+        public DateTime? UpdatedAt { get; set; }
     }
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -61,6 +61,8 @@ builder.Services.Configure<GoogleCloudStorageSettings>(
 builder.Services.AddScoped<IEmailService, EmailService>();
 builder.Services.AddScoped<IDocumentService, DocumentService>();
 builder.Services.AddScoped<IGoogleCloudStorageService, GoogleCloudStorageService>();
+builder.Services.AddScoped<IRiskTypeService, RiskTypeService>();
+builder.Services.AddScoped<IDamageTypeService, DamageTypeService>();
 
 // Add background services
 builder.Services.AddHostedService<EmailBackgroundService>();

--- a/backend/Services/DamageTypeService.cs
+++ b/backend/Services/DamageTypeService.cs
@@ -1,0 +1,208 @@
+using AutomotiveClaimsApi.Data;
+using AutomotiveClaimsApi.DTOs;
+using Microsoft.EntityFrameworkCore;
+
+namespace AutomotiveClaimsApi.Services
+{
+    public class DamageTypeService : IDamageTypeService
+    {
+        private readonly ApplicationDbContext _context;
+
+        public DamageTypeService(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<ServiceResult<IEnumerable<DamageTypeDto>>> GetDamageTypesAsync(Guid? riskTypeId)
+        {
+            try
+            {
+                var query = _context.DamageTypes
+                    .Include(dt => dt.RiskType)
+                    .Where(dt => dt.IsActive);
+
+                if (riskTypeId.HasValue)
+                {
+                    query = query.Where(dt => dt.RiskTypeId == riskTypeId.Value);
+                }
+
+                var damageTypes = await query
+                    .OrderBy(dt => dt.Name)
+                    .Select(dt => new DamageTypeDto
+                    {
+                        Id = dt.Id,
+                        Name = dt.Name,
+                        Code = dt.Code,
+                        Description = dt.Description,
+                        RiskTypeId = dt.RiskTypeId,
+                        RiskTypeName = dt.RiskType != null ? dt.RiskType.Name : null,
+                        IsActive = dt.IsActive,
+                        CreatedAt = dt.CreatedAt,
+                        UpdatedAt = dt.UpdatedAt
+                    })
+                    .ToListAsync();
+
+                return ServiceResult<IEnumerable<DamageTypeDto>>.Ok(damageTypes);
+            }
+            catch
+            {
+                return ServiceResult<IEnumerable<DamageTypeDto>>.Fail("Failed to fetch damage types", 500);
+            }
+        }
+
+        public async Task<ServiceResult<DamageTypeDto>> GetDamageTypeAsync(Guid id)
+        {
+            try
+            {
+                var damageType = await _context.DamageTypes
+                    .Include(dt => dt.RiskType)
+                    .FirstOrDefaultAsync(dt => dt.Id == id && dt.IsActive);
+
+                if (damageType == null)
+                {
+                    return ServiceResult<DamageTypeDto>.Fail("Damage type not found", 404);
+                }
+
+                var dto = new DamageTypeDto
+                {
+                    Id = damageType.Id,
+                    Name = damageType.Name,
+                    Code = damageType.Code,
+                    Description = damageType.Description,
+                    RiskTypeId = damageType.RiskTypeId,
+                    RiskTypeName = damageType.RiskType?.Name,
+                    IsActive = damageType.IsActive,
+                    CreatedAt = damageType.CreatedAt,
+                    UpdatedAt = damageType.UpdatedAt
+                };
+
+                return ServiceResult<DamageTypeDto>.Ok(dto);
+            }
+            catch
+            {
+                return ServiceResult<DamageTypeDto>.Fail("Failed to fetch damage type", 500);
+            }
+        }
+
+        public async Task<ServiceResult<DamageTypeDto>> CreateDamageTypeAsync(DamageTypeDto dto)
+        {
+            try
+            {
+                var riskExists = await _context.RiskTypes
+                    .AnyAsync(rt => rt.Id == dto.RiskTypeId && rt.IsActive);
+                if (!riskExists)
+                {
+                    return ServiceResult<DamageTypeDto>.Fail("Risk type not found or inactive", 400);
+                }
+
+                if (await _context.DamageTypes.AnyAsync(dt => dt.Code == dto.Code && dt.RiskTypeId == dto.RiskTypeId))
+                {
+                    return ServiceResult<DamageTypeDto>.Fail("Damage type code already exists", 409);
+                }
+
+                var damageType = new Models.DamageType
+                {
+                    Id = Guid.NewGuid(),
+                    Name = dto.Name,
+                    Code = dto.Code,
+                    Description = dto.Description,
+                    RiskTypeId = dto.RiskTypeId,
+                    IsActive = dto.IsActive,
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                };
+
+                _context.DamageTypes.Add(damageType);
+                await _context.SaveChangesAsync();
+
+                var riskTypeName = await _context.RiskTypes
+                    .Where(rt => rt.Id == dto.RiskTypeId)
+                    .Select(rt => rt.Name)
+                    .FirstOrDefaultAsync();
+
+                var result = new DamageTypeDto
+                {
+                    Id = damageType.Id,
+                    Name = damageType.Name,
+                    Code = damageType.Code,
+                    Description = damageType.Description,
+                    RiskTypeId = damageType.RiskTypeId,
+                    RiskTypeName = riskTypeName,
+                    IsActive = damageType.IsActive,
+                    CreatedAt = damageType.CreatedAt,
+                    UpdatedAt = damageType.UpdatedAt
+                };
+
+                return ServiceResult<DamageTypeDto>.Created(result);
+            }
+            catch
+            {
+                return ServiceResult<DamageTypeDto>.Fail("Failed to create damage type", 500);
+            }
+        }
+
+        public async Task<ServiceResult> UpdateDamageTypeAsync(Guid id, DamageTypeDto dto)
+        {
+            try
+            {
+                if (id != dto.Id)
+                {
+                    return ServiceResult.Fail("ID mismatch", 400);
+                }
+
+                var damageType = await _context.DamageTypes.FindAsync(id);
+                if (damageType == null || !damageType.IsActive)
+                {
+                    return ServiceResult.Fail("Damage type not found", 404);
+                }
+
+                if (!await _context.RiskTypes.AnyAsync(rt => rt.Id == dto.RiskTypeId && rt.IsActive))
+                {
+                    return ServiceResult.Fail("Risk type not found or inactive", 400);
+                }
+
+                if (await _context.DamageTypes.AnyAsync(dt => dt.Code == dto.Code && dt.RiskTypeId == dto.RiskTypeId && dt.Id != id))
+                {
+                    return ServiceResult.Fail("Damage type code already exists", 409);
+                }
+
+                damageType.Name = dto.Name;
+                damageType.Code = dto.Code;
+                damageType.Description = dto.Description;
+                damageType.RiskTypeId = dto.RiskTypeId;
+                damageType.IsActive = dto.IsActive;
+                damageType.UpdatedAt = DateTime.UtcNow;
+
+                await _context.SaveChangesAsync();
+                return ServiceResult.Ok();
+            }
+            catch
+            {
+                return ServiceResult.Fail("Failed to update damage type", 500);
+            }
+        }
+
+        public async Task<ServiceResult> DeleteDamageTypeAsync(Guid id)
+        {
+            try
+            {
+                var damageType = await _context.DamageTypes.FindAsync(id);
+                if (damageType == null || !damageType.IsActive)
+                {
+                    return ServiceResult.Fail("Damage type not found", 404);
+                }
+
+                damageType.IsActive = false;
+                damageType.UpdatedAt = DateTime.UtcNow;
+
+                await _context.SaveChangesAsync();
+                return ServiceResult.Ok();
+            }
+            catch
+            {
+                return ServiceResult.Fail("Failed to delete damage type", 500);
+            }
+        }
+    }
+}
+

--- a/backend/Services/IDamageTypeService.cs
+++ b/backend/Services/IDamageTypeService.cs
@@ -1,0 +1,14 @@
+using AutomotiveClaimsApi.DTOs;
+
+namespace AutomotiveClaimsApi.Services
+{
+    public interface IDamageTypeService
+    {
+        Task<ServiceResult<IEnumerable<DamageTypeDto>>> GetDamageTypesAsync(Guid? riskTypeId);
+        Task<ServiceResult<DamageTypeDto>> GetDamageTypeAsync(Guid id);
+        Task<ServiceResult<DamageTypeDto>> CreateDamageTypeAsync(DamageTypeDto dto);
+        Task<ServiceResult> UpdateDamageTypeAsync(Guid id, DamageTypeDto dto);
+        Task<ServiceResult> DeleteDamageTypeAsync(Guid id);
+    }
+}
+

--- a/backend/Services/IRiskTypeService.cs
+++ b/backend/Services/IRiskTypeService.cs
@@ -1,0 +1,14 @@
+using AutomotiveClaimsApi.DTOs;
+
+namespace AutomotiveClaimsApi.Services
+{
+    public interface IRiskTypeService
+    {
+        Task<ServiceResult<IEnumerable<RiskTypeDto>>> GetRiskTypesAsync(int? claimObjectTypeId);
+        Task<ServiceResult<RiskTypeDto>> GetRiskTypeAsync(Guid id);
+        Task<ServiceResult<RiskTypeDto>> CreateRiskTypeAsync(RiskTypeDto dto);
+        Task<ServiceResult> UpdateRiskTypeAsync(Guid id, RiskTypeDto dto);
+        Task<ServiceResult> DeleteRiskTypeAsync(Guid id);
+    }
+}
+

--- a/backend/Services/RiskTypeService.cs
+++ b/backend/Services/RiskTypeService.cs
@@ -1,0 +1,176 @@
+using AutomotiveClaimsApi.Data;
+using AutomotiveClaimsApi.DTOs;
+using Microsoft.EntityFrameworkCore;
+
+namespace AutomotiveClaimsApi.Services
+{
+    public class RiskTypeService : IRiskTypeService
+    {
+        private readonly ApplicationDbContext _context;
+
+        public RiskTypeService(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<ServiceResult<IEnumerable<RiskTypeDto>>> GetRiskTypesAsync(int? claimObjectTypeId)
+        {
+            try
+            {
+                var query = _context.RiskTypes.Where(rt => rt.IsActive);
+
+                if (claimObjectTypeId.HasValue)
+                {
+                    query = query.Where(rt => rt.ClaimObjectTypeId == claimObjectTypeId);
+                }
+
+                var riskTypes = await query
+                    .OrderBy(rt => rt.Name)
+                    .Select(rt => new RiskTypeDto
+                    {
+                        Id = rt.Id,
+                        Code = rt.Code,
+                        Name = rt.Name,
+                        Description = rt.Description,
+                        IsActive = rt.IsActive,
+                        CreatedAt = rt.CreatedAt,
+                        UpdatedAt = rt.UpdatedAt
+                    })
+                    .ToListAsync();
+
+                return ServiceResult<IEnumerable<RiskTypeDto>>.Ok(riskTypes);
+            }
+            catch
+            {
+                return ServiceResult<IEnumerable<RiskTypeDto>>.Fail("Failed to fetch risk types", 500);
+            }
+        }
+
+        public async Task<ServiceResult<RiskTypeDto>> GetRiskTypeAsync(Guid id)
+        {
+            try
+            {
+                var riskType = await _context.RiskTypes
+                    .Where(rt => rt.Id == id && rt.IsActive)
+                    .FirstOrDefaultAsync();
+
+                if (riskType == null)
+                {
+                    return ServiceResult<RiskTypeDto>.Fail("Risk type not found", 404);
+                }
+
+                var dto = new RiskTypeDto
+                {
+                    Id = riskType.Id,
+                    Code = riskType.Code,
+                    Name = riskType.Name,
+                    Description = riskType.Description,
+                    IsActive = riskType.IsActive,
+                    CreatedAt = riskType.CreatedAt,
+                    UpdatedAt = riskType.UpdatedAt
+                };
+
+                return ServiceResult<RiskTypeDto>.Ok(dto);
+            }
+            catch
+            {
+                return ServiceResult<RiskTypeDto>.Fail("Failed to fetch risk type", 500);
+            }
+        }
+
+        public async Task<ServiceResult<RiskTypeDto>> CreateRiskTypeAsync(RiskTypeDto dto)
+        {
+            try
+            {
+                if (await _context.RiskTypes.AnyAsync(rt => rt.Code == dto.Code))
+                {
+                    return ServiceResult<RiskTypeDto>.Fail("Risk type code already exists", 409);
+                }
+
+                var riskType = new Models.RiskType
+                {
+                    Id = Guid.NewGuid(),
+                    Code = dto.Code,
+                    Name = dto.Name,
+                    Description = dto.Description,
+                    IsActive = dto.IsActive,
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                };
+
+                _context.RiskTypes.Add(riskType);
+                await _context.SaveChangesAsync();
+
+                var result = new RiskTypeDto
+                {
+                    Id = riskType.Id,
+                    Code = riskType.Code,
+                    Name = riskType.Name,
+                    Description = riskType.Description,
+                    IsActive = riskType.IsActive,
+                    CreatedAt = riskType.CreatedAt,
+                    UpdatedAt = riskType.UpdatedAt
+                };
+
+                return ServiceResult<RiskTypeDto>.Created(result);
+            }
+            catch
+            {
+                return ServiceResult<RiskTypeDto>.Fail("Failed to create risk type", 500);
+            }
+        }
+
+        public async Task<ServiceResult> UpdateRiskTypeAsync(Guid id, RiskTypeDto dto)
+        {
+            try
+            {
+                var riskType = await _context.RiskTypes.FindAsync(id);
+                if (riskType == null || !riskType.IsActive)
+                {
+                    return ServiceResult.Fail("Risk type not found", 404);
+                }
+
+                if (await _context.RiskTypes.AnyAsync(rt => rt.Code == dto.Code && rt.Id != id))
+                {
+                    return ServiceResult.Fail("Risk type code already exists", 409);
+                }
+
+                riskType.Code = dto.Code;
+                riskType.Name = dto.Name;
+                riskType.Description = dto.Description;
+                riskType.IsActive = dto.IsActive;
+                riskType.UpdatedAt = DateTime.UtcNow;
+
+                await _context.SaveChangesAsync();
+                return ServiceResult.Ok();
+            }
+            catch
+            {
+                return ServiceResult.Fail("Failed to update risk type", 500);
+            }
+        }
+
+        public async Task<ServiceResult> DeleteRiskTypeAsync(Guid id)
+        {
+            try
+            {
+                var riskType = await _context.RiskTypes.FindAsync(id);
+                if (riskType == null || !riskType.IsActive)
+                {
+                    return ServiceResult.Fail("Risk type not found", 404);
+                }
+
+                riskType.IsActive = false;
+                riskType.UpdatedAt = DateTime.UtcNow;
+
+                await _context.SaveChangesAsync();
+                return ServiceResult.Ok();
+            }
+            catch
+            {
+                return ServiceResult.Fail("Failed to delete risk type", 500);
+            }
+        }
+    }
+}
+

--- a/backend/Services/ServiceResult.cs
+++ b/backend/Services/ServiceResult.cs
@@ -1,0 +1,38 @@
+namespace AutomotiveClaimsApi.Services
+{
+    /// <summary>
+    /// Generic wrapper used by services to return operation results
+    /// together with status code and error messages.
+    /// </summary>
+    /// <typeparam name="T">Type of the returned data.</typeparam>
+    public class ServiceResult<T>
+    {
+        public bool Success { get; set; }
+        public int StatusCode { get; set; }
+        public string? Error { get; set; }
+        public T? Data { get; set; }
+
+        public static ServiceResult<T> Ok(T data)
+            => new ServiceResult<T> { Success = true, StatusCode = 200, Data = data };
+
+        public static ServiceResult<T> Created(T data)
+            => new ServiceResult<T> { Success = true, StatusCode = 201, Data = data };
+
+        public static ServiceResult<T> Fail(string error, int statusCode)
+            => new ServiceResult<T> { Success = false, StatusCode = statusCode, Error = error };
+    }
+
+    public class ServiceResult
+    {
+        public bool Success { get; set; }
+        public int StatusCode { get; set; }
+        public string? Error { get; set; }
+
+        public static ServiceResult Ok()
+            => new ServiceResult { Success = true, StatusCode = 204 };
+
+        public static ServiceResult Fail(string error, int statusCode)
+            => new ServiceResult { Success = false, StatusCode = statusCode, Error = error };
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ServiceResult helper and CRUD services for risk and damage types with validation and conflict handling
- expose isActive and timestamps on risk type DTO
- simplify RiskTypes and DamageTypes controllers to use services and register them in DI

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689da338a030832c8b12f97836b26185