### PR TITLE
fix: wrap participant details return

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -736,7 +736,7 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
           </div>
         </div>
       </div>
-    )
+    );
   }
 
   return (
@@ -1080,8 +1080,8 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
         )}
       </div>
     </div>
-  )
-}
+  );
+};
 
   switch (activeClaimSection) {
     case "harmonogram":


### PR DESCRIPTION
## Summary
- wrap renderParticipantDetails JSX in parentheses and terminate with semicolons to avoid automatic semicolon insertion issues

## Testing
- `pnpm run build` *(fails: Unexpected token `div` in several TSX files)*

------
https://chatgpt.com/codex/tasks/task_e_689e3f844da8832ca85ff9d76c3d08ca