### PR TITLE
Normalize risk type filtering for claims list

### DIFF
--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -108,7 +108,10 @@ export function ClaimsList({
 
   // TODO: consider moving this filtering to use-claims or the API to reduce client workload
   const allowedRiskTypes = useMemo(
-    () => (claimObjectTypeId ? RISK_TYPE_GROUPS[claimObjectTypeId] : undefined),
+    () =>
+      claimObjectTypeId
+        ? RISK_TYPE_GROUPS[claimObjectTypeId]?.map((type) => type.toLowerCase())
+        : undefined,
     [claimObjectTypeId],
   )
 
@@ -131,7 +134,9 @@ export function ClaimsList({
           const matchesHandler =
             !filterHandler || claim.liquidator?.toLowerCase().includes(filterHandler.toLowerCase())
           const matchesClaimType =
-            !allowedRiskTypes || !claim.riskType || allowedRiskTypes.includes(claim.riskType)
+            !allowedRiskTypes ||
+            !claim.riskType ||
+            allowedRiskTypes.includes(claim.riskType.toLowerCase())
 
           return (
             matchesSearch &&


### PR DESCRIPTION
## Summary
- compare risk type values case-insensitively so API results aren't dropped

## Testing
- `pnpm lint` *(fails: recommends adding Next.js ESLint plugin)*
- `pnpm test` *(fails: Cannot require() ES Module in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689e99e01a58832ca1085dbe4e05b217