### PR TITLE
Link email drafts to related claims

### DIFF
--- a/backend/Services/EmailService.cs
+++ b/backend/Services/EmailService.cs
@@ -56,6 +56,29 @@ namespace AutomotiveClaimsApi.Services
                 };
 
                 _context.Emails.Add(email);
+
+                if (createEmailDto.ClaimIds != null)
+                {
+                    foreach (var claimIdStr in createEmailDto.ClaimIds)
+                    {
+                        if (Guid.TryParse(claimIdStr, out var claimId))
+                        {
+                            var claim = await _context.ClientClaims.FindAsync(claimId);
+                            if (claim != null)
+                            {
+                                var emailClaim = new EmailClaim
+                                {
+                                    EmailId = email.Id,
+                                    Email = email,
+                                    ClaimId = claim.Id,
+                                    Claim = claim
+                                };
+                                email.EmailClaims.Add(emailClaim);
+                            }
+                        }
+                    }
+                }
+
                 await _context.SaveChangesAsync();
 
                 return MapEmailToDto(email);


### PR DESCRIPTION
## Summary
- associate draft emails with selected client claims when creating a draft
- persist email-claim join entries

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e98b8eff8832caafc59832894495a