### PR TITLE
Handle claims with missing riskType

### DIFF
--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -131,7 +131,7 @@ export function ClaimsList({
           const matchesHandler =
             !filterHandler || claim.liquidator?.toLowerCase().includes(filterHandler.toLowerCase())
           const matchesClaimType =
-            !allowedRiskTypes || allowedRiskTypes.includes(claim.riskType || "")
+            !allowedRiskTypes || !claim.riskType || allowedRiskTypes.includes(claim.riskType)
 
           return (
             matchesSearch &&


### PR DESCRIPTION
## Summary
- allow filtering claims when riskType is missing

## Testing
- `pnpm test` *(fails: Cannot require() ES Module in a cycle)*
- `pnpm lint` *(fails: requires interactive configuration)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_689e70c5f570832cb0ecdb12ba769048