### PR TITLE
Preserve document on settlement edit

### DIFF
--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -212,6 +212,17 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
         }
 
         if (isEditing && editingSettlementId) {
+          if (!selectedFile) {
+            const currentSettlement = settlements.find(
+              (s) => s.id === editingSettlementId,
+            )
+            if (currentSettlement?.documentPath) {
+              body.append("documentPath", currentSettlement.documentPath)
+            }
+            if (currentSettlement?.documentName) {
+              body.append("documentName", currentSettlement.documentName)
+            }
+          }
           await updateSettlement(editingSettlementId, body)
           toast({
             title: "Sukces",
@@ -246,8 +257,17 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
         setIsLoading(false)
       }
     },
-    [formData, selectedFile, isEditing, editingSettlementId, eventId, loadSettlements, toast],
-  )
+      [
+        formData,
+        selectedFile,
+        isEditing,
+        editingSettlementId,
+        settlements,
+        eventId,
+        loadSettlements,
+        toast,
+      ],
+    )
 
   // Edit settlement
   const editSettlement = useCallback((settlement: Settlement) => {


### PR DESCRIPTION
## Summary
- keep existing document when updating a settlement without selecting a new file
- include settlements array in the submission callback dependencies

## Testing
- `pnpm lint` *(fails: prompts for Next.js ESLint config)*
- `pnpm test` *(fails: module loader error)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e8bf6d380832caa3d62c6da995c29