### PR TITLE
feat: connect email API routes to backend

### DIFF
--- a/app/api/emails/[id]/read/route.ts
+++ b/app/api/emails/[id]/read/route.ts
@@ -1,15 +1,30 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: { id: string } },
+) {
   try {
-    const emailId = Number.parseInt(params.id)
+    const emailId = params.id
 
-    // Mock implementation - replace with actual backend API call
-    console.log("Marking email as read:", emailId)
+    const response = await fetch(`${API_BASE_URL}/emails/${emailId}/read`, {
+      method: "POST",
+    })
 
-    return NextResponse.json({ success: true, message: "Email marked as read" })
+    if (!response.ok) {
+      const errorText = await response.text()
+      return NextResponse.json({ error: errorText }, { status: response.status })
+    }
+
+    const data = await response.json()
+    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Error marking email as read:", error)
-    return NextResponse.json({ error: "Failed to mark email as read" }, { status: 500 })
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to mark email as read" },
+      { status: 500 },
+    )
   }
 }

--- a/app/api/emails/[id]/route.ts
+++ b/app/api/emails/[id]/route.ts
@@ -1,39 +1,57 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
-  try {
-    const emailId = Number.parseInt(params.id)
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
-    // Mock implementation - replace with actual backend API call
-    const email = {
-      id: emailId,
-      from: "Jan Kowalski <jan.kowalski@example.com>",
-      to: "claims@company.com",
-      subject: "Zgłoszenie szkody - polisa ABC123",
-      body: "<p>Dzień dobry,</p><p>Zgłaszam szkodę komunikacyjną...</p>",
-      receivedDate: new Date("2024-01-15T10:30:00"),
-      read: false,
-      claimId: null,
-      attachments: [],
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const emailId = params.id
+
+    const response = await fetch(`${API_BASE_URL}/emails/${emailId}`, {
+      cache: "no-store",
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      return NextResponse.json({ error: errorText }, { status: response.status })
     }
 
+    const email = await response.json()
     return NextResponse.json(email)
   } catch (error) {
     console.error("Error fetching email:", error)
-    return NextResponse.json({ error: "Failed to fetch email" }, { status: 500 })
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to fetch email" },
+      { status: 500 },
+    )
   }
 }
 
-export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: { id: string } },
+) {
   try {
-    const emailId = Number.parseInt(params.id)
+    const emailId = params.id
 
-    // Mock implementation - replace with actual backend API call
-    console.log("Deleting email:", emailId)
+    const response = await fetch(`${API_BASE_URL}/emails/${emailId}`, {
+      method: "DELETE",
+    })
 
-    return NextResponse.json({ success: true, message: "Email deleted successfully" })
+    if (!response.ok) {
+      const errorText = await response.text()
+      return NextResponse.json({ error: errorText }, { status: response.status })
+    }
+
+    const data = await response.json()
+    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Error deleting email:", error)
-    return NextResponse.json({ error: "Failed to delete email" }, { status: 500 })
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to delete email" },
+      { status: 500 },
+    )
   }
 }

--- a/app/api/emails/assign-to-claim/route.ts
+++ b/app/api/emails/assign-to-claim/route.ts
@@ -1,15 +1,32 @@
 import { type NextRequest, NextResponse } from "next/server"
 
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
+
 export async function POST(request: NextRequest) {
   try {
     const { emailId, claimId } = await request.json()
 
-    // Mock implementation - replace with actual backend API call
-    console.log("Assigning email to claim:", { emailId, claimId })
+    const response = await fetch(`${API_BASE_URL}/emails/assign-to-claim`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ emailId, claimId }),
+    })
 
-    return NextResponse.json({ success: true, message: "Email assigned to claim successfully" })
+    if (!response.ok) {
+      const errorText = await response.text()
+      return NextResponse.json({ error: errorText }, { status: response.status })
+    }
+
+    const data = await response.json()
+    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Error assigning email to claim:", error)
-    return NextResponse.json({ error: "Failed to assign email to claim" }, { status: 500 })
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to assign email to claim",
+      },
+      { status: 500 },
+    )
   }
 }

--- a/app/api/emails/folder/[folder]/route.ts
+++ b/app/api/emails/folder/[folder]/route.ts
@@ -1,45 +1,35 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-export async function GET(request: NextRequest, { params }: { params: { folder: string } }) {
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { folder: string } },
+) {
   try {
     const folder = params.folder
 
-    // Mock implementation - replace with actual backend API call
-    let emails = []
+    const response = await fetch(`${API_BASE_URL}/emails/folder/${folder}`, {
+      cache: "no-store",
+    })
 
-    if (folder === "Inbox") {
-      emails = [
-        {
-          id: 1,
-          from: "Jan Kowalski <jan.kowalski@example.com>",
-          to: "claims@company.com",
-          subject: "Zgłoszenie szkody - polisa ABC123",
-          body: "<p>Dzień dobry,</p><p>Zgłaszam szkodę komunikacyjną...</p>",
-          receivedDate: new Date("2024-01-15T10:30:00"),
-          read: false,
-          claimId: "CLAIM-001",
-          attachments: [],
-        },
-      ]
-    } else if (folder === "Sent") {
-      emails = [
-        {
-          id: 2,
-          from: "claims@company.com",
-          to: "jan.kowalski@example.com",
-          subject: "Re: Zgłoszenie szkody - polisa ABC123",
-          body: "<p>Dziękujemy za zgłoszenie...</p>",
-          receivedDate: new Date("2024-01-15T11:00:00"),
-          read: true,
-          claimId: "CLAIM-001",
-          attachments: [],
-        },
-      ]
+    if (!response.ok) {
+      const errorText = await response.text()
+      return NextResponse.json({ error: errorText }, { status: response.status })
     }
 
+    const emails = await response.json()
     return NextResponse.json(emails)
   } catch (error) {
     console.error("Error fetching emails by folder:", error)
-    return NextResponse.json({ error: "Failed to fetch emails by folder" }, { status: 500 })
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to fetch emails by folder",
+      },
+      { status: 500 },
+    )
   }
 }

--- a/app/api/emails/route.ts
+++ b/app/api/emails/route.ts
@@ -1,64 +1,48 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-export async function GET(request: NextRequest) {
-  try {
-    // Mock implementation - replace with actual backend API call
-    const emails = [
-      {
-        id: 1,
-        from: "Jan Kowalski <jan.kowalski@example.com>",
-        to: "claims@company.com",
-        subject: "Zgłoszenie szkody - polisa ABC123",
-        body: "<p>Dzień dobry,</p><p>Zgłaszam szkodę komunikacyjną...</p>",
-        receivedDate: new Date("2024-01-15T10:30:00"),
-        read: false,
-        claimId: null,
-        attachments: [
-          {
-            id: 1,
-            fileName: "zdjecie_szkody.jpg",
-            contentType: "image/jpeg",
-            size: 1024000,
-          },
-        ],
-      },
-      {
-        id: 2,
-        from: "Anna Nowak <anna.nowak@example.com>",
-        to: "claims@company.com",
-        subject: "Dokumenty do szkody XYZ789",
-        body: "<p>W załączeniu przesyłam dokumenty...</p>",
-        receivedDate: new Date("2024-01-14T14:20:00"),
-        read: true,
-        claimId: "CLAIM-001",
-        attachments: [],
-      },
-    ]
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
+export async function GET(_request: NextRequest) {
+  try {
+    const response = await fetch(`${API_BASE_URL}/emails`, { cache: "no-store" })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      return NextResponse.json({ error: errorText }, { status: response.status })
+    }
+
+    const emails = await response.json()
     return NextResponse.json(emails)
   } catch (error) {
     console.error("Error fetching emails:", error)
-    return NextResponse.json({ error: "Failed to fetch emails" }, { status: 500 })
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to fetch emails" },
+      { status: 500 },
+    )
   }
 }
 
 export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData()
-    const to = formData.get("to") as string
-    const subject = formData.get("subject") as string
-    const body = formData.get("body") as string
-    const attachments = formData.getAll("attachments") as File[]
 
-    // Mock implementation - replace with actual email sending logic
-    console.log("Sending email:", { to, subject, body, attachments: attachments.length })
+    const response = await fetch(`${API_BASE_URL}/emails`, {
+      method: "POST",
+      body: formData,
+    })
 
-    // Simulate API delay
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+    if (!response.ok) {
+      const errorText = await response.text()
+      return NextResponse.json({ error: errorText }, { status: response.status })
+    }
 
-    return NextResponse.json({ success: true, message: "Email sent successfully" })
+    const data = await response.json()
+    return NextResponse.json(data, { status: response.status })
   } catch (error) {
     console.error("Error sending email:", error)
-    return NextResponse.json({ error: "Failed to send email" }, { status: 500 })
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to send email" },
+      { status: 500 },
+    )
   }
 }

--- a/app/api/emails/unassigned/route.ts
+++ b/app/api/emails/unassigned/route.ts
@@ -1,25 +1,30 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-export async function GET(request: NextRequest) {
-  try {
-    // Mock implementation - replace with actual backend API call
-    const unassignedEmails = [
-      {
-        id: 3,
-        from: "Maria Kowalczyk <maria.kowalczyk@example.com>",
-        to: "claims@company.com",
-        subject: "Nowa szkoda do przypisania",
-        body: "<p>Proszę o przypisanie tej szkody...</p>",
-        receivedDate: new Date("2024-01-16T09:15:00"),
-        read: false,
-        claimId: null,
-        attachments: [],
-      },
-    ]
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
+export async function GET(_request: NextRequest) {
+  try {
+    const response = await fetch(`${API_BASE_URL}/emails/unassigned`, {
+      cache: "no-store",
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      return NextResponse.json({ error: errorText }, { status: response.status })
+    }
+
+    const unassignedEmails = await response.json()
     return NextResponse.json(unassignedEmails)
   } catch (error) {
     console.error("Error fetching unassigned emails:", error)
-    return NextResponse.json({ error: "Failed to fetch unassigned emails" }, { status: 500 })
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to fetch unassigned emails",
+      },
+      { status: 500 },
+    )
   }
 }


### PR DESCRIPTION
## Summary
- use backend `/emails` endpoints instead of mock data
- forward backend status codes and messages through API routes
- remove mock console logs and support assigning emails to claims

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689e6f442d68832cbae4af949cfdaae1