### PR TITLE
Hide collapsed repair sections entirely

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -1114,82 +1114,13 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
                     </div>
                   </div>
                 </div>
-                <div className="p-4">
-                  {expandedSections.harmonogram && eventId ? (
+                {expandedSections.harmonogram && eventId && (
+                  <div className="p-4">
                     <div className="border rounded-lg overflow-hidden">
                       <RepairScheduleSection eventId={eventId} />
                     </div>
-                  ) : (
-                    <div className="space-y-4">
-                      {/* Preview of repair schedules */}
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <InfoCard
-                          icon={<Calendar className="h-4 w-4" />}
-                          label="Liczba harmonogramów"
-                          value="2"
-                        />
-                        <InfoCard
-                          icon={<Clock className="h-4 w-4" />}
-                          label="Status ostatniego"
-                          value="W trakcie"
-                        />
-                      </div>
-
-                      {/* Sample repair schedule items */}
-                      <div className="space-y-2">
-                        <div className="bg-gray-50 rounded-lg p-3 border border-gray-200">
-                          <div className="flex items-center justify-between mb-2">
-                            <h4 className="font-medium text-gray-900 text-sm">Harmonogram #1</h4>
-                            <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs font-medium">
-                              W trakcie
-                            </span>
-                          </div>
-                          <div className="grid grid-cols-2 gap-4 text-xs text-gray-600">
-                            <div>
-                              <span className="font-medium">Data rozpoczęcia:</span> 15.01.2025
-                            </div>
-                            <div>
-                              <span className="font-medium">Planowane zakończenie:</span> 22.01.2025
-                            </div>
-                            <div>
-                              <span className="font-medium">Warsztat:</span> AutoSerwis Kowalski
-                            </div>
-                            <div>
-                              <span className="font-medium">Koszt:</span> 4,500 PLN
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="bg-gray-50 rounded-lg p-3 border border-gray-200">
-                          <div className="flex items-center justify-between mb-2">
-                            <h4 className="font-medium text-gray-900 text-sm">Harmonogram #2</h4>
-                            <span className="px-2 py-1 bg-green-100 text-green-800 rounded-full text-xs font-medium">
-                              Zakończony
-                            </span>
-                          </div>
-                          <div className="grid grid-cols-2 gap-4 text-xs text-gray-600">
-                            <div>
-                              <span className="font-medium">Data rozpoczęcia:</span> 08.01.2025
-                            </div>
-                            <div>
-                              <span className="font-medium">Data zakończenia:</span> 12.01.2025
-                            </div>
-                            <div>
-                              <span className="font-medium">Warsztat:</span> Lakiernia Nowak
-                            </div>
-                            <div>
-                              <span className="font-medium">Koszt:</span> 2,800 PLN
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div className="text-center pt-2">
-                        <p className="text-xs text-gray-400">Kliknij "Rozwiń" aby zobaczyć pełne szczegóły i dodać nowe harmonogramy</p>
-                      </div>
-                    </div>
-                  )}
-                </div>
+                  </div>
+                )}
               </div>
             </CardContent>
           </Card>
@@ -1237,8 +1168,8 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
                     </div>
                   </div>
                 </div>
-                <div className="p-4">
-                  {expandedSections.naprawa && eventId ? (
+                {expandedSections.naprawa && eventId && (
+                  <div className="p-4">
                     <div className="border rounded-lg overflow-hidden">
                       <RepairDetailsSection
                         eventId={eventId}
@@ -1246,61 +1177,8 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
                         onAutoShowFormHandled={() => setAutoShowRepairForm(false)}
                       />
                     </div>
-                  ) : (
-                    <div className="space-y-4">
-                      {/* Preview of repair details */}
-                      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                        <InfoCard
-                          icon={<Wrench className="h-4 w-4" />}
-                          label="Liczba pozycji"
-                          value={repairDetails.length.toString()}
-                        />
-                        <InfoCard
-                          icon={<DollarSign className="h-4 w-4" />}
-                          label="Całkowity koszt"
-                          value=""
-                        />
-                        <InfoCard
-                          icon={<Clock className="h-4 w-4" />}
-                          label="Status"
-                          value={summaryStatus}
-                        />
-                      </div>
-
-                      {repairDetails.length > 0 && (
-                        <div className="space-y-2">
-                          {repairDetails.slice(0, 2).map((detail, index) => (
-                            <div key={detail.id || index} className="bg-gray-50 rounded-lg p-3 border border-gray-200">
-                              <div className="flex items-center justify-between mb-2">
-                                <h4 className="font-medium text-gray-900 text-sm">
-                                  {detail.vehicleTabNumber} ({detail.vehicleRegistration})
-                                </h4>
-                                <span className="px-2 py-1 bg-gray-100 text-gray-800 rounded-full text-xs font-medium">
-                                  {detail.status}
-                                </span>
-                              </div>
-                              <div className="grid grid-cols-2 gap-4 text-xs text-gray-600">
-                                <div>
-                                  <span className="font-medium">Łączne godziny:</span>{" "}
-                                  {(detail.bodyworkHours + detail.paintingHours + detail.assemblyHours + detail.otherWorkHours).toFixed(1)}
-                                </div>
-                                {detail.repairStartDate && (
-                                  <div>
-                                    <span className="font-medium">Rozpoczęcie:</span> {detail.repairStartDate}
-                                  </div>
-                                )}
-                              </div>
-                            </div>
-                            ))}
-                          </div>
-                        )}
-
-                      <div className="text-center pt-2">
-                        <p className="text-xs text-gray-400">Kliknij "Rozwiń" aby zobaczyć pełne szczegóły i dodać nowe pozycje naprawy</p>
-                      </div>
-                    </div>
-                  )}
-                </div>
+                  </div>
+                )}
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary
- stop rendering preview placeholders for repair schedule and details sections when collapsed
- render section contents only when expanded and `eventId` is present

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689e311d956c832cba6102fceab5f610