### PR TITLE
refactor: integrate transport damage section

### DIFF
--- a/components/claim-form/transport-damage-section.tsx
+++ b/components/claim-form/transport-damage-section.tsx
@@ -8,44 +8,49 @@ import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
 import { Plus, Trash2 } from "lucide-react"
+import type { Claim, TransportDamage } from "@/types"
 
-interface TransportDamage {
-  cargoDescription: string
-  losses: string[]
-  carrier: string
-  policyNumber: string
-  inspectionContactName: string
-  inspectionContactPhone: string
-  inspectionContactEmail: string
-}
-
-export interface TransportDamageSectionProps {
-  value: TransportDamage
-  onChange: (value: TransportDamage) => void
+interface TransportDamageSectionProps {
+  claimFormData: Claim
+  handleFormChange: (field: keyof Claim, value: any) => void
   disabled?: boolean
 }
 
 export function TransportDamageSection({
-  value,
-  onChange,
+  claimFormData,
+  handleFormChange,
   disabled = false,
 }: TransportDamageSectionProps) {
+  const transportDamage: TransportDamage =
+    claimFormData.transportDamage || {
+      cargoDescription: "",
+      losses: [""],
+      carrier: "",
+      policyNumber: "",
+      inspectionContactName: "",
+      inspectionContactPhone: "",
+      inspectionContactEmail: "",
+    }
+
   const handleFieldChange = (field: keyof TransportDamage, fieldValue: any) => {
-    onChange({ ...value, [field]: fieldValue })
+    handleFormChange("transportDamage", {
+      ...transportDamage,
+      [field]: fieldValue,
+    })
   }
 
   const handleLossChange = (index: number, newLoss: string) => {
-    const updated = [...value.losses]
+    const updated = [...transportDamage.losses]
     updated[index] = newLoss
     handleFieldChange("losses", updated)
   }
 
   const addLoss = () => {
-    handleFieldChange("losses", [...value.losses, ""])
+    handleFieldChange("losses", [...transportDamage.losses, ""])
   }
 
   const removeLoss = (index: number) => {
-    const updated = value.losses.filter((_, i) => i !== index)
+    const updated = transportDamage.losses.filter((_, i) => i !== index)
     handleFieldChange("losses", updated)
   }
 
@@ -60,7 +65,7 @@ export function TransportDamageSection({
           <Textarea
             id="cargoDescription"
             placeholder="Opisz ładunek lub ogólną listę strat"
-            value={value.cargoDescription}
+            value={transportDamage.cargoDescription}
             onChange={(e) => handleFieldChange("cargoDescription", e.target.value)}
             disabled={disabled}
             rows={3}
@@ -69,7 +74,7 @@ export function TransportDamageSection({
 
         <div className="space-y-2">
           <Label>Lista strat</Label>
-          {value.losses.map((loss, index) => (
+          {transportDamage.losses.map((loss, index) => (
             <div key={`loss-${index}`} className="flex items-center space-x-2">
               <Input
                 placeholder={`Strata ${index + 1}`}
@@ -103,7 +108,7 @@ export function TransportDamageSection({
             <Input
               id="carrier"
               placeholder="Nazwa przewoźnika lub ubezpieczyciela"
-              value={value.carrier}
+              value={transportDamage.carrier}
               onChange={(e) => handleFieldChange("carrier", e.target.value)}
               disabled={disabled}
             />
@@ -113,7 +118,7 @@ export function TransportDamageSection({
             <Input
               id="policyNumber"
               placeholder=""
-              value={value.policyNumber}
+              value={transportDamage.policyNumber}
               onChange={(e) => handleFieldChange("policyNumber", e.target.value)}
               disabled={disabled}
             />
@@ -125,20 +130,20 @@ export function TransportDamageSection({
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <Input
               placeholder="Imię i nazwisko"
-              value={value.inspectionContactName}
+              value={transportDamage.inspectionContactName}
               onChange={(e) => handleFieldChange("inspectionContactName", e.target.value)}
               disabled={disabled}
             />
             <Input
               placeholder="Telefon"
-              value={value.inspectionContactPhone}
+              value={transportDamage.inspectionContactPhone}
               onChange={(e) => handleFieldChange("inspectionContactPhone", e.target.value)}
               disabled={disabled}
             />
             <Input
               type="email"
               placeholder="E-mail"
-              value={value.inspectionContactEmail}
+              value={transportDamage.inspectionContactEmail}
               onChange={(e) => handleFieldChange("inspectionContactEmail", e.target.value)}
               disabled={disabled}
             />

--- a/types/index.ts
+++ b/types/index.ts
@@ -20,6 +20,16 @@ export interface Note {
   dueDate?: string
 }
 
+export interface TransportDamage {
+  cargoDescription: string
+  losses: string[]
+  carrier: string
+  policyNumber: string
+  inspectionContactName: string
+  inspectionContactPhone: string
+  inspectionContactEmail: string
+}
+
 export interface Claim
   extends Omit<
     ClaimDto,
@@ -71,6 +81,7 @@ export interface Claim
   cargoDetails?: string
   carrierInfo?: string
   damageDescription?: string
+  transportDamage?: TransportDamage
   damages?: DamageItem[]
   notes?: Note[]
   injuredParty?: ParticipantInfo


### PR DESCRIPTION
## Summary
- refactor transport damage section to use claim form state and handler
- add TransportDamage type and hook into Claim interface

## Testing
- `pnpm lint` *(fails: Next.js ESLint config prompt)*
- `pnpm test` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_689e35bba3c8832c890809e9dc0315ab