### PR TITLE
fix risk types endpoint casing

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -942,19 +942,19 @@ class ApiService {
     if (params.isActive !== undefined) {
       searchParams.append('isActive', String(params.isActive))
     }
-    const url = `/risk-types${searchParams.toString() ? `?${searchParams.toString()}` : ''}`
+    const url = `/RiskTypes${searchParams.toString() ? `?${searchParams.toString()}` : ''}`
     return this.request<RiskTypeDto[]>(url)
   }
 
   async createRiskType(data: CreateRiskTypeDto): Promise<RiskTypeDto> {
-    return this.request<RiskTypeDto>('/risk-types', {
+    return this.request<RiskTypeDto>('/RiskTypes', {
       method: 'POST',
       body: JSON.stringify(data),
     })
   }
 
   async updateRiskType(id: string, data: UpdateRiskTypeDto): Promise<void> {
-    await this.request<void>(`/risk-types/${id}`, {
+    await this.request<void>(`/RiskTypes/${id}`, {
       method: 'PUT',
       body: JSON.stringify(data),
     })
@@ -962,7 +962,7 @@ class ApiService {
 
   async deleteRiskType(id: string): Promise<void> {
     const token = this.getToken()
-    const response = await fetch(`${API_BASE_URL}/risk-types/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/RiskTypes/${id}`, {
       method: 'DELETE',
       credentials: 'include',
       headers: {


### PR DESCRIPTION
## Summary
- use `/RiskTypes` casing for risk type API requests

## Testing
- `pnpm test` *(fails: Cannot require() ES Module in a cycle)*
- `pnpm build` *(fails: Unexpected token `div`. Expected jsx identifier)*
- `curl -i http://localhost:5200/api/RiskTypes` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_689dabe201c0832cb40fff10c3cba96d