### PR TITLE
Add unassigned email assignment page

### DIFF
--- a/app/api/claims/options/route.ts
+++ b/app/api/claims/options/route.ts
@@ -1,0 +1,45 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const search = searchParams.get("search") || ""
+
+    const url = new URL(`${API_BASE_URL}/claims`)
+    url.searchParams.set("page", "1")
+    url.searchParams.set("pageSize", "50")
+    if (search) {
+      url.searchParams.set("search", search)
+    }
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      cache: "no-store",
+    })
+
+    if (!response.ok) {
+      throw new Error(`Backend API error: ${response.status}`)
+    }
+
+    const data = await response.json()
+    const items = Array.isArray(data) ? data : data.items || []
+
+    const options = items.map((claim: any) => ({
+      value: claim.id?.toString(),
+      label: claim.claimNumber || claim.id?.toString(),
+    }))
+
+    return NextResponse.json(options)
+  } catch (error) {
+    console.error("Error fetching claim options:", error)
+    return NextResponse.json(
+      { error: "Failed to fetch claim options" },
+      { status: 500 },
+    )
+  }
+}

--- a/app/emails/layout.tsx
+++ b/app/emails/layout.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+import { Sidebar } from '@/components/sidebar'
+import { Header } from '@/components/header'
+
+export default function EmailsLayout({ children }: { children: ReactNode }) {
+  const [activeTab, setActiveTab] = useState('unassigned')
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+      <div className="ml-16 flex flex-col min-h-screen">
+        <Header onMenuClick={() => {}} />
+        <main className="flex-1">{children}</main>
+      </div>
+    </div>
+  )
+}

--- a/app/emails/unassigned/page.tsx
+++ b/app/emails/unassigned/page.tsx
@@ -1,0 +1,5 @@
+import { UnassignedEmailList } from '@/components/email/unassigned-list'
+
+export default function UnassignedEmailsPage() {
+  return <UnassignedEmailList />
+}

--- a/components/email/unassigned-list.tsx
+++ b/components/email/unassigned-list.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { SearchableSelect } from "@/components/ui/searchable-select"
+import { emailService, type EmailDto } from "@/lib/email-service"
+
+export function UnassignedEmailList() {
+  const [emails, setEmails] = useState<EmailDto[]>([])
+  const [loading, setLoading] = useState(false)
+  const [assigningEmail, setAssigningEmail] = useState<EmailDto | null>(null)
+  const [selectedClaim, setSelectedClaim] = useState("")
+
+  useEffect(() => {
+    const fetchEmails = async () => {
+      setLoading(true)
+      try {
+        const data = await emailService.getUnassignedEmails()
+        setEmails(data)
+      } catch (error) {
+        console.error("Failed to load emails", error)
+        setEmails([])
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchEmails()
+  }, [])
+
+  const handleAssign = async () => {
+    if (!assigningEmail || !selectedClaim) return
+    try {
+      const success = await emailService.assignEmailToClaim(
+        assigningEmail.id,
+        selectedClaim,
+      )
+      if (success) {
+        setEmails((prev) => prev.filter((e) => e.id !== assigningEmail.id))
+        setAssigningEmail(null)
+        setSelectedClaim("")
+      }
+    } catch (error) {
+      console.error("Failed to assign email", error)
+    }
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Szkody nieprzydzielone</h1>
+      {loading ? (
+        <p>Ładowanie...</p>
+      ) : (
+        <ul className="space-y-4">
+          {emails.map((email) => (
+            <li key={email.id} className="border rounded p-4">
+              <div className="flex justify-between items-start">
+                <div>
+                  <p className="font-medium">{email.subject}</p>
+                  <p className="text-sm text-gray-500">{email.from}</p>
+                </div>
+                <Button onClick={() => setAssigningEmail(email)}>Przypisz</Button>
+              </div>
+            </li>
+          ))}
+          {emails.length === 0 && !loading && (
+            <li className="text-gray-500">Brak e-maili do przypisania</li>
+          )}
+        </ul>
+      )}
+
+      <Dialog
+        open={assigningEmail !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setAssigningEmail(null)
+            setSelectedClaim("")
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Przypisz do szkody</DialogTitle>
+          </DialogHeader>
+          <SearchableSelect
+            apiEndpoint="/api/claims/options"
+            value={selectedClaim}
+            onValueChange={setSelectedClaim}
+            placeholder="Wybierz szkodę"
+            searchPlaceholder="Szukaj szkody..."
+            emptyText="Nie znaleziono"
+          />
+          <DialogFooter className="mt-4">
+            <Button variant="outline" onClick={() => { setAssigningEmail(null); setSelectedClaim("") }}>Anuluj</Button>
+            <Button onClick={handleAssign} disabled={!selectedClaim}>Przypisz</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -2,7 +2,7 @@
 import Link from "next/link"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import { LayoutDashboard, FileText, Car, Settings } from "lucide-react"
+import { LayoutDashboard, FileText, Car, Settings, Inbox } from "lucide-react"
 import { useAuth } from "@/hooks/use-auth"
 
 interface SidebarProps {
@@ -22,6 +22,12 @@ const menuItems = [
     label: "Szkody",
     icon: FileText,
     href: "/claims",
+  },
+  {
+    id: "unassigned",
+    label: "Szkody nieprzydzielone",
+    icon: Inbox,
+    href: "/emails/unassigned",
   },
   {
     id: "settings",


### PR DESCRIPTION
## Summary
- show unassigned emails with ability to assign them to claims
- add navigation link for "Szkody nieprzydzielone"
- expose claim options API for searchable select

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm add -D eslint` *(fails: GET https://registry.npmjs.org/eslint: Forbidden - 403)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689e709f25c8832cad7fbeebe14ffeb8