### PR TITLE
refactor: centralize Settlement type definition

### DIFF
--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -12,7 +12,7 @@ import { useToast } from "@/hooks/use-toast"
 import { HandHeart, Plus, Minus, Edit, Trash2, Download, Eye, X, Upload, FileText, Info, Loader2 } from "lucide-react"
 import { getSettlements, createSettlement, updateSettlement, deleteSettlement } from "@/lib/api/settlements"
 import { API_BASE_URL } from "@/lib/api"
-import type { Settlement } from "@/types"
+import type { Settlement } from "@/lib/api/settlements"
 
 interface SettlementsSectionProps {
   eventId: string

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,5 +1,8 @@
 import type React from "react"
 import type { ClaimDto } from "@/lib/api"
+import type { Settlement } from "@/lib/api/settlements"
+
+export type { Settlement } from "@/lib/api/settlements"
 
 export type ClaimStatus =
   | "Złożone"
@@ -247,27 +250,6 @@ export interface Recourse {
   description: string
   amount?: number
   status?: string
-}
-
-export interface Settlement {
-  id?: string
-  eventId?: string
-  externalEntity?: string
-  customExternalEntity?: string
-  transferDate?: string
-  status?: string
-  settlementDate?: string
-  settlementAmount?: number
-  amount?: number
-  currency?: string
-  paymentMethod?: string
-  notes?: string
-  description?: string
-  settlementNumber?: string
-  settlementType?: string
-  documentPath?: string
-  documentName?: string
-  documentDescription?: string
 }
 
 export type Service = "policja" | "pogotowie" | "straz" | "holownik"


### PR DESCRIPTION
## Summary
- source Settlement type from Zod schema and export for reuse
- remove duplicated Settlement interface in shared types
- consume Settlement type from API module in claim form

## Testing
- `pnpm lint` *(fails: requires interactive config)*
- `pnpm test` *(fails: Cannot require() ES Module in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689e8473fe94832c967e5c393cbf4f11