### PR TITLE
feat: add contact info for case handlers

### DIFF
--- a/backend/Controllers/DictionariesController.cs
+++ b/backend/Controllers/DictionariesController.cs
@@ -35,6 +35,9 @@ namespace AutomotiveClaimsApi.Controllers
                         Id = h.Id.ToString(),
                         Name = h.Name,
                         Code = h.Code,
+                        Email = h.Email,
+                        Phone = h.Phone,
+                        Department = h.Department,
                         IsActive = h.IsActive
                     })
                     .ToListAsync();

--- a/backend/DTOs/Dictionary/DictionaryItemDto.cs
+++ b/backend/DTOs/Dictionary/DictionaryItemDto.cs
@@ -8,5 +8,9 @@ namespace AutomotiveClaimsApi.DTOs.Dictionary
         public string? Description { get; set; }
         public bool IsActive { get; set; } = true;
         public int? SortOrder { get; set; }
+
+        public string? Email { get; set; }
+        public string? Phone { get; set; }
+        public string? Department { get; set; }
     }
 }

--- a/backend/Models/Dictionary/CaseHandler.cs
+++ b/backend/Models/Dictionary/CaseHandler.cs
@@ -16,6 +16,15 @@ namespace AutomotiveClaimsApi.Models.Dictionary
         [StringLength(20)]
         public string? Code { get; set; }
 
+        [StringLength(200)]
+        public string Email { get; set; } = string.Empty;
+
+        [StringLength(50)]
+        public string Phone { get; set; } = string.Empty;
+
+        [StringLength(100)]
+        public string Department { get; set; } = string.Empty;
+
         public bool IsActive { get; set; } = true;
     }
 }

--- a/components/handler-dropdown.tsx
+++ b/components/handler-dropdown.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { ChevronDown, Phone, Mail, MapPin, Check } from "lucide-react"
+import { ChevronDown, Phone, Mail, MapPin, Check, Briefcase } from "lucide-react"
 import type { Handler, HandlerSelectionEvent } from "@/types/handler"
 import { HandlersService } from "@/lib/handlers"
 
@@ -125,6 +125,9 @@ export default function HandlerDropdown({
       onHandlerSelected({
         handlerId: handler.id,
         handlerName: handler.name,
+        handlerEmail: handler.email,
+        handlerPhone: handler.phone,
+        handlerDepartment: handler.department,
       })
     }
   }
@@ -207,7 +210,7 @@ export default function HandlerDropdown({
       {selectedHandler && (
         <Card className="mt-6 border-gray-200 shadow-sm">
           <CardContent className="p-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
               {/* Phone */}
               <div>
                 <h3 className="flex items-center text-sm font-medium mb-2 text-gray-700">
@@ -236,6 +239,19 @@ export default function HandlerDropdown({
                   </a>
                 ) : (
                   <p className="text-gray-500 italic text-sm">Brak adresu e-mail</p>
+                )}
+              </div>
+
+              {/* Department */}
+              <div>
+                <h3 className="flex items-center text-sm font-medium mb-2 text-gray-700">
+                  <Briefcase className="h-4 w-4 mr-2 text-blue-600" />
+                  Dział
+                </h3>
+                {hasContactInfo(selectedHandler.department || "") ? (
+                  <p className="text-gray-900 text-sm">{selectedHandler.department}</p>
+                ) : (
+                  <p className="text-gray-500 italic text-sm">Brak działu</p>
                 )}
               </div>
             </div>

--- a/lib/dictionary-service.ts
+++ b/lib/dictionary-service.ts
@@ -7,6 +7,7 @@ interface DictionaryItemDto {
   symbol?: string
   phone?: string
   email?: string
+  department?: string
   address?: string
   sortOrder?: number
   isActive: boolean

--- a/types/handler.ts
+++ b/types/handler.ts
@@ -35,6 +35,7 @@ export interface HandlerSelectionEvent {
   handlerName: string
   handlerEmail: string
   handlerPhone: string
+  handlerDepartment?: string
 }
 
 // Enum for handler departments


### PR DESCRIPTION
## Summary
- extend dictionary item and models with email, phone and department details
- populate case handler contact data in dictionary controller
- expose department info in handler dropdown and dictionary service

## Testing
- `pnpm test` (fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)
- `dotnet test` (fails: command not found: dotnet)
- `apt-get update` (fails: repository ... is not signed)

------
https://chatgpt.com/codex/tasks/task_e_689e9a28d9f8832c9db52583871c5c9a