### PR TITLE
refactor: use string handler IDs

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -1439,12 +1439,10 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
                       Szkodę zarejestrował
                     </Label>
                     <HandlerDropdown
-                      selectedHandlerId={claimFormData.handlerId ? parseInt(claimFormData.handlerId) : undefined}
+                      selectedHandlerId={claimFormData.handlerId || undefined}
                       onHandlerSelected={(event: HandlerSelectionEvent) => {
-                        handleFormChange("handlerId", event.handlerId.toString())
+                        handleFormChange("handlerId", event.handlerId)
                         handleFormChange("handler", event.handlerName)
-                        handleFormChange("handlerEmail", event.handlerEmail || "")
-                        handleFormChange("handlerPhone", event.handlerPhone || "")
                       }}
                       className="mt-1"
                     />

--- a/components/handler-dropdown.tsx
+++ b/components/handler-dropdown.tsx
@@ -10,7 +10,7 @@ import type { Handler, HandlerSelectionEvent } from "@/types/handler"
 import { HandlersService } from "@/lib/handlers"
 
 interface HandlerDropdownProps {
-  selectedHandlerId?: number
+  selectedHandlerId?: string
   onHandlerSelected?: (event: HandlerSelectionEvent) => void
   className?: string
 }
@@ -53,10 +53,11 @@ export default function HandlerDropdown({
   }, [selectedHandlerId])
 
   useEffect(() => {
+    const lower = searchTerm.toLowerCase()
     const filtered = handlers.filter(
       (handler) =>
-        handler.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        handler.email.toLowerCase().includes(searchTerm.toLowerCase()),
+        handler.name.toLowerCase().includes(lower) ||
+        (handler.email?.toLowerCase().includes(lower) ?? false),
     )
     setFilteredHandlers(filtered)
   }, [searchTerm, handlers])
@@ -121,16 +122,11 @@ export default function HandlerDropdown({
     setIsDropdownOpen(false)
     setSearchTerm("")
 
-    if (onHandlerSelected) {
-      onHandlerSelected({
-        handlerId: handler.id,
-        handlerName: handler.name,
-      })
-    }
+    onHandlerSelected?.({ handlerId: handler.id, handlerName: handler.name })
   }
 
-  const hasContactInfo = (info: string): boolean => {
-    return info && info !== "brak" && info.trim() !== ""
+  const hasContactInfo = (info?: string): boolean => {
+    return !!info && info !== "brak" && info.trim() !== ""
   }
 
   const renderDropdownPortal = () => {

--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -18,7 +18,7 @@ test('includes dropdown selections in payload', () => {
   assert.equal(payload.damageType, 'DT')
   assert.equal(payload.insuranceCompanyId, 5)
   assert.equal(payload.clientId, 7)
-  assert.equal(payload.handlerId, 9)
+  assert.equal(payload.handlerId, '9')
 })
 
 test('maps damageType object to its code value', () => {

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -46,7 +46,7 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
     rowVersion: apiClaim.rowVersion,
     insuranceCompanyId: apiClaim.insuranceCompanyId?.toString(),
     leasingCompanyId: apiClaim.leasingCompanyId?.toString(),
-    handlerId: apiClaim.handlerId?.toString(),
+    handlerId: apiClaim.handlerId,
     clientId: apiClaim.clientId?.toString(),
     totalClaim: apiClaim.totalClaim ?? 0,
     payout: apiClaim.payout ?? 0,
@@ -227,7 +227,7 @@ export const transformFrontendClaimToApiPayload = (
     insuranceCompanyId: insuranceCompanyId ? parseInt(insuranceCompanyId, 10) : undefined,
     leasingCompanyId: leasingCompanyId ? parseInt(leasingCompanyId, 10) : undefined,
     clientId: clientId ? parseInt(clientId, 10) : undefined,
-    handlerId: handlerId ? parseInt(handlerId, 10) : undefined,
+    handlerId: handlerId || undefined,
     riskType,
     ...(damageTypeValue ? { damageType: damageTypeValue } : {}),
     damageDate: toIso(rest.damageDate, "damageDate"),
@@ -361,7 +361,7 @@ export function useClaims() {
           clientId: claim.clientId?.toString(),
           insuranceCompanyId: claim.insuranceCompanyId?.toString(),
           leasingCompanyId: claim.leasingCompanyId?.toString(),
-          handlerId: claim.handlerId?.toString(),
+          handlerId: claim.handlerId,
         })) as Claim[]
 
         setClaims((prev) =>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -21,7 +21,7 @@ export interface EventListItemDto {
   insuranceCompany?: string
   leasingCompanyId?: number
   leasingCompany?: string
-  handlerId?: number
+  handlerId?: string
   handler?: string
   objectTypeId?: number
   registeredById?: string
@@ -43,7 +43,7 @@ export interface EventDto extends EventListItemDto {
   servicesCalled?: string
 
   insuranceCompanyId?: number
-  handlerId?: number
+  handlerId?: string
   riskType?: string
   damageType?: string
   subcontractorName?: string
@@ -104,7 +104,7 @@ export interface EventUpsertDto {
   insuranceCompany?: string
   leasingCompanyId?: number
   leasingCompany?: string
-  handlerId?: number
+  handlerId?: string
   handler?: string
   damageDate?: string
   reportDate?: string

--- a/lib/handlers.ts
+++ b/lib/handlers.ts
@@ -3,7 +3,7 @@ import type { Handler } from "@/types/handler"
 export class HandlersService {
   private static handlers: Handler[] = [
     {
-      id: 1,
+      id: "1",
       name: "Małgorzata Roczniak",
       email: "malgorzata.roczniak@sparta.pl",
       phone: "+48 22 123 45 67",
@@ -11,7 +11,7 @@ export class HandlersService {
       position: "Starszy likwidator",
     },
     {
-      id: 2,
+      id: "2",
       name: "Anna Kowalska",
       email: "anna.kowalska@sparta.pl",
       phone: "+48 22 234 56 78",
@@ -19,7 +19,7 @@ export class HandlersService {
       position: "Likwidator",
     },
     {
-      id: 3,
+      id: "3",
       name: "Piotr Nowak",
       email: "piotr.nowak@sparta.pl",
       phone: "+48 22 345 67 89",
@@ -27,7 +27,7 @@ export class HandlersService {
       position: "Likwidator senior",
     },
     {
-      id: 4,
+      id: "4",
       name: "Katarzyna Wiśniewska",
       email: "katarzyna.wisniewska@sparta.pl",
       phone: "+48 22 456 78 90",
@@ -35,7 +35,7 @@ export class HandlersService {
       position: "Radca prawny",
     },
     {
-      id: 5,
+      id: "5",
       name: "Tomasz Wójcik",
       email: "tomasz.wojcik@sparta.pl",
       phone: "+48 22 567 89 01",
@@ -43,7 +43,7 @@ export class HandlersService {
       position: "Rzeczoznawca",
     },
     {
-      id: 6,
+      id: "6",
       name: "Magdalena Kaczmarek",
       email: "magdalena.kaczmarek@sparta.pl",
       phone: "+48 22 678 90 12",
@@ -51,7 +51,7 @@ export class HandlersService {
       position: "Specjalista ds. klienta",
     },
     {
-      id: 7,
+      id: "7",
       name: "Marcin Zieliński",
       email: "marcin.zielinski@sparta.pl",
       phone: "+48 22 789 01 23",
@@ -59,7 +59,7 @@ export class HandlersService {
       position: "Kierownik działu",
     },
     {
-      id: 8,
+      id: "8",
       name: "Agnieszka Szymańska",
       email: "agnieszka.szymanska@sparta.pl",
       phone: "+48 22 890 12 34",
@@ -67,7 +67,7 @@ export class HandlersService {
       position: "Specjalista ds. regresu",
     },
     {
-      id: 9,
+      id: "9",
       name: "Paweł Dąbrowski",
       email: "pawel.dabrowski@sparta.pl",
       phone: "+48 22 901 23 45",
@@ -75,7 +75,7 @@ export class HandlersService {
       position: "Likwidator",
     },
     {
-      id: 10,
+      id: "10",
       name: "Joanna Lewandowska",
       email: "joanna.lewandowska@sparta.pl",
       phone: "+48 22 012 34 56",
@@ -88,7 +88,7 @@ export class HandlersService {
     return this.handlers
   }
 
-  static getHandlerById(id: number): Handler | undefined {
+  static getHandlerById(id: string): Handler | undefined {
     return this.handlers.find((handler) => handler.id === id)
   }
 

--- a/types/handler.ts
+++ b/types/handler.ts
@@ -1,18 +1,19 @@
 // Base model for handler data
 export interface Handler {
-  id: number
+  id: string
   name: string
-  email: string
-  phone: string
+  email?: string
+  phone?: string
   department?: string
   position?: string
+  address?: string
 }
 
 // Model for the dropdown state
 export interface HandlerDropdownState {
   isOpen: boolean
   searchTerm: string
-  selectedHandlerId: number | null
+  selectedHandlerId: string | null
 }
 
 // Model for handler filtering options
@@ -31,10 +32,8 @@ export interface HandlerDetails extends Handler {
 
 // Model for handler selection event
 export interface HandlerSelectionEvent {
-  handlerId: number
+  handlerId: string
   handlerName: string
-  handlerEmail: string
-  handlerPhone: string
 }
 
 // Enum for handler departments


### PR DESCRIPTION
## Summary
- use string IDs for handlers and dropdown state
- simplify handler selection events and make contact fields optional
- adjust claim transformations and API types to support string IDs

## Testing
- `pnpm test` *(fails: ERR_REQUIRE_CYCLE_MODULE in appeals route test)*

------
https://chatgpt.com/codex/tasks/task_e_689ef44bc260832c976f63752302c414