### PR TITLE
feat: track event creator

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -27,6 +27,7 @@ import { ClaimTopHeader } from "@/components/claim-form/claim-top-header"
 import { ClaimMainContent } from "@/components/claim-form/claim-main-content"
 import { useClaimForm } from "@/hooks/use-claim-form"
 import { useClaims, transformApiClaimToFrontend } from "@/hooks/use-claims"
+import { useAuth } from "@/hooks/use-auth"
 import { generateId } from "@/lib/constants"
 import type { Claim, UploadedFile, RequiredDocument } from "@/types"
 
@@ -37,6 +38,7 @@ export default function ClaimPage() {
   const router = useRouter()
   const { toast } = useToast()
   const { createClaim, updateClaim } = useClaims()
+  const { user } = useAuth()
 
   // Determine page mode and ID from params
   const paramsArray = Array.isArray(params.params) ? params.params : [params.params].filter(Boolean)
@@ -137,6 +139,12 @@ export default function ClaimPage() {
     }
   }, [loadClaimData])
 
+  useEffect(() => {
+    if (!claimId && user) {
+      setClaimFormData((prev) => ({ ...prev, registeredById: user.id, registeredByName: user.username }))
+    }
+  }, [claimId, user, setClaimFormData])
+
   const handleSaveClaim = async (exitAfterSave = false) => {
     if (isSaving) return
 
@@ -147,6 +155,7 @@ export default function ClaimPage() {
           ...claimFormData,
           id: generateId(),
           claimNumber: `PL${new Date().getFullYear()}${String(Date.now()).slice(-8)}`,
+          registeredById: user?.id,
         } as Claim
 
         const createdClaim = await createClaim(newClaimData)

--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -20,6 +20,7 @@ import { ClaimTopHeader } from "@/components/claim-form/claim-top-header"
 import { ClaimMainContent } from "@/components/claim-form/claim-main-content"
 import { useClaimForm } from "@/hooks/use-claim-form"
 import { useClaims } from "@/hooks/use-claims"
+import { useAuth } from "@/hooks/use-auth"
 import { generateId } from "@/lib/constants"
 import { apiService } from "@/lib/api"
 import { pksData, type Employee } from "@/lib/pks-data"
@@ -55,6 +56,7 @@ export default function NewClaimPage() {
   const claimObjectTypeParam = searchParams.get("claimObjectType") || "1"
   const { toast } = useToast()
   const { createClaim, deleteClaim, initializeClaim } = useClaims()
+  const { user } = useAuth()
   const [claimId, setClaimId] = useState<string>("")
   const [activeClaimSection, setActiveClaimSection] = useState("dane-zdarzenia-podstawowe")
   const [isSaving, setIsSaving] = useState(false)
@@ -113,6 +115,12 @@ export default function NewClaimPage() {
       }
     })
   }, [initializeClaim, setClaimFormData])
+
+  useEffect(() => {
+    if (user) {
+      setClaimFormData((prev) => ({ ...prev, registeredById: user.id, registeredByName: user.username }))
+    }
+  }, [user, setClaimFormData])
 
   useEffect(() => {
     const clientId = searchParams.get("clientId")
@@ -296,6 +304,7 @@ export default function NewClaimPage() {
         claimNumber:
           claimFormData.claimNumber ||
           `PL${new Date().getFullYear()}${String(Date.now()).slice(-8)}`,
+        registeredById: user?.id,
       } as Claim
 
       const createdClaim = await createClaim(newClaimData)

--- a/backend/DTOs/EventDto.cs
+++ b/backend/DTOs/EventDto.cs
@@ -62,6 +62,8 @@ namespace AutomotiveClaimsApi.DTOs
         public DateTime? ComplaintResponseDate { get; set; }
         public string? DamageDescription { get; set; }
         public string? Description { get; set; }
+        public string? RegisteredById { get; set; }
+        public string? RegisteredByName { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
         

--- a/backend/DTOs/EventListItemDto.cs
+++ b/backend/DTOs/EventListItemDto.cs
@@ -31,5 +31,7 @@ namespace AutomotiveClaimsApi.DTOs
         public int? LeasingCompanyId { get; set; }
         public string? LeasingCompany { get; set; }
         public string? Area { get; set; }
+        public string? RegisteredById { get; set; }
+        public string? RegisteredByName { get; set; }
     }
 }

--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -155,6 +155,7 @@ namespace AutomotiveClaimsApi.DTOs
 
         [StringLength(2000)]
         public string? Description { get; set; }
+        public string? RegisteredById { get; set; }
 
         public ICollection<ParticipantUpsertDto>? Participants { get; set; }
 

--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -54,6 +54,11 @@ namespace AutomotiveClaimsApi.Data
                 entity.Property(e => e.ClaimNumber).HasMaxLength(50);
                 entity.HasIndex(e => e.ClaimNumber).IsUnique();
 
+                entity.HasOne(e => e.RegisteredBy)
+                      .WithMany()
+                      .HasForeignKey(e => e.RegisteredById)
+                      .OnDelete(DeleteBehavior.SetNull);
+
                 entity.HasMany(e => e.Damages).WithOne(d => d.Event).HasForeignKey(d => d.EventId).OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.Appeals).WithOne(a => a.Event).HasForeignKey(a => a.EventId).OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.ClientClaims).WithOne(c => c.Event).HasForeignKey(c => c.EventId).OnDelete(DeleteBehavior.Cascade);

--- a/backend/Migrations/20240130000020_AddRegisteredByToEvents.cs
+++ b/backend/Migrations/20240130000020_AddRegisteredByToEvents.cs
@@ -1,0 +1,46 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    public partial class AddRegisteredByToEvents : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "RegisteredById",
+                table: "Events",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Events_RegisteredById",
+                table: "Events",
+                column: "RegisteredById");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Events_AspNetUsers_RegisteredById",
+                table: "Events",
+                column: "RegisteredById",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Events_AspNetUsers_RegisteredById",
+                table: "Events");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Events_RegisteredById",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "RegisteredById",
+                table: "Events");
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1019,9 +1019,18 @@ namespace AutomotiveClaimsApi.Migrations
                     b.Property<bool?>("WereInjured")
                         .HasColumnType("boolean");
 
+                    b.Property<string>("RegisteredById")
+                        .HasColumnType("text");
+
+                    b.HasIndex("RegisteredById");
+
                     b.HasKey("Id");
 
                     b.ToTable("Events");
+
+                    b.HasOne("AutomotiveClaimsApi.Models.ApplicationUser", "RegisteredBy")
+                        .WithMany()
+                        .HasForeignKey("RegisteredById");
                 });
 
             modelBuilder.Entity("AutomotiveClaimsApi.Models.Participant", b =>
@@ -1432,6 +1441,8 @@ namespace AutomotiveClaimsApi.Migrations
                     b.Navigation("Recourses");
 
                     b.Navigation("Settlements");
+
+                    b.Navigation("RegisteredBy");
                 });
 
             modelBuilder.Entity("AutomotiveClaimsApi.Models.Participant", b =>

--- a/backend/Models/Event.cs
+++ b/backend/Models/Event.cs
@@ -157,6 +157,10 @@ namespace AutomotiveClaimsApi.Models
 
         public string? Description { get; set; }
 
+        public string? RegisteredById { get; set; }
+
+        public ApplicationUser? RegisteredBy { get; set; }
+
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/components/claim-form/claim-top-header.tsx
+++ b/components/claim-form/claim-top-header.tsx
@@ -107,7 +107,7 @@ export function ClaimTopHeader({ claimFormData, onClose }: ClaimTopHeaderProps) 
             <div className="flex-1 min-w-0">
               <span className="block text-sm font-medium text-gray-700 mb-1">Szkodę zarejestrował</span>
               <span className="block text-sm text-gray-900 font-semibold truncate">
-                {claimFormData.handler || "Nie określono"}
+                {claimFormData.registeredByName || "Nie określono"}
               </span>
             </div>
           </div>

--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { apiService } from "@/lib/api"
 
 interface User {
+  id: string
   username: string
   email?: string
   roles?: string[]

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -140,6 +140,7 @@ export const transformFrontendClaimToApiPayload = (
     clientId,
     riskType,
     damageType,
+    registeredByName,
 
     ...rest
   } = claimData

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -24,6 +24,8 @@ export interface EventListItemDto {
   handlerId?: number
   handler?: string
   objectTypeId?: number
+  registeredById?: string
+  registeredByName?: string
 }
 
 export interface EventDto extends EventListItemDto {
@@ -97,6 +99,7 @@ export interface EventUpsertDto {
   riskType?: string
   damageType?: string
   objectTypeId?: number
+  registeredById?: string
   insuranceCompanyId?: number
   insuranceCompany?: string
   leasingCompanyId?: number
@@ -728,10 +731,10 @@ class ApiService {
     this.setToken(null)
   }
 
-  async getCurrentUser(): Promise<{ username: string; email?: string; roles?: string[]; createdAt?: string; lastLogin?: string } | undefined> {
+  async getCurrentUser(): Promise<{ id: string; username: string; email?: string; roles?: string[]; createdAt?: string; lastLogin?: string } | undefined> {
     const data = await this.request<{ id: string; userName: string; email: string; roles: string[]; createdAt: string; lastLogin?: string }>("/auth/me")
     if (!data) return undefined
-    return { username: data.userName, email: data.email, roles: data.roles, createdAt: data.createdAt, lastLogin: data.lastLogin }
+    return { id: data.id, username: data.userName, email: data.email, roles: data.roles, createdAt: data.createdAt, lastLogin: data.lastLogin }
   }
 
 


### PR DESCRIPTION
## Summary
- track which user created an event and expose this info in APIs
- surface the creator on the claim UI and send the user id when creating claims

## Testing
- `pnpm test` (fails: tests 1, fail 1)
- `dotnet ef database update` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689e9eb75d34832c816ff439e789f51f