### PR TITLE
feat: add case handlers hook

### DIFF
--- a/hooks/use-case-handlers.ts
+++ b/hooks/use-case-handlers.ts
@@ -1,0 +1,45 @@
+'use client'
+
+import useSWR from 'swr'
+import type { DictionaryResponseDto } from '@/lib/dictionary-service'
+
+interface Handler {
+  id: string
+  name: string
+  code?: string
+  isActive: boolean
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status}`)
+  }
+  return (await response.json()) as T
+}
+
+async function fetchCaseHandlers(): Promise<Handler[]> {
+  const data = await getJson<DictionaryResponseDto>('/api/dictionaries/case-handlers')
+  return data.items.map(({ id, name, code, isActive }) => ({
+    id,
+    name,
+    code,
+    isActive,
+  }))
+}
+
+export function useCaseHandlers() {
+  const { data, error, isLoading, mutate } = useSWR(
+    'case-handlers',
+    fetchCaseHandlers,
+    {
+      dedupingInterval: 5 * 60_000,
+      revalidateOnFocus: false,
+      revalidateIfStale: true,
+      revalidateOnReconnect: true,
+    },
+  )
+
+  return { handlers: data ?? [], loading: isLoading, error, refresh: mutate }
+}
+


### PR DESCRIPTION
## Summary
- add `useCaseHandlers` hook powered by SWR to load case handler dictionary
- expose helpers for refresh, loading, and error states

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689ef44dd288832cb8bac82ae7395ead