### PR TITLE
fix: load claims when no initial data

### DIFF
--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -63,11 +63,11 @@ export function ClaimsList({
   } = useClaims()
   const { toast } = useToast()
 
-  const claims = initialClaims ?? fetchedClaims
-  const totalRecords = initialClaims ? initialClaims.length : totalCount
+  const claims = initialClaims?.length ? initialClaims : fetchedClaims
+  const totalRecords = initialClaims?.length ? initialClaims.length : totalCount
 
   useEffect(() => {
-    if (initialClaims) return
+    if (initialClaims?.length) return
 
     const loadClaims = async () => {
       try {
@@ -158,7 +158,7 @@ export function ClaimsList({
 
   useEffect(() => {
 
-    if (initialClaims) return
+    if (initialClaims?.length) return
 
     const node = loaderRef.current
     const observer = new IntersectionObserver(


### PR DESCRIPTION
## Summary
- ensure claims list fetches data when initial claims array is empty
- use fetched results for display unless initial data provided

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(fails: next lint asks how to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_689ea000a56c832cb1f971387bbe3e6c