### PR TITLE
Add ObjectTypeId to events and DTOs

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -102,6 +102,7 @@ namespace AutomotiveClaimsApi.Controllers
                         InsuranceCompany = e.InsuranceCompany,
                         RiskType = e.RiskType,
                         DamageType = e.DamageType,
+                        ObjectTypeId = e.ObjectTypeId,
                         LeasingCompanyId = e.LeasingCompanyId,
                         LeasingCompany = e.LeasingCompany,
                         HandlerId = e.HandlerId,
@@ -675,6 +676,7 @@ namespace AutomotiveClaimsApi.Controllers
             entity.Currency = dto.Currency;
             entity.RiskType = dto.RiskType;
             entity.DamageType = dto.DamageType;
+            entity.ObjectTypeId = dto.ObjectTypeId;
             entity.Liquidator = dto.Liquidator;
             entity.ClientId = dto.ClientId;
             entity.Client = dto.Client;
@@ -1451,6 +1453,7 @@ namespace AutomotiveClaimsApi.Controllers
             Currency = e.Currency,
             RiskType = e.RiskType,
             DamageType = e.DamageType,
+            ObjectTypeId = e.ObjectTypeId,
             Liquidator = e.Liquidator,
             ClientId = e.ClientId,
             Client = e.Client,

--- a/backend/DTOs/EventDto.cs
+++ b/backend/DTOs/EventDto.cs
@@ -27,6 +27,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Currency { get; set; }
         public string? RiskType { get; set; }
         public string? DamageType { get; set; }
+        public int? ObjectTypeId { get; set; }
         public string? Liquidator { get; set; }
         public int? ClientId { get; set; }
         public string? Client { get; set; }

--- a/backend/DTOs/EventListItemDto.cs
+++ b/backend/DTOs/EventListItemDto.cs
@@ -25,6 +25,7 @@ namespace AutomotiveClaimsApi.DTOs
         public DateTime? ReportDate { get; set; }
         public string? RiskType { get; set; }
         public string? DamageType { get; set; }
+        public int? ObjectTypeId { get; set; }
         public int? HandlerId { get; set; }
         public string? Handler { get; set; }
         public int? LeasingCompanyId { get; set; }

--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -65,6 +65,8 @@ namespace AutomotiveClaimsApi.DTOs
         [StringLength(100)]
         public string? DamageType { get; set; }
 
+        public int? ObjectTypeId { get; set; }
+
         [StringLength(200)]
         public string? Liquidator { get; set; }
 

--- a/backend/Migrations/20240130000016_AddObjectTypeIdToEvents.cs
+++ b/backend/Migrations/20240130000016_AddObjectTypeIdToEvents.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddObjectTypeIdToEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ObjectTypeId",
+                table: "Events",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ObjectTypeId",
+                table: "Events");
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -832,6 +832,9 @@ namespace AutomotiveClaimsApi.Migrations
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
 
+                    b.Property<int?>("ObjectTypeId")
+                        .HasColumnType("integer");
+
                     b.Property<string>("Description")
                         .HasColumnType("text");
 

--- a/backend/Models/Event.cs
+++ b/backend/Models/Event.cs
@@ -70,6 +70,8 @@ namespace AutomotiveClaimsApi.Models
         [MaxLength(100)]
         public string? DamageType { get; set; }
 
+        public int? ObjectTypeId { get; set; }
+
         [MaxLength(200)]
         public string? Liquidator { get; set; }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -23,6 +23,7 @@ export interface EventListItemDto {
   leasingCompany?: string
   handlerId?: number
   handler?: string
+  objectTypeId?: number
 }
 
 export interface EventDto extends EventListItemDto {
@@ -95,6 +96,7 @@ export interface EventUpsertDto {
   status?: string
   riskType?: string
   damageType?: string
+  objectTypeId?: number
   insuranceCompanyId?: number
   insuranceCompany?: string
   leasingCompanyId?: number


### PR DESCRIPTION
## Summary
- add nullable ObjectTypeId to Event model
- expose ObjectTypeId in DTOs, controller mappings, and frontend API types
- add EF Core migration for new column

## Testing
- `dotnet test` *(fails: command not found)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `dotnet ef database update` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e868e65f4832c98ab6551ede58879