### PR TITLE
Add NIP and REGON fields to client

### DIFF
--- a/app/settings/clients/page.tsx
+++ b/app/settings/clients/page.tsx
@@ -23,8 +23,8 @@ export default function ClientsPage() {
     address: "",
     city: "",
     postalCode: "",
-    taxId: "",
-    registrationNumber: "",
+    nip: "",
+    regon: "",
     isActive: true,
   })
   const [editingId, setEditingId] = useState<number | null>(null)
@@ -52,8 +52,8 @@ export default function ClientsPage() {
       address: "",
       city: "",
       postalCode: "",
-      taxId: "",
-      registrationNumber: "",
+      nip: "",
+      regon: "",
       isActive: true,
     })
     setEditingId(null)
@@ -68,8 +68,8 @@ export default function ClientsPage() {
       address: client.address,
       city: client.city,
       postalCode: client.postalCode,
-      taxId: client.taxId,
-      registrationNumber: client.registrationNumber,
+      nip: client.nip,
+      regon: client.regon,
       isActive: client.isActive,
     })
     setEditingId(client.id)
@@ -118,6 +118,24 @@ export default function ClientsPage() {
             />
           </div>
         </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="nip">NIP</Label>
+            <Input
+              id="nip"
+              value={formData.nip ?? ""}
+              onChange={(e) => setFormData({ ...formData, nip: e.target.value })}
+            />
+          </div>
+          <div>
+            <Label htmlFor="regon">REGON</Label>
+            <Input
+              id="regon"
+              value={formData.regon ?? ""}
+              onChange={(e) => setFormData({ ...formData, regon: e.target.value })}
+            />
+          </div>
+        </div>
         <div className="flex space-x-2">
           <Button type="submit">{editingId ? "Aktualizuj" : "Dodaj"}</Button>
           {editingId && (
@@ -133,8 +151,8 @@ export default function ClientsPage() {
                   address: "",
                   city: "",
                   postalCode: "",
-                  taxId: "",
-                  registrationNumber: "",
+                  nip: "",
+                  regon: "",
                   isActive: true,
                 })
               }}

--- a/backend/Controllers/ClientsController.cs
+++ b/backend/Controllers/ClientsController.cs
@@ -45,8 +45,8 @@ namespace AutomotiveClaimsApi.Controllers
                     Name = c.Name,
                     FullName = c.FullName,
                     ShortName = c.ShortName,
-                    TaxId = c.TaxId,
-                    RegistrationNumber = c.RegistrationNumber,
+                    Nip = c.Nip,
+                    Regon = c.Regon,
                     PhoneNumber = c.PhoneNumber,
                     Email = c.Email,
                     Address = c.Address,
@@ -72,8 +72,8 @@ namespace AutomotiveClaimsApi.Controllers
                     Name = c.Name,
                     FullName = c.FullName,
                     ShortName = c.ShortName,
-                    TaxId = c.TaxId,
-                    RegistrationNumber = c.RegistrationNumber,
+                    Nip = c.Nip,
+                    Regon = c.Regon,
                     PhoneNumber = c.PhoneNumber,
                     Email = c.Email,
                     Address = c.Address,
@@ -101,8 +101,8 @@ namespace AutomotiveClaimsApi.Controllers
                 Name = createClientDto.Name,
                 FullName = createClientDto.FullName,
                 ShortName = createClientDto.ShortName,
-                TaxId = createClientDto.TaxId,
-                RegistrationNumber = createClientDto.RegistrationNumber,
+                Nip = createClientDto.Nip,
+                Regon = createClientDto.Regon,
                 PhoneNumber = createClientDto.PhoneNumber,
                 Email = createClientDto.Email,
                 Address = createClientDto.Address,
@@ -121,8 +121,8 @@ namespace AutomotiveClaimsApi.Controllers
                 Name = client.Name,
                 FullName = client.FullName,
                 ShortName = client.ShortName,
-                TaxId = client.TaxId,
-                RegistrationNumber = client.RegistrationNumber,
+                Nip = client.Nip,
+                Regon = client.Regon,
                 PhoneNumber = client.PhoneNumber,
                 Email = client.Email,
                 Address = client.Address,
@@ -148,8 +148,8 @@ namespace AutomotiveClaimsApi.Controllers
             client.Name = updateClientDto.Name ?? client.Name;
             client.FullName = updateClientDto.FullName ?? client.FullName;
             client.ShortName = updateClientDto.ShortName ?? client.ShortName;
-            client.TaxId = updateClientDto.TaxId ?? client.TaxId;
-            client.RegistrationNumber = updateClientDto.RegistrationNumber ?? client.RegistrationNumber;
+            client.Nip = updateClientDto.Nip ?? client.Nip;
+            client.Regon = updateClientDto.Regon ?? client.Regon;
             client.PhoneNumber = updateClientDto.PhoneNumber ?? client.PhoneNumber;
             client.Email = updateClientDto.Email ?? client.Email;
             client.Address = updateClientDto.Address ?? client.Address;

--- a/backend/DTOs/ClientDto.cs
+++ b/backend/DTOs/ClientDto.cs
@@ -8,8 +8,8 @@ namespace AutomotiveClaimsApi.DTOs
         public string Name { get; set; } = string.Empty;
         public string? FullName { get; set; }
         public string? ShortName { get; set; }
-        public string? TaxId { get; set; }
-        public string? RegistrationNumber { get; set; }
+        public string? Nip { get; set; }
+        public string? Regon { get; set; }
         public string? PhoneNumber { get; set; }
         public string? Email { get; set; }
         public string? Address { get; set; }

--- a/backend/DTOs/CreateClientDto.cs
+++ b/backend/DTOs/CreateClientDto.cs
@@ -8,8 +8,8 @@ namespace AutomotiveClaimsApi.DTOs
         public string Name { get; set; } = string.Empty;
         public string? FullName { get; set; }
         public string? ShortName { get; set; }
-        public string? TaxId { get; set; }
-        public string? RegistrationNumber { get; set; }
+        public string? Nip { get; set; }
+        public string? Regon { get; set; }
         public string? PhoneNumber { get; set; }
         public string? Email { get; set; }
         public string? Address { get; set; }

--- a/backend/DTOs/UpdateClientDto.cs
+++ b/backend/DTOs/UpdateClientDto.cs
@@ -5,8 +5,8 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Name { get; set; }
         public string? FullName { get; set; }
         public string? ShortName { get; set; }
-        public string? TaxId { get; set; }
-        public string? RegistrationNumber { get; set; }
+        public string? Nip { get; set; }
+        public string? Regon { get; set; }
         public string? PhoneNumber { get; set; }
         public string? Email { get; set; }
         public string? Address { get; set; }

--- a/backend/Models/Client.cs
+++ b/backend/Models/Client.cs
@@ -20,10 +20,12 @@ namespace AutomotiveClaimsApi.Models
         public string? ShortName { get; set; }
 
         [StringLength(20)]
-        public string? TaxId { get; set; }
+        [Column("TaxId")]
+        public string? Nip { get; set; }
 
         [StringLength(20)]
-        public string? RegistrationNumber { get; set; }
+        [Column("RegistrationNumber")]
+        public string? Regon { get; set; }
 
         [StringLength(20)]
         public string? PhoneNumber { get; set; }

--- a/components/client-dropdown.tsx
+++ b/components/client-dropdown.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { ChevronDown, Phone, Mail, MapPin, Check, Plus } from "lucide-react"
+import { ChevronDown, Phone, Mail, MapPin, Check, Plus, FileText, Hash } from "lucide-react"
 import type { Client, ClientSelectionEvent } from "@/types/client"
 import { apiService } from "@/lib/api"
 
@@ -74,7 +74,9 @@ export default function ClientDropdown({
     const filtered = clients.filter(
       (client) =>
         client.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        (client.email ?? "").toLowerCase().includes(searchTerm.toLowerCase()),
+        (client.email ?? "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+        (client.nip ?? "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+        (client.regon ?? "").toLowerCase().includes(searchTerm.toLowerCase()),
     )
     setFilteredClients(filtered)
   }, [searchTerm, clients])
@@ -204,7 +206,13 @@ export default function ClientDropdown({
                 {selectedClient?.id === client.id && <Check className="h-4 w-4 mr-2 text-blue-600" />}
                 <div className="flex flex-col">
                   <span className="font-medium">{client.name}</span>
-                  <span className="text-xs text-gray-500">{client.email}</span>
+                  <span className="text-xs text-gray-500">
+                    {client.nip
+                      ? `NIP: ${client.nip}`
+                      : client.regon
+                        ? `REGON: ${client.regon}`
+                        : client.email}
+                  </span>
                 </div>
               </div>
             ))
@@ -265,6 +273,32 @@ export default function ClientDropdown({
                   </a>
                 ) : (
                   <p className="text-gray-500 italic text-sm">Brak adresu e-mail</p>
+                )}
+              </div>
+
+              {/* NIP */}
+              <div>
+                <h3 className="flex items-center text-sm font-medium mb-2 text-gray-700">
+                  <FileText className="h-4 w-4 mr-2 text-blue-600" />
+                  NIP
+                </h3>
+                {hasContactInfo(selectedClient.nip ?? "") ? (
+                  <p className="text-gray-900 text-sm">{selectedClient.nip}</p>
+                ) : (
+                  <p className="text-gray-500 italic text-sm">Brak NIP</p>
+                )}
+              </div>
+
+              {/* REGON */}
+              <div>
+                <h3 className="flex items-center text-sm font-medium mb-2 text-gray-700">
+                  <Hash className="h-4 w-4 mr-2 text-blue-600" />
+                  REGON
+                </h3>
+                {hasContactInfo(selectedClient.regon ?? "") ? (
+                  <p className="text-gray-900 text-sm">{selectedClient.regon}</p>
+                ) : (
+                  <p className="text-gray-500 italic text-sm">Brak REGON</p>
                 )}
               </div>
             </div>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -167,8 +167,8 @@ export interface ClientDto {
   name: string
   fullName?: string
   shortName?: string
-  taxId?: string
-  registrationNumber?: string
+  nip?: string
+  regon?: string
   phoneNumber?: string
   email?: string
   address?: string
@@ -183,8 +183,8 @@ export interface CreateClientDto {
   name: string
   fullName?: string
   shortName?: string
-  taxId?: string
-  registrationNumber?: string
+  nip?: string
+  regon?: string
   phoneNumber?: string
   email?: string
   address?: string
@@ -197,8 +197,8 @@ export interface UpdateClientDto {
   name?: string
   fullName?: string
   shortName?: string
-  taxId?: string
-  registrationNumber?: string
+  nip?: string
+  regon?: string
   phoneNumber?: string
   email?: string
   address?: string

--- a/types/client.ts
+++ b/types/client.ts
@@ -3,8 +3,8 @@ export interface Client {
   name: string
   fullName?: string
   shortName?: string
-  taxId?: string
-  registrationNumber?: string
+  nip?: string
+  regon?: string
   phoneNumber?: string
   email?: string
   address?: string


### PR DESCRIPTION
## Summary
- add `Nip` and `Regon` properties to the client model and controller
- expose new fields through DTOs and API typings
- extend client settings form to input NIP and REGON values
- display NIP and REGON information in the client dropdown

## Testing
- `dotnet test` *(fails: command not found)*
- `pnpm lint` *(fails: Next.js ESLint plugin prompt)*
- `pnpm test` *(fails: Cannot require() ES Module in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689f074a28ac832cbd27034ad0edc0ad