### PR TITLE
feat: add SWR provider

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,10 +2,7 @@ import type React from "react"
 import type { Metadata } from "next"
 import { GeistSans } from "geist/font/sans"
 import { GeistMono } from "geist/font/mono"
-import { ThemeProvider } from "@/components/theme-provider"
-import { Toaster } from "@/components/ui/toaster"
-import Footer from "@/components/footer"
-import QueryProvider from "@/components/query-provider"
+import Providers from "./providers"
 import "./globals.css"
 
 export const metadata: Metadata = {
@@ -31,13 +28,7 @@ html {
         `}</style>
       </head>
       <body className="min-h-screen bg-gray-50">
-        <QueryProvider>
-          <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
-            <main className="flex-1">{children}</main>
-            <Footer />
-            <Toaster />
-          </ThemeProvider>
-        </QueryProvider>
+        <Providers>{children}</Providers>
       </body>
     </html>
   )

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import type React from 'react'
+import { SWRConfig } from 'swr'
+import QueryProvider from '@/components/query-provider'
+import { ThemeProvider } from '@/components/theme-provider'
+import { Toaster } from '@/components/ui/toaster'
+import Footer from '@/components/footer'
+
+function localStorageProvider(): Map<any, any> {
+  if (typeof window === 'undefined') {
+    return new Map()
+  }
+  const map = new Map(JSON.parse(localStorage.getItem('app-swr-cache') || '[]'))
+  window.addEventListener('beforeunload', () => {
+    const appCache = Array.from(map.entries())
+    localStorage.setItem('app-swr-cache', JSON.stringify(appCache))
+  })
+  return map
+}
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 10000,
+        revalidateOnFocus: false,
+        provider: localStorageProvider,
+      }}
+    >
+      <QueryProvider>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
+          <main className="flex-1">{children}</main>
+          <Footer />
+          <Toaster />
+        </ThemeProvider>
+      </QueryProvider>
+    </SWRConfig>
+  )
+}
+

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "sonner": "latest",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",
+    "swr": "latest",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "latest",


### PR DESCRIPTION
## Summary
- add global SWRConfig provider with default options and persisted cache
- wrap app in the new Providers component
- declare `swr` dependency

## Testing
- `pnpm lint` *(fails: next lint prompts for configuration)*
- `pnpm test` *(fails: Cannot require() ES Module in a cycle)*
- `pnpm add swr` *(fails: GET https://registry.npmjs.org/swr: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ef44fbcf0832c804abd783dd4d7e6