### PR TITLE
Add event resolver helper to email processing service

### DIFF
--- a/backend/Services/EmailProcessingService.cs
+++ b/backend/Services/EmailProcessingService.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using AutomotiveClaimsApi.Data;
+
+namespace AutomotiveClaimsApi.Services
+{
+    public class EmailProcessingService
+    {
+        private async Task<Guid?> ResolveEventIdFromEventNumberAsync(
+            ApplicationDbContext dbContext, string eventNumber)
+        {
+            if (string.IsNullOrWhiteSpace(eventNumber))
+                return null;
+
+            var evt = await dbContext.Events
+                .AsNoTracking()
+                .Where(e =>
+                    e.ClaimNumber == eventNumber ||
+                    e.InsurerClaimNumber == eventNumber)
+                .Select(e => e.Id)
+                .FirstOrDefaultAsync();
+
+            return evt == Guid.Empty ? (Guid?)null : evt;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add private helper to resolve event ID from an event number in `EmailProcessingService`

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e8df6f144832caf4ea5bc29eba7fc