### PR TITLE
feat: add transport damage section

### DIFF
--- a/components/claim-form/transport-damage-section.tsx
+++ b/components/claim-form/transport-damage-section.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import type React from "react"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { Plus, Trash2 } from "lucide-react"
+
+interface TransportDamage {
+  cargoDescription: string
+  losses: string[]
+  carrier: string
+  policyNumber: string
+  inspectionContactName: string
+  inspectionContactPhone: string
+  inspectionContactEmail: string
+}
+
+export interface TransportDamageSectionProps {
+  value: TransportDamage
+  onChange: (value: TransportDamage) => void
+  disabled?: boolean
+}
+
+export function TransportDamageSection({
+  value,
+  onChange,
+  disabled = false,
+}: TransportDamageSectionProps) {
+  const handleFieldChange = (field: keyof TransportDamage, fieldValue: any) => {
+    onChange({ ...value, [field]: fieldValue })
+  }
+
+  const handleLossChange = (index: number, newLoss: string) => {
+    const updated = [...value.losses]
+    updated[index] = newLoss
+    handleFieldChange("losses", updated)
+  }
+
+  const addLoss = () => {
+    handleFieldChange("losses", [...value.losses, ""])
+  }
+
+  const removeLoss = (index: number) => {
+    const updated = value.losses.filter((_, i) => i !== index)
+    handleFieldChange("losses", updated)
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Szkoda w transporcie</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-2">
+          <Label htmlFor="cargoDescription">Opis ładunku / lista strat</Label>
+          <Textarea
+            id="cargoDescription"
+            placeholder="Opisz ładunek lub ogólną listę strat"
+            value={value.cargoDescription}
+            onChange={(e) => handleFieldChange("cargoDescription", e.target.value)}
+            disabled={disabled}
+            rows={3}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label>Lista strat</Label>
+          {value.losses.map((loss, index) => (
+            <div key={index} className="flex items-center space-x-2">
+              <Input
+                placeholder={`Strata ${index + 1}`}
+                value={loss}
+                onChange={(e) => handleLossChange(index, e.target.value)}
+                disabled={disabled}
+              />
+              {!disabled && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => removeLoss(index)}
+                  className="h-8 w-8"
+                >
+                  <Trash2 className="h-4 w-4 text-red-500" />
+                </Button>
+              )}
+            </div>
+          ))}
+          {!disabled && (
+            <Button type="button" variant="outline" size="sm" onClick={addLoss}>
+              <Plus className="h-4 w-4 mr-2" /> Dodaj stratę
+            </Button>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="carrier">Przewoźnik / ubezpieczyciel</Label>
+            <Input
+              id="carrier"
+              placeholder="Nazwa przewoźnika lub ubezpieczyciela"
+              value={value.carrier}
+              onChange={(e) => handleFieldChange("carrier", e.target.value)}
+              disabled={disabled}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="policyNumber">Numer polisy</Label>
+            <Input
+              id="policyNumber"
+              placeholder=""
+              value={value.policyNumber}
+              onChange={(e) => handleFieldChange("policyNumber", e.target.value)}
+              disabled={disabled}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Dane kontaktowe do oględzin</Label>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <Input
+              placeholder="Imię i nazwisko"
+              value={value.inspectionContactName}
+              onChange={(e) => handleFieldChange("inspectionContactName", e.target.value)}
+              disabled={disabled}
+            />
+            <Input
+              placeholder="Telefon"
+              value={value.inspectionContactPhone}
+              onChange={(e) => handleFieldChange("inspectionContactPhone", e.target.value)}
+              disabled={disabled}
+            />
+            <Input
+              type="email"
+              placeholder="E-mail"
+              value={value.inspectionContactEmail}
+              onChange={(e) => handleFieldChange("inspectionContactEmail", e.target.value)}
+              disabled={disabled}
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add transport damage section mirroring property damage props
- include cargo, loss list, carrier/policy and inspection contact fields

## Testing
- `pnpm test` (fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)
- `pnpm lint` (fails: interactive ESLint configuration prompt)


------
https://chatgpt.com/codex/tasks/task_e_689e278e8960832c892ccec0126841c6