### PR TITLE
feat: add event rule scheduler

### DIFF
--- a/backend/AutomotiveClaimsApi.csproj
+++ b/backend/AutomotiveClaimsApi.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.0" />
+    <PackageReference Include="Cronos" Version="0.8.5" />
   </ItemGroup>
 
 </Project>

--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -28,6 +28,8 @@ namespace AutomotiveClaimsApi.Data
         public DbSet<Client> Clients { get; set; }
         public DbSet<RiskType> RiskTypes { get; set; }
         public DbSet<DamageType> DamageTypes { get; set; }
+        public DbSet<EventRule> EventRules { get; set; }
+        public DbSet<NotificationHistory> NotificationHistories { get; set; }
 
         // Dictionary entities
         public DbSet<CaseHandler> CaseHandlers { get; set; }

--- a/backend/Models/EventRule.cs
+++ b/backend/Models/EventRule.cs
@@ -1,0 +1,37 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using AutomotiveClaimsApi.Services;
+
+namespace AutomotiveClaimsApi.Models
+{
+    /// <summary>
+    /// Defines a rule that triggers <see cref="ClaimNotificationEvent"/> for a given
+    /// <see cref="Event"/> according to a cron expression.
+    /// </summary>
+    public class EventRule
+    {
+        [Key]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Cron expression defining when the rule should fire.
+        /// </summary>
+        [Required]
+        public string CronExpression { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The notification event that should be raised.
+        /// </summary>
+        [Required]
+        public ClaimNotificationEvent NotificationEvent { get; set; }
+
+        /// <summary>
+        /// Reference to the claim/event that should be used when raising the notification.
+        /// </summary>
+        [ForeignKey(nameof(Event))]
+        public Guid EventId { get; set; }
+
+        public Event? Event { get; set; }
+    }
+}

--- a/backend/Models/NotificationHistory.cs
+++ b/backend/Models/NotificationHistory.cs
@@ -1,0 +1,31 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AutomotiveClaimsApi.Models
+{
+    /// <summary>
+    /// Records scheduled notification jobs for tracking and cancellation.
+    /// </summary>
+    public class NotificationHistory
+    {
+        [Key]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Related event rule.
+        /// </summary>
+        [ForeignKey(nameof(EventRule))]
+        public int EventRuleId { get; set; }
+
+        public EventRule? EventRule { get; set; }
+
+        /// <summary>
+        /// Identifier of the scheduled job returned by the scheduler.
+        /// </summary>
+        [Required]
+        public string JobId { get; set; } = string.Empty;
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -71,6 +71,7 @@ builder.Services.AddScoped<IDamageTypeService, DamageTypeService>();
 // Add background services
 builder.Services.AddHostedService<EmailBackgroundService>();
 builder.Services.AddHostedService<AppealReminderService>();
+builder.Services.AddHostedService<EventRuleScheduler>();
 
 // Add CORS
 builder.Services.AddCors(options =>

--- a/backend/Services/EventRuleScheduler.cs
+++ b/backend/Services/EventRuleScheduler.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Cronos;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using AutomotiveClaimsApi.Data;
+using AutomotiveClaimsApi.Models;
+
+namespace AutomotiveClaimsApi.Services
+{
+    /// <summary>
+    /// Hosted service that schedules notifications based on <see cref="EventRule"/> records.
+    /// </summary>
+    public class EventRuleScheduler : IHostedService
+    {
+        private readonly IServiceProvider _services;
+        private readonly ILogger<EventRuleScheduler> _logger;
+        private readonly Dictionary<int, Timer> _timers = new();
+        private readonly Dictionary<int, string> _jobIds = new();
+
+        public EventRuleScheduler(IServiceProvider services, ILogger<EventRuleScheduler> logger)
+        {
+            _services = services;
+            _logger = logger;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            using var scope = _services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var rules = await db.EventRules.AsNoTracking().ToListAsync(cancellationToken);
+            foreach (var rule in rules)
+            {
+                await ScheduleRuleAsync(rule, cancellationToken);
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            foreach (var timer in _timers.Values)
+            {
+                timer.Dispose();
+            }
+            _timers.Clear();
+            _jobIds.Clear();
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Schedules a rule based on its cron expression and persists the generated job id
+        /// to <see cref="NotificationHistory"/>.
+        /// </summary>
+        private async Task ScheduleRuleAsync(EventRule rule, CancellationToken ct)
+        {
+            var cron = CronExpression.Parse(rule.CronExpression);
+            var next = cron.GetNextOccurrence(DateTimeOffset.UtcNow);
+            if (next == null)
+            {
+                return;
+            }
+
+            var jobId = Guid.NewGuid().ToString();
+            _jobIds[rule.Id] = jobId;
+
+            Timer? timer = null;
+            async void Callback(object? _)
+            {
+                using var scope = _services.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                var notificationService = scope.ServiceProvider.GetRequiredService<INotificationService>();
+                var ev = await db.Events.FindAsync(rule.EventId);
+                if (ev != null)
+                {
+                    await notificationService.NotifyAsync(ev, null, rule.NotificationEvent);
+                }
+
+                // reschedule next occurrence
+                var nextTime = cron.GetNextOccurrence(DateTimeOffset.UtcNow);
+                if (nextTime != null)
+                {
+                    timer?.Change(nextTime.Value - DateTimeOffset.UtcNow, Timeout.InfiniteTimeSpan);
+                }
+            }
+
+            var delay = next.Value - DateTimeOffset.UtcNow;
+            timer = new Timer(Callback, null, delay, Timeout.InfiniteTimeSpan);
+            _timers[rule.Id] = timer;
+
+            using var scope2 = _services.CreateScope();
+            var db2 = scope2.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            db2.NotificationHistories.Add(new NotificationHistory { EventRuleId = rule.Id, JobId = jobId });
+            await db2.SaveChangesAsync(ct);
+        }
+
+        /// <summary>
+        /// Cancels a scheduled rule and removes its notification history.
+        /// </summary>
+        public async Task CancelRuleAsync(int ruleId)
+        {
+            if (_timers.TryGetValue(ruleId, out var timer))
+            {
+                timer.Dispose();
+                _timers.Remove(ruleId);
+            }
+
+            _jobIds.Remove(ruleId);
+
+            using var scope = _services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var histories = db.NotificationHistories.Where(h => h.EventRuleId == ruleId);
+            db.NotificationHistories.RemoveRange(histories);
+            await db.SaveChangesAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce EventRule and NotificationHistory models for cron-based notifications
- schedule notifications via new EventRuleScheduler hosted service
- register scheduler and add Cronos package

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fc0888974832cba5387322b1b4f86