### PR TITLE
Document risk type endpoints

### DIFF
--- a/backend/Controllers/README.md
+++ b/backend/Controllers/README.md
@@ -7,3 +7,9 @@ Creates and returns a new `Guid` for a damage record without persisting it.
 
 ### POST /api/damages
 Persists a new damage using the id from the init endpoint and the submitted details.
+
+## RiskTypesController
+
+Provides CRUD operations for risk types at `/api/RiskTypes`.
+
+`/api/dictionaries/risk-types` exposes the same data as a read-only dictionary endpoint.

--- a/backend/Controllers/RiskTypesController.cs
+++ b/backend/Controllers/RiskTypesController.cs
@@ -9,6 +9,12 @@ using System.Threading.Tasks;
 
 namespace AutomotiveClaimsApi.Controllers
 {
+    /// <summary>
+    /// Handles create, read, update and delete operations for risk types at `/api/RiskTypes`.
+    /// </summary>
+    /// <remarks>
+    /// The read-only dictionary endpoint is exposed separately at `/api/dictionaries/risk-types`.
+    /// </remarks>
     [ApiController]
     [Route("api/[controller]")]
     public class RiskTypesController : ControllerBase


### PR DESCRIPTION
## Summary
- note that `/api/RiskTypes` exposes CRUD operations
- mention that `/api/dictionaries/risk-types` is a read-only dictionary endpoint

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689e884af10c832c91caaf09689ff400