### PR TITLE
Use dict schema for dictionary tables

### DIFF
--- a/backend/Models/Dictionary/ClaimStatus.cs
+++ b/backend/Models/Dictionary/ClaimStatus.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutomotiveClaimsApi.Models.Dictionary
 {
+    [Table("ClaimStatuses", Schema = "dict")]
     public class ClaimStatus
     {
         public Guid Id { get; set; }

--- a/backend/Models/Dictionary/ContractType.cs
+++ b/backend/Models/Dictionary/ContractType.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutomotiveClaimsApi.Models.Dictionary
 {
+    [Table("ContractTypes", Schema = "dict")]
     public class ContractType
     {
         public Guid Id { get; set; }

--- a/backend/Models/Dictionary/Country.cs
+++ b/backend/Models/Dictionary/Country.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutomotiveClaimsApi.Models.Dictionary
 {
+    [Table("Countries", Schema = "dict")]
     public class Country
     {
         public Guid Id { get; set; }

--- a/backend/Models/Dictionary/Currency.cs
+++ b/backend/Models/Dictionary/Currency.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutomotiveClaimsApi.Models.Dictionary
 {
+    [Table("Currencies", Schema = "dict")]
     public class Currency
     {
         public Guid Id { get; set; }

--- a/backend/Models/Dictionary/DocumentStatus.cs
+++ b/backend/Models/Dictionary/DocumentStatus.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutomotiveClaimsApi.Models.Dictionary
 {
+    [Table("DocumentStatuses", Schema = "dict")]
     public class DocumentStatus
     {
         public Guid Id { get; set; }

--- a/backend/Models/Dictionary/EventStatus.cs
+++ b/backend/Models/Dictionary/EventStatus.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutomotiveClaimsApi.Models.Dictionary
 {
+    [Table("EventStatuses", Schema = "dict")]
     public class EventStatus
     {
         public Guid Id { get; set; }

--- a/backend/Models/Dictionary/PaymentMethod.cs
+++ b/backend/Models/Dictionary/PaymentMethod.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutomotiveClaimsApi.Models.Dictionary
 {
+    [Table("PaymentMethods", Schema = "dict")]
     public class PaymentMethod
     {
         public Guid Id { get; set; }

--- a/backend/Models/Dictionary/Priority.cs
+++ b/backend/Models/Dictionary/Priority.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutomotiveClaimsApi.Models.Dictionary
 {
+    [Table("Priorities", Schema = "dict")]
     public class Priority
     {
         public Guid Id { get; set; }

--- a/backend/Models/Dictionary/VehicleType.cs
+++ b/backend/Models/Dictionary/VehicleType.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutomotiveClaimsApi.Models.Dictionary
 {
+    [Table("VehicleTypes", Schema = "dict")]
     public class VehicleType
     {
         public Guid Id { get; set; }

--- a/scripts/015_create_dictionary_tables.sql
+++ b/scripts/015_create_dictionary_tables.sql
@@ -1,7 +1,11 @@
 -- Create dictionary tables for dropdown values
 
+-- Ensure dictionary schema exists
+IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'dict')
+    EXEC('CREATE SCHEMA dict');
+
 -- Countries table
-CREATE TABLE Countries (
+CREATE TABLE dict.Countries (
     Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
     Code NVARCHAR(10) NOT NULL UNIQUE,
     Name NVARCHAR(255) NOT NULL,
@@ -11,7 +15,7 @@ CREATE TABLE Countries (
 );
 
 -- Currencies table
-CREATE TABLE Currencies (
+CREATE TABLE dict.Currencies (
     Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
     Code NVARCHAR(10) NOT NULL UNIQUE,
     Name NVARCHAR(255) NOT NULL,
@@ -22,7 +26,7 @@ CREATE TABLE Currencies (
 );
 
 -- Insurance Companies table
-CREATE TABLE InsuranceCompanies (
+CREATE TABLE dict.InsuranceCompanies (
     Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
     Code NVARCHAR(50),
     Name NVARCHAR(500) NOT NULL,
@@ -35,7 +39,7 @@ CREATE TABLE InsuranceCompanies (
 );
 
 -- Leasing Companies table
-CREATE TABLE LeasingCompanies (
+CREATE TABLE dict.LeasingCompanies (
     Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
     Code NVARCHAR(50),
     Name NVARCHAR(500) NOT NULL,
@@ -48,7 +52,7 @@ CREATE TABLE LeasingCompanies (
 );
 
 -- Document Statuses table
-CREATE TABLE DocumentStatuses (
+CREATE TABLE dict.DocumentStatuses (
     Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
     Code NVARCHAR(50) NOT NULL UNIQUE,
     Name NVARCHAR(255) NOT NULL,
@@ -60,7 +64,7 @@ CREATE TABLE DocumentStatuses (
 );
 
 -- Contract Types table
-CREATE TABLE ContractTypes (
+CREATE TABLE dict.ContractTypes (
     Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
     Code NVARCHAR(50) NOT NULL UNIQUE,
     Name NVARCHAR(255) NOT NULL,
@@ -71,7 +75,7 @@ CREATE TABLE ContractTypes (
 );
 
 -- Payment Methods table
-CREATE TABLE PaymentMethods (
+CREATE TABLE dict.PaymentMethods (
     Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
     Code NVARCHAR(50) NOT NULL UNIQUE,
     Name NVARCHAR(255) NOT NULL,
@@ -82,7 +86,7 @@ CREATE TABLE PaymentMethods (
 );
 
 -- Claim Statuses table
-CREATE TABLE ClaimStatuses (
+CREATE TABLE dict.ClaimStatuses (
     Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
     Code NVARCHAR(50) NOT NULL UNIQUE,
     Name NVARCHAR(255) NOT NULL,
@@ -94,7 +98,7 @@ CREATE TABLE ClaimStatuses (
 );
 
 -- Vehicle Types table
-CREATE TABLE VehicleTypes (
+CREATE TABLE dict.VehicleTypes (
     Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
     Code NVARCHAR(50) NOT NULL UNIQUE,
     Name NVARCHAR(255) NOT NULL,
@@ -105,7 +109,7 @@ CREATE TABLE VehicleTypes (
 );
 
 -- Priorities table
-CREATE TABLE Priorities (
+CREATE TABLE dict.Priorities (
     Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
     Code NVARCHAR(50) NOT NULL UNIQUE,
     Name NVARCHAR(255) NOT NULL,
@@ -118,7 +122,7 @@ CREATE TABLE Priorities (
 );
 
 -- Event Statuses table
-CREATE TABLE EventStatuses (
+CREATE TABLE dict.EventStatuses (
     Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
     Code NVARCHAR(50) NOT NULL UNIQUE,
     Name NVARCHAR(255) NOT NULL,
@@ -130,36 +134,36 @@ CREATE TABLE EventStatuses (
 );
 
 -- Create indexes for better performance
-CREATE INDEX IX_Countries_Code ON Countries(Code);
-CREATE INDEX IX_Countries_IsActive ON Countries(IsActive);
+CREATE INDEX IX_Countries_Code ON dict.Countries(Code);
+CREATE INDEX IX_Countries_IsActive ON dict.Countries(IsActive);
 
-CREATE INDEX IX_Currencies_Code ON Currencies(Code);
-CREATE INDEX IX_Currencies_IsActive ON Currencies(IsActive);
+CREATE INDEX IX_Currencies_Code ON dict.Currencies(Code);
+CREATE INDEX IX_Currencies_IsActive ON dict.Currencies(IsActive);
 
-CREATE INDEX IX_InsuranceCompanies_IsActive ON InsuranceCompanies(IsActive);
-CREATE INDEX IX_InsuranceCompanies_Name ON InsuranceCompanies(Name);
+CREATE INDEX IX_InsuranceCompanies_IsActive ON dict.InsuranceCompanies(IsActive);
+CREATE INDEX IX_InsuranceCompanies_Name ON dict.InsuranceCompanies(Name);
 
-CREATE INDEX IX_LeasingCompanies_IsActive ON LeasingCompanies(IsActive);
-CREATE INDEX IX_LeasingCompanies_Name ON LeasingCompanies(Name);
+CREATE INDEX IX_LeasingCompanies_IsActive ON dict.LeasingCompanies(IsActive);
+CREATE INDEX IX_LeasingCompanies_Name ON dict.LeasingCompanies(Name);
 
-CREATE INDEX IX_DocumentStatuses_Code ON DocumentStatuses(Code);
-CREATE INDEX IX_DocumentStatuses_IsActive ON DocumentStatuses(IsActive);
+CREATE INDEX IX_DocumentStatuses_Code ON dict.DocumentStatuses(Code);
+CREATE INDEX IX_DocumentStatuses_IsActive ON dict.DocumentStatuses(IsActive);
 
-CREATE INDEX IX_ContractTypes_Code ON ContractTypes(Code);
-CREATE INDEX IX_ContractTypes_IsActive ON ContractTypes(IsActive);
+CREATE INDEX IX_ContractTypes_Code ON dict.ContractTypes(Code);
+CREATE INDEX IX_ContractTypes_IsActive ON dict.ContractTypes(IsActive);
 
-CREATE INDEX IX_PaymentMethods_Code ON PaymentMethods(Code);
-CREATE INDEX IX_PaymentMethods_IsActive ON PaymentMethods(IsActive);
+CREATE INDEX IX_PaymentMethods_Code ON dict.PaymentMethods(Code);
+CREATE INDEX IX_PaymentMethods_IsActive ON dict.PaymentMethods(IsActive);
 
-CREATE INDEX IX_ClaimStatuses_Code ON ClaimStatuses(Code);
-CREATE INDEX IX_ClaimStatuses_IsActive ON ClaimStatuses(IsActive);
+CREATE INDEX IX_ClaimStatuses_Code ON dict.ClaimStatuses(Code);
+CREATE INDEX IX_ClaimStatuses_IsActive ON dict.ClaimStatuses(IsActive);
 
-CREATE INDEX IX_VehicleTypes_Code ON VehicleTypes(Code);
-CREATE INDEX IX_VehicleTypes_IsActive ON VehicleTypes(IsActive);
+CREATE INDEX IX_VehicleTypes_Code ON dict.VehicleTypes(Code);
+CREATE INDEX IX_VehicleTypes_IsActive ON dict.VehicleTypes(IsActive);
 
-CREATE INDEX IX_Priorities_Code ON Priorities(Code);
-CREATE INDEX IX_Priorities_IsActive ON Priorities(IsActive);
-CREATE INDEX IX_Priorities_SortOrder ON Priorities(SortOrder);
+CREATE INDEX IX_Priorities_Code ON dict.Priorities(Code);
+CREATE INDEX IX_Priorities_IsActive ON dict.Priorities(IsActive);
+CREATE INDEX IX_Priorities_SortOrder ON dict.Priorities(SortOrder);
 
-CREATE INDEX IX_EventStatuses_Code ON EventStatuses(Code);
-CREATE INDEX IX_EventStatuses_IsActive ON EventStatuses(IsActive);
+CREATE INDEX IX_EventStatuses_Code ON dict.EventStatuses(Code);
+CREATE INDEX IX_EventStatuses_IsActive ON dict.EventStatuses(IsActive);

--- a/scripts/018_create_complete_dictionary_tables.sql
+++ b/scripts/018_create_complete_dictionary_tables.sql
@@ -1,7 +1,10 @@
 -- Create dictionary tables for all dropdowns used in the frontend
 
+-- Ensure dictionary schema exists
+CREATE SCHEMA IF NOT EXISTS dict;
+
 -- Case Handlers table (Prowadzący sprawę)
-CREATE TABLE IF NOT EXISTS CaseHandlers (
+CREATE TABLE IF NOT EXISTS dict.CaseHandlers (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     Name VARCHAR(200) NOT NULL,
     Email VARCHAR(200) NOT NULL DEFAULT '',
@@ -11,10 +14,10 @@ CREATE TABLE IF NOT EXISTS CaseHandlers (
     CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-CREATE INDEX IF NOT EXISTS idx_case_handlers_is_active ON CaseHandlers(IsActive);
+CREATE INDEX IF NOT EXISTS idx_case_handlers_is_active ON dict.CaseHandlers(IsActive);
 
 -- Countries table
-CREATE TABLE IF NOT EXISTS Countries (
+CREATE TABLE IF NOT EXISTS dict.Countries (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     Code VARCHAR(10) NOT NULL UNIQUE,
     Name VARCHAR(200) NOT NULL,
@@ -22,11 +25,11 @@ CREATE TABLE IF NOT EXISTS Countries (
     CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-CREATE INDEX IF NOT EXISTS idx_countries_code ON Countries(Code);
-CREATE INDEX IF NOT EXISTS idx_countries_is_active ON Countries(IsActive);
+CREATE INDEX IF NOT EXISTS idx_countries_code ON dict.Countries(Code);
+CREATE INDEX IF NOT EXISTS idx_countries_is_active ON dict.Countries(IsActive);
 
 -- Currencies table
-CREATE TABLE IF NOT EXISTS Currencies (
+CREATE TABLE IF NOT EXISTS dict.Currencies (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     Code VARCHAR(10) NOT NULL UNIQUE,
     Name VARCHAR(100) NOT NULL,
@@ -35,11 +38,11 @@ CREATE TABLE IF NOT EXISTS Currencies (
     CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-CREATE INDEX IF NOT EXISTS idx_currencies_code ON Currencies(Code);
-CREATE INDEX IF NOT EXISTS idx_currencies_is_active ON Currencies(IsActive);
+CREATE INDEX IF NOT EXISTS idx_currencies_code ON dict.Currencies(Code);
+CREATE INDEX IF NOT EXISTS idx_currencies_is_active ON dict.Currencies(IsActive);
 
 -- Insurance Companies table
-CREATE TABLE IF NOT EXISTS InsuranceCompanies (
+CREATE TABLE IF NOT EXISTS dict.InsuranceCompanies (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     Name VARCHAR(200) NOT NULL,
     FullName VARCHAR(500),
@@ -50,11 +53,11 @@ CREATE TABLE IF NOT EXISTS InsuranceCompanies (
     CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-CREATE INDEX IF NOT EXISTS idx_insurance_companies_is_active ON InsuranceCompanies(IsActive);
-CREATE INDEX IF NOT EXISTS idx_insurance_companies_name ON InsuranceCompanies(Name);
+CREATE INDEX IF NOT EXISTS idx_insurance_companies_is_active ON dict.InsuranceCompanies(IsActive);
+CREATE INDEX IF NOT EXISTS idx_insurance_companies_name ON dict.InsuranceCompanies(Name);
 
 -- Leasing Companies table
-CREATE TABLE IF NOT EXISTS LeasingCompanies (
+CREATE TABLE IF NOT EXISTS dict.LeasingCompanies (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     Name VARCHAR(200) NOT NULL,
     FullName VARCHAR(500),
@@ -65,11 +68,11 @@ CREATE TABLE IF NOT EXISTS LeasingCompanies (
     CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-CREATE INDEX IF NOT EXISTS idx_leasing_companies_is_active ON LeasingCompanies(IsActive);
-CREATE INDEX IF NOT EXISTS idx_leasing_companies_name ON LeasingCompanies(Name);
+CREATE INDEX IF NOT EXISTS idx_leasing_companies_is_active ON dict.LeasingCompanies(IsActive);
+CREATE INDEX IF NOT EXISTS idx_leasing_companies_name ON dict.LeasingCompanies(Name);
 
 -- Document Statuses table
-CREATE TABLE IF NOT EXISTS DocumentStatuses (
+CREATE TABLE IF NOT EXISTS dict.DocumentStatuses (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     Code VARCHAR(50) NOT NULL UNIQUE,
     Name VARCHAR(200) NOT NULL,
@@ -79,11 +82,11 @@ CREATE TABLE IF NOT EXISTS DocumentStatuses (
     CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-CREATE INDEX IF NOT EXISTS idx_document_statuses_code ON DocumentStatuses(Code);
-CREATE INDEX IF NOT EXISTS idx_document_statuses_is_active ON DocumentStatuses(IsActive);
+CREATE INDEX IF NOT EXISTS idx_document_statuses_code ON dict.DocumentStatuses(Code);
+CREATE INDEX IF NOT EXISTS idx_document_statuses_is_active ON dict.DocumentStatuses(IsActive);
 
 -- Contract Types table
-CREATE TABLE IF NOT EXISTS ContractTypes (
+CREATE TABLE IF NOT EXISTS dict.ContractTypes (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     Code VARCHAR(50) NOT NULL UNIQUE,
     Name VARCHAR(200) NOT NULL,
@@ -92,11 +95,11 @@ CREATE TABLE IF NOT EXISTS ContractTypes (
     CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-CREATE INDEX IF NOT EXISTS idx_contract_types_code ON ContractTypes(Code);
-CREATE INDEX IF NOT EXISTS idx_contract_types_is_active ON ContractTypes(IsActive);
+CREATE INDEX IF NOT EXISTS idx_contract_types_code ON dict.ContractTypes(Code);
+CREATE INDEX IF NOT EXISTS idx_contract_types_is_active ON dict.ContractTypes(IsActive);
 
 -- Payment Methods table
-CREATE TABLE IF NOT EXISTS PaymentMethods (
+CREATE TABLE IF NOT EXISTS dict.PaymentMethods (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     Code VARCHAR(50) NOT NULL UNIQUE,
     Name VARCHAR(200) NOT NULL,
@@ -105,11 +108,11 @@ CREATE TABLE IF NOT EXISTS PaymentMethods (
     CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-CREATE INDEX IF NOT EXISTS idx_payment_methods_code ON PaymentMethods(Code);
-CREATE INDEX IF NOT EXISTS idx_payment_methods_is_active ON PaymentMethods(IsActive);
+CREATE INDEX IF NOT EXISTS idx_payment_methods_code ON dict.PaymentMethods(Code);
+CREATE INDEX IF NOT EXISTS idx_payment_methods_is_active ON dict.PaymentMethods(IsActive);
 
 -- Claim Statuses table
-CREATE TABLE IF NOT EXISTS ClaimStatuses (
+CREATE TABLE IF NOT EXISTS dict.ClaimStatuses (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     Code VARCHAR(50) NOT NULL UNIQUE,
     Name VARCHAR(200) NOT NULL,
@@ -119,11 +122,11 @@ CREATE TABLE IF NOT EXISTS ClaimStatuses (
     CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-CREATE INDEX IF NOT EXISTS idx_claim_statuses_code ON ClaimStatuses(Code);
-CREATE INDEX IF NOT EXISTS idx_claim_statuses_is_active ON ClaimStatuses(IsActive);
+CREATE INDEX IF NOT EXISTS idx_claim_statuses_code ON dict.ClaimStatuses(Code);
+CREATE INDEX IF NOT EXISTS idx_claim_statuses_is_active ON dict.ClaimStatuses(IsActive);
 
 -- Vehicle Types table
-CREATE TABLE IF NOT EXISTS VehicleTypes (
+CREATE TABLE IF NOT EXISTS dict.VehicleTypes (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     Code VARCHAR(50) NOT NULL UNIQUE,
     Name VARCHAR(200) NOT NULL,
@@ -132,11 +135,11 @@ CREATE TABLE IF NOT EXISTS VehicleTypes (
     CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-CREATE INDEX IF NOT EXISTS idx_vehicle_types_code ON VehicleTypes(Code);
-CREATE INDEX IF NOT EXISTS idx_vehicle_types_is_active ON VehicleTypes(IsActive);
+CREATE INDEX IF NOT EXISTS idx_vehicle_types_code ON dict.VehicleTypes(Code);
+CREATE INDEX IF NOT EXISTS idx_vehicle_types_is_active ON dict.VehicleTypes(IsActive);
 
 -- Priorities table
-CREATE TABLE IF NOT EXISTS Priorities (
+CREATE TABLE IF NOT EXISTS dict.Priorities (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     Code VARCHAR(50) NOT NULL UNIQUE,
     Name VARCHAR(200) NOT NULL,
@@ -147,12 +150,12 @@ CREATE TABLE IF NOT EXISTS Priorities (
     CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-CREATE INDEX IF NOT EXISTS idx_priorities_code ON Priorities(Code);
-CREATE INDEX IF NOT EXISTS idx_priorities_is_active ON Priorities(IsActive);
-CREATE INDEX IF NOT EXISTS idx_priorities_sort_order ON Priorities(SortOrder);
+CREATE INDEX IF NOT EXISTS idx_priorities_code ON dict.Priorities(Code);
+CREATE INDEX IF NOT EXISTS idx_priorities_is_active ON dict.Priorities(IsActive);
+CREATE INDEX IF NOT EXISTS idx_priorities_sort_order ON dict.Priorities(SortOrder);
 
 -- Event Statuses table
-CREATE TABLE IF NOT EXISTS EventStatuses (
+CREATE TABLE IF NOT EXISTS dict.EventStatuses (
     Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     Code VARCHAR(50) NOT NULL UNIQUE,
     Name VARCHAR(200) NOT NULL,
@@ -162,5 +165,5 @@ CREATE TABLE IF NOT EXISTS EventStatuses (
     CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-CREATE INDEX IF NOT EXISTS idx_event_statuses_code ON EventStatuses(Code);
-CREATE INDEX IF NOT EXISTS idx_event_statuses_is_active ON EventStatuses(IsActive);
+CREATE INDEX IF NOT EXISTS idx_event_statuses_code ON dict.EventStatuses(Code);
+CREATE INDEX IF NOT EXISTS idx_event_statuses_is_active ON dict.EventStatuses(IsActive);


### PR DESCRIPTION
## Summary
- place all dictionary tables in a dedicated `dict` schema
- annotate dictionary EF models with `Table` attributes targeting the `dict` schema
- update SQL creation scripts to create tables and indexes under `dict`

## Testing
- `pnpm test` *(fails: Cannot require() ES Module in a cycle)*
- `dotnet ef database update` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e9a292ffc832c9fd4ab4781eb2f5b