### PR TITLE
feat: add property and transport claim forms

### DIFF
--- a/app/api/dictionaries/risk-types/route.ts
+++ b/app/api/dictionaries/risk-types/route.ts
@@ -34,13 +34,15 @@ export async function GET(request: NextRequest) {
       
       // claimObjectTypeId = 2 (Szkody mienia)
       { id: 3, riskId: 4, name: "MAJĄTKOWE", description: "MAJĄTKOWE", claimObjectTypeId: 2 },
-      { id: 4, riskId: 4, name: "OCPD", description: "OCPD", claimObjectTypeId: 2 },
-      { id: 5, riskId: 4, name: "CARGO", description: "CARGO", claimObjectTypeId: 2 },
       { id: 8, riskId: 57, name: "NNW", description: "NNW", claimObjectTypeId: 2 },
       { id: 9, riskId: 57, name: "CPM", description: "CPM", claimObjectTypeId: 2 },
       { id: 10, riskId: 57, name: "CAR/EAR", description: "CAR/EAR", claimObjectTypeId: 2 },
       { id: 11, riskId: 57, name: "BI", description: "BI", claimObjectTypeId: 2 },
-      { id: 12, riskId: 57, name: "GWARANCJIE", description: "GWARANCJIE", claimObjectTypeId: 2 }
+      { id: 12, riskId: 57, name: "GWARANCJIE", description: "GWARANCJIE", claimObjectTypeId: 2 },
+
+      // claimObjectTypeId = 3 (Szkody transportowe)
+      { id: 4, riskId: 4, name: "OCPD", description: "OCPD", claimObjectTypeId: 3 },
+      { id: 5, riskId: 4, name: "CARGO", description: "CARGO", claimObjectTypeId: 3 }
     ]
     
     const { searchParams } = new URL(request.url)

--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -52,6 +52,7 @@ interface RepairSchedule {
 export default function NewClaimPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const claimObjectTypeParam = searchParams.get("claimObjectType") || "1"
   const { toast } = useToast()
   const { createClaim, deleteClaim, initializeClaim } = useClaims()
   const [claimId, setClaimId] = useState<string>("")
@@ -406,6 +407,7 @@ export default function NewClaimPage() {
               setUploadedFiles={setUploadedFiles}
               requiredDocuments={requiredDocuments}
               setRequiredDocuments={setRequiredDocuments}
+              initialClaimObjectType={claimObjectTypeParam}
             />
 
             {/* Repair Schedules and Details Section */}

--- a/app/claims/property/page.tsx
+++ b/app/claims/property/page.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { useState } from "react"
+import { ClaimsList } from "@/components/claims-list"
+import { NewClaimDialog } from "@/components/new-claim-dialog"
+
+export default function PropertyClaimsPage() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <ClaimsList
+        onNewClaim={() => setOpen(true)}
+        claimObjectTypeId="2"
+      />
+      <NewClaimDialog open={open} onOpenChange={setOpen} />
+    </>
+  )
+}
+

--- a/app/claims/transport/page.tsx
+++ b/app/claims/transport/page.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { useState } from "react"
+import { ClaimsList } from "@/components/claims-list"
+import { NewClaimDialog } from "@/components/new-claim-dialog"
+
+export default function TransportClaimsPage() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <ClaimsList
+        onNewClaim={() => setOpen(true)}
+        claimObjectTypeId="3"
+      />
+      <NewClaimDialog open={open} onOpenChange={setOpen} />
+    </>
+  )
+}
+

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -79,6 +79,7 @@ interface ClaimMainContentProps {
   setUploadedFiles: React.Dispatch<React.SetStateAction<UploadedFile[]>>
   requiredDocuments: RequiredDocument[]
   setRequiredDocuments: React.Dispatch<React.SetStateAction<RequiredDocument[]>>
+  initialClaimObjectType?: string
 }
 
 const formatDateForInput = (dateString: string | undefined): string => {
@@ -185,6 +186,7 @@ export const ClaimMainContent = ({
   setUploadedFiles,
   requiredDocuments = [],
   setRequiredDocuments,
+  initialClaimObjectType = "1",
 }: ClaimMainContentProps) => {
   const { toast } = useToast()
 
@@ -234,7 +236,7 @@ export const ClaimMainContent = ({
   // State for dropdown data
   const [riskTypes, setRiskTypes] = useState<RiskType[]>([])
   const [loadingRiskTypes, setLoadingRiskTypes] = useState(false)
-  const [claimObjectType, setClaimObjectType] = useState<string>("1") // Default to communication claims
+  const [claimObjectType, setClaimObjectType] = useState<string>(initialClaimObjectType) // Default to communication claims
 
   // Add to the state declarations at the top of the component (around line 80)
   const [caseHandlers, setCaseHandlers] = useState<any[]>([])
@@ -328,19 +330,28 @@ export const ClaimMainContent = ({
         { value: "22", label: "OC ROLNIKA" },
         { value: "1", label: "INNE" },
       ]
-      
+
       const propertyRiskTypes = [
         { value: "4", label: "MAJĄTKOWE" },
-        { value: "4", label: "OCPD" },
-        { value: "4", label: "CARGO" },
         { value: "57", label: "NNW" },
         { value: "57", label: "CPM" },
         { value: "57", label: "CAR/EAR" },
         { value: "57", label: "BI" },
         { value: "57", label: "GWARANCJIE" },
       ]
-      
-      setRiskTypes(claimObjectType === "1" ? communicationRiskTypes : propertyRiskTypes)
+
+      const transportRiskTypes = [
+        { value: "4", label: "OCPD" },
+        { value: "4", label: "CARGO" },
+      ]
+
+      setRiskTypes(
+        claimObjectType === "1"
+          ? communicationRiskTypes
+          : claimObjectType === "2"
+            ? propertyRiskTypes
+            : transportRiskTypes,
+      )
       
       toast({
         title: "Uwaga",
@@ -1295,6 +1306,7 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
                       <SelectContent>
                         <SelectItem value="1">Szkody komunikacyjne</SelectItem>
                         <SelectItem value="2">Szkody mienia</SelectItem>
+                        <SelectItem value="3">Szkody transportowe</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>


### PR DESCRIPTION
## Summary
- add claim type selector in new claim dialog
- support property and transport risk types and forms
- provide fallback risk types for transport claims
- add claim type filtering to claims list
- add property and transport claim list pages

## Testing
- `pnpm lint` (fails: Next.js ESLint plugin prompt)
- `pnpm test` (fails: Test failed. See above for more details.)


------
https://chatgpt.com/codex/tasks/task_e_689dc76a8030832cb9731723528010d8