### PR TITLE
feat: track subcontractor details in claims

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -701,6 +701,15 @@ namespace AutomotiveClaimsApi.Controllers
             entity.ServicesCalled = dto.ServicesCalled;
             entity.PoliceUnitDetails = dto.PoliceUnitDetails;
             entity.VehicleType = dto.VehicleType;
+            entity.SubcontractorName = dto.SubcontractorName;
+            entity.SubcontractorPolicyNumber = dto.SubcontractorPolicyNumber;
+            entity.SubcontractorInsurer = dto.SubcontractorInsurer;
+            entity.ComplaintToSubcontractor = dto.ComplaintToSubcontractor;
+            entity.ComplaintToSubcontractorDate = dto.ComplaintToSubcontractorDate;
+            entity.ClaimFromSubcontractorPolicy = dto.ClaimFromSubcontractorPolicy;
+            entity.ClaimFromSubcontractorPolicyDate = dto.ClaimFromSubcontractorPolicyDate;
+            entity.ComplaintResponse = dto.ComplaintResponse;
+            entity.ComplaintResponseDate = dto.ComplaintResponseDate;
             entity.DamageDescription = dto.DamageDescription;
             entity.Description = dto.Description;
         }
@@ -1463,6 +1472,15 @@ namespace AutomotiveClaimsApi.Controllers
             ServicesCalled = e.ServicesCalled?.Split(',', StringSplitOptions.RemoveEmptyEntries),
             PoliceUnitDetails = e.PoliceUnitDetails,
             VehicleType = e.VehicleType,
+            SubcontractorName = e.SubcontractorName,
+            SubcontractorPolicyNumber = e.SubcontractorPolicyNumber,
+            SubcontractorInsurer = e.SubcontractorInsurer,
+            ComplaintToSubcontractor = e.ComplaintToSubcontractor,
+            ComplaintToSubcontractorDate = e.ComplaintToSubcontractorDate,
+            ClaimFromSubcontractorPolicy = e.ClaimFromSubcontractorPolicy,
+            ClaimFromSubcontractorPolicyDate = e.ClaimFromSubcontractorPolicyDate,
+            ComplaintResponse = e.ComplaintResponse,
+            ComplaintResponseDate = e.ComplaintResponseDate,
             DamageDescription = e.DamageDescription,
             Description = e.Description,
             CreatedAt = e.CreatedAt,

--- a/backend/DTOs/EventDto.cs
+++ b/backend/DTOs/EventDto.cs
@@ -50,6 +50,15 @@ namespace AutomotiveClaimsApi.DTOs
         public string[]? ServicesCalled { get; set; }
         public string? PoliceUnitDetails { get; set; }
         public string? VehicleType { get; set; }
+        public string? SubcontractorName { get; set; }
+        public string? SubcontractorPolicyNumber { get; set; }
+        public string? SubcontractorInsurer { get; set; }
+        public bool? ComplaintToSubcontractor { get; set; }
+        public DateTime? ComplaintToSubcontractorDate { get; set; }
+        public bool? ClaimFromSubcontractorPolicy { get; set; }
+        public DateTime? ClaimFromSubcontractorPolicyDate { get; set; }
+        public bool? ComplaintResponse { get; set; }
+        public DateTime? ComplaintResponseDate { get; set; }
         public string? DamageDescription { get; set; }
         public string? Description { get; set; }
         public DateTime CreatedAt { get; set; }

--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -127,6 +127,27 @@ namespace AutomotiveClaimsApi.DTOs
         [StringLength(100)]
         public string? VehicleType { get; set; }
 
+        [StringLength(200)]
+        public string? SubcontractorName { get; set; }
+
+        [StringLength(100)]
+        public string? SubcontractorPolicyNumber { get; set; }
+
+        [StringLength(200)]
+        public string? SubcontractorInsurer { get; set; }
+
+        public bool? ComplaintToSubcontractor { get; set; }
+
+        public DateTime? ComplaintToSubcontractorDate { get; set; }
+
+        public bool? ClaimFromSubcontractorPolicy { get; set; }
+
+        public DateTime? ClaimFromSubcontractorPolicyDate { get; set; }
+
+        public bool? ComplaintResponse { get; set; }
+
+        public DateTime? ComplaintResponseDate { get; set; }
+
         [StringLength(2000)]
         public string? DamageDescription { get; set; }
 

--- a/backend/Migrations/20240130000019_AddSubcontractorFields.cs
+++ b/backend/Migrations/20240130000019_AddSubcontractorFields.cs
@@ -1,0 +1,109 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    public partial class AddSubcontractorFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SubcontractorName",
+                table: "Events",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SubcontractorPolicyNumber",
+                table: "Events",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SubcontractorInsurer",
+                table: "Events",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ComplaintToSubcontractor",
+                table: "Events",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ComplaintToSubcontractorDate",
+                table: "Events",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ClaimFromSubcontractorPolicy",
+                table: "Events",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ClaimFromSubcontractorPolicyDate",
+                table: "Events",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ComplaintResponse",
+                table: "Events",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ComplaintResponseDate",
+                table: "Events",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SubcontractorName",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "SubcontractorPolicyNumber",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "SubcontractorInsurer",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "ComplaintToSubcontractor",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "ComplaintToSubcontractorDate",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "ClaimFromSubcontractorPolicy",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "ClaimFromSubcontractorPolicyDate",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "ComplaintResponse",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "ComplaintResponseDate",
+                table: "Events");
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -983,6 +983,36 @@ namespace AutomotiveClaimsApi.Migrations
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
 
+                    b.Property<string>("SubcontractorName")
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("SubcontractorPolicyNumber")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("SubcontractorInsurer")
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<bool?>("ComplaintToSubcontractor")
+                        .HasColumnType("boolean");
+
+                    b.Property<DateTime?>("ComplaintToSubcontractorDate")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<bool?>("ClaimFromSubcontractorPolicy")
+                        .HasColumnType("boolean");
+
+                    b.Property<DateTime?>("ClaimFromSubcontractorPolicyDate")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<bool?>("ComplaintResponse")
+                        .HasColumnType("boolean");
+
+                    b.Property<DateTime?>("ComplaintResponseDate")
+                        .HasColumnType("timestamp with time zone");
+
                     b.Property<bool?>("WereInjured")
                         .HasColumnType("boolean");
 

--- a/backend/Models/Event.cs
+++ b/backend/Models/Event.cs
@@ -130,6 +130,27 @@ namespace AutomotiveClaimsApi.Models
         [MaxLength(100)]
         public string? VehicleType { get; set; }
 
+        [MaxLength(200)]
+        public string? SubcontractorName { get; set; }
+
+        [MaxLength(100)]
+        public string? SubcontractorPolicyNumber { get; set; }
+
+        [MaxLength(200)]
+        public string? SubcontractorInsurer { get; set; }
+
+        public bool? ComplaintToSubcontractor { get; set; }
+
+        public DateTime? ComplaintToSubcontractorDate { get; set; }
+
+        public bool? ClaimFromSubcontractorPolicy { get; set; }
+
+        public DateTime? ClaimFromSubcontractorPolicyDate { get; set; }
+
+        public bool? ComplaintResponse { get; set; }
+
+        public DateTime? ComplaintResponseDate { get; set; }
+
         public string? DamageDescription { get; set; }
 
         public string? Description { get; set; }

--- a/components/claim-form/transport-damage-section.tsx
+++ b/components/claim-form/transport-damage-section.tsx
@@ -7,7 +7,20 @@ import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Plus, Trash2 } from "lucide-react"
+
+interface SubcontractorInfo {
+  subcontractorName: string
+  subcontractorPolicyNumber: string
+  subcontractorInsurer: string
+  complaintToSubcontractor: boolean
+  complaintToSubcontractorDate: string
+  claimFromSubcontractorPolicy: boolean
+  claimFromSubcontractorPolicyDate: string
+  complaintResponse: boolean
+  complaintResponseDate: string
+}
 
 interface TransportDamage {
   cargoDescription: string
@@ -17,6 +30,7 @@ interface TransportDamage {
   inspectionContactName: string
   inspectionContactPhone: string
   inspectionContactEmail: string
+  subcontractor: SubcontractorInfo
 }
 
 export interface TransportDamageSectionProps {
@@ -47,6 +61,16 @@ export function TransportDamageSection({
   const removeLoss = (index: number) => {
     const updated = value.losses.filter((_, i) => i !== index)
     handleFieldChange("losses", updated)
+  }
+
+  const handleSubcontractorChange = (
+    field: keyof SubcontractorInfo,
+    fieldValue: any,
+  ) => {
+    handleFieldChange("subcontractor", {
+      ...value.subcontractor,
+      [field]: fieldValue,
+    })
   }
 
   return (
@@ -140,6 +164,130 @@ export function TransportDamageSection({
               placeholder="E-mail"
               value={value.inspectionContactEmail}
               onChange={(e) => handleFieldChange("inspectionContactEmail", e.target.value)}
+              disabled={disabled}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <Label>Podwykonawca</Label>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <Input
+              placeholder="Nazwa podwykonawcy"
+              value={value.subcontractor.subcontractorName}
+              onChange={(e) =>
+                handleSubcontractorChange("subcontractorName", e.target.value)
+              }
+              disabled={disabled}
+            />
+            <Input
+              placeholder="Numer polisy"
+              value={value.subcontractor.subcontractorPolicyNumber}
+              onChange={(e) =>
+                handleSubcontractorChange(
+                  "subcontractorPolicyNumber",
+                  e.target.value,
+                )
+              }
+              disabled={disabled}
+            />
+            <Input
+              placeholder="Ubezpieczyciel"
+              value={value.subcontractor.subcontractorInsurer}
+              onChange={(e) =>
+                handleSubcontractorChange(
+                  "subcontractorInsurer",
+                  e.target.value,
+                )
+              }
+              disabled={disabled}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="complaintToSubcontractor"
+                checked={value.subcontractor.complaintToSubcontractor}
+                onCheckedChange={(checked) =>
+                  handleSubcontractorChange(
+                    "complaintToSubcontractor",
+                    checked === true,
+                  )
+                }
+                disabled={disabled}
+              />
+              <Label htmlFor="complaintToSubcontractor">
+                Reklamacja do podwykonawcy
+              </Label>
+            </div>
+            <Input
+              type="date"
+              value={value.subcontractor.complaintToSubcontractorDate}
+              onChange={(e) =>
+                handleSubcontractorChange(
+                  "complaintToSubcontractorDate",
+                  e.target.value,
+                )
+              }
+              disabled={disabled}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="claimFromSubcontractorPolicy"
+                checked={value.subcontractor.claimFromSubcontractorPolicy}
+                onCheckedChange={(checked) =>
+                  handleSubcontractorChange(
+                    "claimFromSubcontractorPolicy",
+                    checked === true,
+                  )
+                }
+                disabled={disabled}
+              />
+              <Label htmlFor="claimFromSubcontractorPolicy">
+                Roszczenie z polisy podwykonawcy
+              </Label>
+            </div>
+            <Input
+              type="date"
+              value={value.subcontractor.claimFromSubcontractorPolicyDate}
+              onChange={(e) =>
+                handleSubcontractorChange(
+                  "claimFromSubcontractorPolicyDate",
+                  e.target.value,
+                )
+              }
+              disabled={disabled}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="complaintResponse"
+                checked={value.subcontractor.complaintResponse}
+                onCheckedChange={(checked) =>
+                  handleSubcontractorChange(
+                    "complaintResponse",
+                    checked === true,
+                  )
+                }
+                disabled={disabled}
+              />
+              <Label htmlFor="complaintResponse">Odpowiedź na reklamację</Label>
+            </div>
+            <Input
+              type="date"
+              value={value.subcontractor.complaintResponseDate}
+              onChange={(e) =>
+                handleSubcontractorChange(
+                  "complaintResponseDate",
+                  e.target.value,
+                )
+              }
               disabled={disabled}
             />
           </div>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -43,6 +43,15 @@ export interface EventDto extends EventListItemDto {
   handlerId?: number
   riskType?: string
   damageType?: string
+  subcontractorName?: string
+  subcontractorPolicyNumber?: string
+  subcontractorInsurer?: string
+  complaintToSubcontractor?: boolean
+  complaintToSubcontractorDate?: string
+  claimFromSubcontractorPolicy?: boolean
+  claimFromSubcontractorPolicyDate?: string
+  complaintResponse?: boolean
+  complaintResponseDate?: string
   participants?: ParticipantDto[]
   damages?: DamageDto[]
   notes?: NoteDto[]
@@ -108,6 +117,15 @@ export interface EventUpsertDto {
   totalClaim?: number
   payout?: number
   currency?: string
+  subcontractorName?: string
+  subcontractorPolicyNumber?: string
+  subcontractorInsurer?: string
+  complaintToSubcontractor?: boolean
+  complaintToSubcontractorDate?: string
+  claimFromSubcontractorPolicy?: boolean
+  claimFromSubcontractorPolicyDate?: string
+  complaintResponse?: boolean
+  complaintResponseDate?: string
   participants?: ParticipantUpsertDto[]
 
   notes?: NoteUpsertDto[]

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -88,6 +88,17 @@ export const initialClaimFormData: Partial<Claim> = {
   leasingCompany: "",
   leasingCompanyId: "",
   description: "",
+  subcontractor: {
+    subcontractorName: "",
+    subcontractorPolicyNumber: "",
+    subcontractorInsurer: "",
+    complaintToSubcontractor: false,
+    complaintToSubcontractorDate: "",
+    claimFromSubcontractorPolicy: false,
+    claimFromSubcontractorPolicyDate: "",
+    complaintResponse: false,
+    complaintResponseDate: "",
+  },
   perpetrator: {
     ...emptyParticipant,
     drivers: [{ ...emptyDriver }],

--- a/types/index.ts
+++ b/types/index.ts
@@ -20,6 +20,18 @@ export interface Note {
   dueDate?: string
 }
 
+export interface SubcontractorInfo {
+  subcontractorName: string
+  subcontractorPolicyNumber: string
+  subcontractorInsurer: string
+  complaintToSubcontractor?: boolean
+  complaintToSubcontractorDate?: string
+  claimFromSubcontractorPolicy?: boolean
+  claimFromSubcontractorPolicyDate?: string
+  complaintResponse?: boolean
+  complaintResponseDate?: string
+}
+
 export interface Claim
   extends Omit<
     ClaimDto,
@@ -36,6 +48,15 @@ export interface Claim
     | "clientClaims"
     | "recourses"
     | "settlements"
+    | "subcontractorName"
+    | "subcontractorPolicyNumber"
+    | "subcontractorInsurer"
+    | "complaintToSubcontractor"
+    | "complaintToSubcontractorDate"
+    | "claimFromSubcontractorPolicy"
+    | "claimFromSubcontractorPolicyDate"
+    | "complaintResponse"
+    | "complaintResponseDate"
   > {
   id?: string
   clientId?: string
@@ -85,6 +106,7 @@ export interface Claim
   documents?: UploadedFile[]
   pendingFiles?: UploadedFile[]
   documentsSectionProps?: DocumentsSectionProps
+  subcontractor?: SubcontractorInfo
 }
 
 export interface ParticipantInfo {


### PR DESCRIPTION
## Summary
- add subcontractor subsection to transport damage form
- track subcontractor details in claim types and initial state
- persist subcontractor data in event DTOs and database

## Testing
- `pnpm test` *(fails: Cannot run tests)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e35bd9408832c956983eca2e86a30