### PR TITLE
Expose department and contact fields for case handlers

### DIFF
--- a/backend/Controllers/DictionariesController.cs
+++ b/backend/Controllers/DictionariesController.cs
@@ -35,6 +35,9 @@ namespace AutomotiveClaimsApi.Controllers
                         Id = h.Id.ToString(),
                         Name = h.Name,
                         Code = h.Code,
+                        Email = h.Email,
+                        Phone = h.Phone,
+                        Department = h.Department,
                         IsActive = h.IsActive
                     })
                     .ToListAsync();

--- a/backend/DTOs/Dictionary/DictionaryItemDto.cs
+++ b/backend/DTOs/Dictionary/DictionaryItemDto.cs
@@ -8,5 +8,8 @@ namespace AutomotiveClaimsApi.DTOs.Dictionary
         public string? Description { get; set; }
         public bool IsActive { get; set; } = true;
         public int? SortOrder { get; set; }
+        public string? Email { get; set; }
+        public string? Phone { get; set; }
+        public string? Department { get; set; }
     }
 }

--- a/backend/Migrations/20240130000020_AddCaseHandlers.cs
+++ b/backend/Migrations/20240130000020_AddCaseHandlers.cs
@@ -1,0 +1,50 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCaseHandlers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CaseHandlers",
+                schema: "dict",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Code = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    Email = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    Phone = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    Department = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CaseHandlers", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CaseHandlers_IsActive",
+                schema: "dict",
+                table: "CaseHandlers",
+                column: "IsActive");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CaseHandlers",
+                schema: "dict");
+        }
+    }
+}
+

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1279,6 +1279,44 @@ namespace AutomotiveClaimsApi.Migrations
                     b.ToTable("Settlements");
                 });
 
+            modelBuilder.Entity("AutomotiveClaimsApi.Models.Dictionary.CaseHandler", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer")
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+                    b.Property<string>("Code")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("Department")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("Email")
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<bool>("IsActive")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("Phone")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("IsActive");
+
+                    b.ToTable("CaseHandlers", "dict");
+                });
+
             modelBuilder.Entity("AutomotiveClaimsApi.Models.Appeal", b =>
                 {
                     b.HasOne("AutomotiveClaimsApi.Models.Event", "Event")

--- a/backend/Models/Dictionary/CaseHandler.cs
+++ b/backend/Models/Dictionary/CaseHandler.cs
@@ -16,6 +16,15 @@ namespace AutomotiveClaimsApi.Models.Dictionary
         [StringLength(20)]
         public string? Code { get; set; }
 
+        [StringLength(200)]
+        public string? Email { get; set; }
+
+        [StringLength(50)]
+        public string? Phone { get; set; }
+
+        [StringLength(100)]
+        public string? Department { get; set; }
+
         public bool IsActive { get; set; } = true;
     }
 }

--- a/lib/dictionary-service.ts
+++ b/lib/dictionary-service.ts
@@ -8,6 +8,7 @@ interface DictionaryItemDto {
   phone?: string
   email?: string
   address?: string
+  department?: string
   sortOrder?: number
   isActive: boolean
   createdAt: string

--- a/scripts/018_create_complete_dictionary_tables.sql
+++ b/scripts/018_create_complete_dictionary_tables.sql
@@ -1,17 +1,19 @@
 -- Create dictionary tables for all dropdowns used in the frontend
 
+CREATE SCHEMA IF NOT EXISTS dict;
+
 -- Case Handlers table (Prowadzący sprawę)
-CREATE TABLE IF NOT EXISTS CaseHandlers (
-    Id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+CREATE TABLE IF NOT EXISTS dict.CaseHandlers (
+    Id SERIAL PRIMARY KEY,
     Name VARCHAR(200) NOT NULL,
-    Email VARCHAR(200) NOT NULL DEFAULT '',
-    Phone VARCHAR(50) NOT NULL DEFAULT '',
-    Department VARCHAR(100) NOT NULL DEFAULT '',
-    IsActive BOOLEAN NOT NULL DEFAULT TRUE,
-    CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+    Code VARCHAR(20),
+    Email VARCHAR(200),
+    Phone VARCHAR(50),
+    Department VARCHAR(100),
+    IsActive BOOLEAN NOT NULL DEFAULT TRUE
 );
-CREATE INDEX IF NOT EXISTS idx_case_handlers_is_active ON CaseHandlers(IsActive);
+CREATE INDEX IF NOT EXISTS idx_case_handlers_is_active ON dict.CaseHandlers(IsActive);
+CREATE INDEX IF NOT EXISTS idx_case_handlers_code ON dict.CaseHandlers(Code);
 
 -- Countries table
 CREATE TABLE IF NOT EXISTS Countries (

--- a/scripts/019_seed_complete_dictionary_data.sql
+++ b/scripts/019_seed_complete_dictionary_data.sql
@@ -1,20 +1,20 @@
 -- Seed all dictionary tables with initial data
 
 -- Case Handlers (Prowadzący sprawę)
-INSERT INTO CaseHandlers (Name, Email, Phone, Department) VALUES
-('Marcin Małuj', 'marcin.maluj@spartabrokers.pl', '600 111 222', 'Likwidacja szkód'),
-('Małgorzata Roczniak', 'malgorzata.roczniak@spartabrokers.pl', '600 222 333', 'Likwidacja szkód'),
-('Piotr Raniecki', 'piotr.raniecki@spartabrokers.pl', '600 333 355', 'Likwidacja szkód'),
-('Joanna Romanowska', 'joanna.romanowska@spartabrokers.pl', '600 444 555', 'Likwidacja szkód'),
-('Paweł Gułaj', 'pawel.gulaj@spartabrokers.pl', '600 555 666', 'Likwidacja szkód'),
-('Kamila Szepit', 'kamila.szepit@spartabrokers.pl', '600 666 777', 'Likwidacja szkód'),
-('Jacek Kamiński', 'jacek.kaminski@spartabrokers.pl', '600 777 888', 'Likwidacja szkód'),
-('Edyta Dyczkowska', 'edyta.dyczkowska@spartabrokers.pl', '600 888 999', 'Likwidacja szkód'),
-('Ireneusz Osiński', 'ireneusz.osinski@spartabrokers.pl', '600 999 000', 'Likwidacja szkód'),
-('Kinga Tuzimek', 'kinga.tuzimek@spartabrokers.pl', '600 000 111', 'Likwidacja szkód'),
-('Jan Kowalski', 'jan.kowalski@sparta.pl', '+48 123 456 789', 'Obsługa klienta'),
-('Anna Nowak', 'anna.nowak@sparta.pl', '+48 987 654 321', 'Obsługa klienta'),
-('Piotr Wiśniewski', 'piotr.wisniewski@sparta.pl', '+48 555 666 777', 'Obsługa klienta')
+INSERT INTO dict.CaseHandlers (Name, Code, Email, Phone, Department) VALUES
+('Marcin Małuj', 'CH001', 'marcin.maluj@spartabrokers.pl', '600 111 222', 'Likwidacja szkód'),
+('Małgorzata Roczniak', 'CH002', 'malgorzata.roczniak@spartabrokers.pl', '600 222 333', 'Likwidacja szkód'),
+('Piotr Raniecki', 'CH003', 'piotr.raniecki@spartabrokers.pl', '600 333 355', 'Likwidacja szkód'),
+('Joanna Romanowska', 'CH004', 'joanna.romanowska@spartabrokers.pl', '600 444 555', 'Likwidacja szkód'),
+('Paweł Gułaj', 'CH005', 'pawel.gulaj@spartabrokers.pl', '600 555 666', 'Likwidacja szkód'),
+('Kamila Szepit', 'CH006', 'kamila.szepit@spartabrokers.pl', '600 666 777', 'Likwidacja szkód'),
+('Jacek Kamiński', 'CH007', 'jacek.kaminski@spartabrokers.pl', '600 777 888', 'Likwidacja szkód'),
+('Edyta Dyczkowska', 'CH008', 'edyta.dyczkowska@spartabrokers.pl', '600 888 999', 'Likwidacja szkód'),
+('Ireneusz Osiński', 'CH009', 'ireneusz.osinski@spartabrokers.pl', '600 999 000', 'Likwidacja szkód'),
+('Kinga Tuzimek', 'CH010', 'kinga.tuzimek@spartabrokers.pl', '600 000 111', 'Likwidacja szkód'),
+('Jan Kowalski', 'CH011', 'jan.kowalski@sparta.pl', '+48 123 456 789', 'Obsługa klienta'),
+('Anna Nowak', 'CH012', 'anna.nowak@sparta.pl', '+48 987 654 321', 'Obsługa klienta'),
+('Piotr Wiśniewski', 'CH013', 'piotr.wisniewski@sparta.pl', '+48 555 666 777', 'Obsługa klienta')
 ON CONFLICT (Name) DO NOTHING;
 
 -- Countries


### PR DESCRIPTION
## Summary
- extend CaseHandler model with Email, Phone and Department
- add migration and SQL scripts for case handler table and seed data
- surface new fields through dictionary API and DTOs

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)*
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689e9a2a8c54832c9a773cd48674f1b9