### PR TITLE
Refactor email event extraction logic

### DIFF
--- a/backend/Services/IEmailService.cs
+++ b/backend/Services/IEmailService.cs
@@ -15,7 +15,6 @@ namespace AutomotiveClaimsApi.Services
         Task<bool> DeleteEmailAsync(Guid id);
         Task FetchEmailsAsync();
         Task<bool> AssignEmailToClaimAsync(Guid emailId, IEnumerable<Guid> claimIds);
-        IEnumerable<string> ExtractClaimNumbers(string message);
-        Task<List<Guid>> FindClaimIdsFromMessage(string message);
+        string? ExtractEventNumber(string message);
     }
 }


### PR DESCRIPTION
## Summary
- replace claim-number parsing with `ExtractEventNumber`
- resolve event IDs from parsed numbers during email entity creation
- remove unused claim-based lookup

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689e8df7f1e4832cb02ff3c2c0c449a2