### PR TITLE
feat: make claim object type configurable

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -319,6 +319,9 @@ export default function ClaimPage() {
                 setUploadedFiles={setUploadedFiles}
                 requiredDocuments={requiredDocuments}
                 setRequiredDocuments={setRequiredDocuments}
+                initialClaimObjectType={
+                  claim?.objectTypeId?.toString() ?? claimFormData.objectTypeId?.toString()
+                }
               />
             </div>
           </div>

--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -248,6 +248,7 @@ export default function EditClaimPage() {
               setUploadedFiles={setUploadedFiles}
               requiredDocuments={requiredDocuments}
               setRequiredDocuments={setRequiredDocuments}
+              initialClaimObjectType={claimFormData.objectTypeId?.toString()}
             />
           </div>
         </div>

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -71,6 +71,7 @@ interface ClaimMainContentProps {
   setUploadedFiles: React.Dispatch<React.SetStateAction<UploadedFile[]>>
   requiredDocuments: RequiredDocument[]
   setRequiredDocuments: React.Dispatch<React.SetStateAction<RequiredDocument[]>>
+  initialClaimObjectType?: string
 }
 
 const formatDateForInput = (dateString: string | undefined): string => {
@@ -177,6 +178,7 @@ export const ClaimMainContent = ({
   setUploadedFiles,
   requiredDocuments = [],
   setRequiredDocuments,
+  initialClaimObjectType = "1",
 }: ClaimMainContentProps) => {
   const { toast } = useToast()
 
@@ -226,7 +228,7 @@ export const ClaimMainContent = ({
   // State for dropdown data
   const [riskTypes, setRiskTypes] = useState<RiskType[]>([])
   const [loadingRiskTypes, setLoadingRiskTypes] = useState(false)
-  const [claimObjectType, setClaimObjectType] = useState<string>("1") // Default to communication claims
+  const [claimObjectType, setClaimObjectType] = useState<string>(initialClaimObjectType) // Default to communication claims
 
   // Add to the state declarations at the top of the component (around line 80)
   const [caseHandlers, setCaseHandlers] = useState<any[]>([])


### PR DESCRIPTION
## Summary
- allow setting initial claim object type via `ClaimMainContent` prop
- forward claim object type from pages to `ClaimMainContent`

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689fb8b002ec832cb70951c989cde27a