### PR TITLE
Restrict settings access to administrators

### DIFF
--- a/app/settings/layout.tsx
+++ b/app/settings/layout.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Header } from '@/components/header'
 import { Sidebar } from '@/components/sidebar'
+import { ProtectedRoute } from '@/components/protected-route'
 import { cn } from '@/lib/utils'
 
 export default function SettingsLayout({ children }: { children: ReactNode }) {
@@ -20,32 +21,34 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
   ]
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
-      <div className="ml-16 flex flex-col min-h-screen">
-        <Header onMenuClick={() => {}} />
-        <div className="flex flex-1">
-          <nav className="w-48 border-r bg-white p-4 space-y-2">
-            {settingsItems.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={cn(
-                  'block px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100',
-                  pathname === item.href
-                    ? 'bg-gray-100 text-[#1a3a6c]'
-                    : 'text-gray-700'
-                )}
-              >
-                {item.label}
-              </Link>
-            ))}
-          </nav>
-          <main className="flex-1 p-6">
-            {children}
-          </main>
+    <ProtectedRoute roles={["Admin", "admin"]}>
+      <div className="min-h-screen bg-gray-50">
+        <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+        <div className="ml-16 flex flex-col min-h-screen">
+          <Header onMenuClick={() => {}} />
+          <div className="flex flex-1">
+            <nav className="w-48 border-r bg-white p-4 space-y-2">
+              {settingsItems.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={cn(
+                    'block px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100',
+                    pathname === item.href
+                      ? 'bg-gray-100 text-[#1a3a6c]'
+                      : 'text-gray-700'
+                  )}
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+            <main className="flex-1 p-6">
+              {children}
+            </main>
+          </div>
         </div>
       </div>
-    </div>
+    </ProtectedRoute>
   )
 }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -116,10 +116,12 @@ export function Header({ onMenuClick, user, onLogout }: HeaderProps) {
                   <User className="mr-2 h-4 w-4" />
                   <span>Profil</span>
                 </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <Settings className="mr-2 h-4 w-4" />
-                  <span>Ustawienia</span>
-                </DropdownMenuItem>
+                {user?.roles?.some((r) => r.toLowerCase() === 'admin') && (
+                  <DropdownMenuItem>
+                    <Settings className="mr-2 h-4 w-4" />
+                    <span>Ustawienia</span>
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuSeparator />
                 <DropdownMenuItem 
                   onClick={() => {

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { LayoutDashboard, FileText, Car, Settings } from "lucide-react"
+import { useAuth } from "@/hooks/use-auth"
 
 interface SidebarProps {
   activeTab: string
@@ -27,10 +28,12 @@ const menuItems = [
     label: "Settings",
     icon: Settings,
     href: "/settings",
+    roles: ["Admin", "admin"],
   },
 ]
 
 export function Sidebar(props: SidebarProps) {
+  const { user } = useAuth()
   return (
     <div className="fixed left-0 top-0 z-40 h-full w-16 bg-[#1a3a6c] border-r border-[#2a4a7c] flex flex-col">
       {/* Header */}
@@ -40,9 +43,17 @@ export function Sidebar(props: SidebarProps) {
 
       {/* Navigation */}
       <nav className="flex-1 p-2 space-y-2">
-        {menuItems.map((item) => {
-          const Icon = item.icon
-          const isActive = props.activeTab === item.id
+        {menuItems
+          .filter(
+            (item) =>
+              !item.roles ||
+              item.roles.some((role) =>
+                user?.roles?.some((r) => r.toLowerCase() === role.toLowerCase())
+              )
+          )
+          .map((item) => {
+            const Icon = item.icon
+            const isActive = props.activeTab === item.id
 
           return (
             <Button


### PR DESCRIPTION
## Summary
- limit Settings pages to admin users via ProtectedRoute
- hide Settings navigation for non-admin users
- show Settings dropdown option only for admin accounts

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_e_689e64c97530832c967fe60f3606adfa