### PR TITLE
Fix JSX structure in claim participant details

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -708,9 +708,8 @@ const renderParticipantDetails = (
                   Numer rejestracyjny:
                 </label>
                 <p className="text-sm font-medium text-gray-900">{participant.vehicleRegistration || "Nie określono"}</p>
-                    </div>
-                  </div>
-                  <div>
+              </div>
+              <div>
                 <label className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
                   VIN:
                 </label>


### PR DESCRIPTION
## Summary
- remove stray closing tags in participant details grid to fix JSX syntax

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: multiple JSX syntax errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689e4b5085a4832c8c4552fd01c6f0f4