### PR TITLE
fix: update damage type endpoint casing

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -1409,7 +1409,7 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
                       value={claimFormData.damageType || ""}
                       onValueChange={(value) => handleFormChange("damageType", value)}
                       placeholder="Wybierz rodzaj szkody..."
-                      apiUrl="/api/damage-types"
+                      apiUrl="/api/DamageTypes"
                       riskTypeId={claimFormData.riskType}
                       disabled={!claimFormData.riskType}
                     />

--- a/components/claim-form/damage-basic-info-section.tsx
+++ b/components/claim-form/damage-basic-info-section.tsx
@@ -84,7 +84,7 @@ export function DamageBasicInfoSection({
           value={claimFormData.damageType || ""}
           onValueChange={(value) => handleFormChange("damageType", value)}
           placeholder="Wybierz rodzaj szkody..."
-          apiUrl="/api/damage-types"
+          apiUrl="/api/DamageTypes"
           riskTypeId={claimFormData.riskType}
           disabled={!claimFormData.riskType}
         />


### PR DESCRIPTION
## Summary
- use new `/api/DamageTypes` endpoint for damage type selects

## Testing
- `pnpm build` *(fails: Unexpected token `div` in app/claims/[id]/view/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689efacba738832cbcdd66225b4de6d2