### PR TITLE
Default claim tab based on user role

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -47,7 +47,7 @@ export default function ClaimPage() {
   const isEdit = paramsArray[1] === "edit" || isNew
   const mode: PageMode = isNew ? "new" : isEdit ? "edit" : "view"
 
-  const [activeClaimSection, setActiveClaimSection] = useState("dane-zdarzenia-podstawowe")
+  const [activeClaimSection, setActiveClaimSection] = useState("teczka-szkodowa")
   const [isSaving, setIsSaving] = useState(false)
   const [isLoading, setIsLoading] = useState(!isNew)
   const [loadError, setLoadError] = useState<string | null>(null)
@@ -78,6 +78,15 @@ export default function ClaimPage() {
     { id: "11", name: "Faktura za holowanie", required: true, uploaded: false },
     { id: "12", name: "Faktura za wynajem", required: true, uploaded: false },
   ])
+
+  useEffect(() => {
+    if (user?.roles) {
+      const privileged = user.roles.some((r) =>
+        ["likwidacja", "administrator", "admin"].includes(r.toLowerCase()),
+      )
+      setActiveClaimSection(privileged ? "dane-zdarzenia" : "teczka-szkodowa")
+    }
+  }, [user])
 
   const {
     claimFormData,

--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -11,6 +11,7 @@ import { ClaimTopHeader } from "@/components/claim-form/claim-top-header"
 import { ClaimMainContent } from "@/components/claim-form/claim-main-content"
 import { useClaimForm } from "@/hooks/use-claim-form"
 import { useClaims, transformApiClaimToFrontend } from "@/hooks/use-claims"
+import { useAuth } from "@/hooks/use-auth"
 import type { UploadedFile, RequiredDocument } from "@/types"
 
 export default function EditClaimPage() {
@@ -18,12 +19,22 @@ export default function EditClaimPage() {
   const router = useRouter()
   const { toast } = useToast()
   const { updateClaim } = useClaims()
-  const [activeClaimSection, setActiveClaimSection] = useState("dane-zdarzenia-podstawowe")
+  const { user } = useAuth()
+  const [activeClaimSection, setActiveClaimSection] = useState("teczka-szkodowa")
   const [isSaving, setIsSaving] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
 
   const id = params.id as string
+
+  useEffect(() => {
+    if (user?.roles) {
+      const privileged = user.roles.some((r) =>
+        ["likwidacja", "administrator", "admin"].includes(r.toLowerCase()),
+      )
+      setActiveClaimSection(privileged ? "dane-zdarzenia" : "teczka-szkodowa")
+    }
+  }, [user])
 
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([
     {

--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -58,7 +58,7 @@ export default function NewClaimPage() {
   const { createClaim, deleteClaim, initializeClaim } = useClaims()
   const { user } = useAuth()
   const [claimId, setClaimId] = useState<string>("")
-  const [activeClaimSection, setActiveClaimSection] = useState("dane-zdarzenia-podstawowe")
+  const [activeClaimSection, setActiveClaimSection] = useState("teczka-szkodowa")
   const [isSaving, setIsSaving] = useState(false)
   
   // Repair schedules and details state
@@ -121,6 +121,15 @@ export default function NewClaimPage() {
       setClaimFormData((prev) => ({ ...prev, registeredById: user.id, registeredByName: user.username }))
     }
   }, [user, setClaimFormData])
+
+  useEffect(() => {
+    if (user?.roles) {
+      const privileged = user.roles.some((r) =>
+        ["likwidacja", "administrator", "admin"].includes(r.toLowerCase()),
+      )
+      setActiveClaimSection(privileged ? "dane-zdarzenia" : "teczka-szkodowa")
+    }
+  }, [user])
 
   useEffect(() => {
     const clientId = searchParams.get("clientId")


### PR DESCRIPTION
## Summary
- Default to "Teczka szkodowa" tab unless user has likwidacja or administrator role
- Privileged users (likwidacja, administrator, admin) now see "Dane zdarzenia i szkody" first when creating, editing, or viewing a claim

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_689fa9a91df0832c8b4b9a21a2deda87