### PR TITLE
Handle non-JSON API responses

### DIFF
--- a/lib/api/settlements.ts
+++ b/lib/api/settlements.ts
@@ -47,9 +47,14 @@ async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
     ...options,
   });
   const text = await response.text();
-  const data = text ? JSON.parse(text) : undefined;
+  let data: unknown;
+  try {
+    data = text ? JSON.parse(text) : undefined;
+  } catch {
+    data = undefined;
+  }
   if (!response.ok) {
-    const message = (data?.error || data?.message || text || response.statusText) as string;
+    const message = ((data as any)?.error || (data as any)?.message || text || response.statusText) as string;
     throw new Error(message);
   }
   return data as T;


### PR DESCRIPTION
## Summary
- avoid JSON parse errors in settlements API client by swallowing invalid JSON

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*
- `pnpm test` *(fails: Module._compile etc, 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_689fbb9c9b08832ca4c3d7ad8128581c