### PR TITLE
feat: add rule management controller

### DIFF
--- a/backend/Controllers/RuleManagementController.cs
+++ b/backend/Controllers/RuleManagementController.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using AutomotiveClaimsApi.Data;
+using AutomotiveClaimsApi.DTOs;
+using AutomotiveClaimsApi.Models;
+
+namespace AutomotiveClaimsApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize(Roles = "Admin")]
+    public class RuleManagementController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+
+        public RuleManagementController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        // Task Templates
+        [HttpGet("task-templates")]
+        public async Task<ActionResult<IEnumerable<TaskTemplateDto>>> GetTaskTemplates()
+        {
+            var templates = await _context.TaskTemplates.AsNoTracking().ToListAsync();
+            return templates.Select(MapTaskTemplateToDto).ToList();
+        }
+
+        [HttpPost("task-templates")]
+        public async Task<ActionResult<TaskTemplateDto>> CreateTaskTemplate([FromBody] TaskTemplateUpsertDto dto)
+        {
+            var entity = new TaskTemplate
+            {
+                Id = Guid.NewGuid(),
+                Name = dto.Name ?? string.Empty,
+                Description = dto.Description,
+                Channel = dto.Channel,
+                Recipients = dto.Recipients != null ? string.Join(",", dto.Recipients) : string.Empty,
+                CronExpression = dto.CronExpression
+            };
+            _context.TaskTemplates.Add(entity);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(GetTaskTemplates), new { id = entity.Id }, MapTaskTemplateToDto(entity));
+        }
+
+        [HttpPut("task-templates/{id}")]
+        public async Task<ActionResult<TaskTemplateDto>> UpdateTaskTemplate(Guid id, [FromBody] TaskTemplateUpsertDto dto)
+        {
+            var entity = await _context.TaskTemplates.FindAsync(id);
+            if (entity == null) return NotFound();
+
+            entity.Name = dto.Name ?? entity.Name;
+            entity.Description = dto.Description ?? entity.Description;
+            entity.Channel = dto.Channel;
+            entity.Recipients = dto.Recipients != null ? string.Join(",", dto.Recipients) : entity.Recipients;
+            entity.CronExpression = dto.CronExpression;
+
+            await _context.SaveChangesAsync();
+            return MapTaskTemplateToDto(entity);
+        }
+
+        [HttpDelete("task-templates/{id}")]
+        public async Task<IActionResult> DeleteTaskTemplate(Guid id)
+        {
+            var entity = await _context.TaskTemplates.FindAsync(id);
+            if (entity == null) return NotFound();
+            _context.TaskTemplates.Remove(entity);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        // Notification Templates
+        [HttpGet("notification-templates")]
+        public async Task<ActionResult<IEnumerable<NotificationTemplateDto>>> GetNotificationTemplates()
+        {
+            var templates = await _context.NotificationTemplates.AsNoTracking().ToListAsync();
+            return templates.Select(MapNotificationTemplateToDto).ToList();
+        }
+
+        [HttpPost("notification-templates")]
+        public async Task<ActionResult<NotificationTemplateDto>> CreateNotificationTemplate([FromBody] NotificationTemplateUpsertDto dto)
+        {
+            var entity = new NotificationTemplate
+            {
+                Id = Guid.NewGuid(),
+                Name = dto.Name ?? string.Empty,
+                Subject = dto.Subject ?? string.Empty,
+                Body = dto.Body ?? string.Empty,
+                Channel = dto.Channel,
+                Recipients = dto.Recipients != null ? string.Join(",", dto.Recipients) : string.Empty
+            };
+            _context.NotificationTemplates.Add(entity);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(GetNotificationTemplates), new { id = entity.Id }, MapNotificationTemplateToDto(entity));
+        }
+
+        [HttpPut("notification-templates/{id}")]
+        public async Task<ActionResult<NotificationTemplateDto>> UpdateNotificationTemplate(Guid id, [FromBody] NotificationTemplateUpsertDto dto)
+        {
+            var entity = await _context.NotificationTemplates.FindAsync(id);
+            if (entity == null) return NotFound();
+
+            entity.Name = dto.Name ?? entity.Name;
+            entity.Subject = dto.Subject ?? entity.Subject;
+            entity.Body = dto.Body ?? entity.Body;
+            entity.Channel = dto.Channel;
+            entity.Recipients = dto.Recipients != null ? string.Join(",", dto.Recipients) : entity.Recipients;
+
+            await _context.SaveChangesAsync();
+            return MapNotificationTemplateToDto(entity);
+        }
+
+        [HttpDelete("notification-templates/{id}")]
+        public async Task<IActionResult> DeleteNotificationTemplate(Guid id)
+        {
+            var entity = await _context.NotificationTemplates.FindAsync(id);
+            if (entity == null) return NotFound();
+            _context.NotificationTemplates.Remove(entity);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        // Event Rules
+        [HttpGet("event-rules")]
+        public async Task<ActionResult<IEnumerable<EventRuleDto>>> GetEventRules()
+        {
+            var rules = await _context.EventRules.AsNoTracking().ToListAsync();
+            return rules.Select(MapEventRuleToDto).ToList();
+        }
+
+        [HttpPost("event-rules")]
+        public async Task<ActionResult<EventRuleDto>> CreateEventRule([FromBody] EventRuleUpsertDto dto)
+        {
+            var entity = new EventRule
+            {
+                Id = Guid.NewGuid(),
+                Name = dto.Name ?? string.Empty,
+                EventType = dto.EventType,
+                TaskTemplateId = dto.TaskTemplateId,
+                NotificationTemplateId = dto.NotificationTemplateId,
+                CronExpression = dto.CronExpression
+            };
+            _context.EventRules.Add(entity);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(GetEventRules), new { id = entity.Id }, MapEventRuleToDto(entity));
+        }
+
+        [HttpPut("event-rules/{id}")]
+        public async Task<ActionResult<EventRuleDto>> UpdateEventRule(Guid id, [FromBody] EventRuleUpsertDto dto)
+        {
+            var entity = await _context.EventRules.FindAsync(id);
+            if (entity == null) return NotFound();
+
+            entity.Name = dto.Name ?? entity.Name;
+            entity.EventType = dto.EventType ?? entity.EventType;
+            entity.TaskTemplateId = dto.TaskTemplateId;
+            entity.NotificationTemplateId = dto.NotificationTemplateId;
+            entity.CronExpression = dto.CronExpression;
+
+            await _context.SaveChangesAsync();
+            return MapEventRuleToDto(entity);
+        }
+
+        [HttpDelete("event-rules/{id}")]
+        public async Task<IActionResult> DeleteEventRule(Guid id)
+        {
+            var entity = await _context.EventRules.FindAsync(id);
+            if (entity == null) return NotFound();
+            _context.EventRules.Remove(entity);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        private static TaskTemplateDto MapTaskTemplateToDto(TaskTemplate t) => new()
+        {
+            Id = t.Id,
+            Name = t.Name,
+            Description = t.Description,
+            Channel = t.Channel,
+            CronExpression = t.CronExpression,
+            Recipients = string.IsNullOrEmpty(t.Recipients) ? new List<string>() : t.Recipients.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList()
+        };
+
+        private static NotificationTemplateDto MapNotificationTemplateToDto(NotificationTemplate t) => new()
+        {
+            Id = t.Id,
+            Name = t.Name,
+            Subject = t.Subject,
+            Body = t.Body,
+            Channel = t.Channel,
+            Recipients = string.IsNullOrEmpty(t.Recipients) ? new List<string>() : t.Recipients.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList()
+        };
+
+        private static EventRuleDto MapEventRuleToDto(EventRule r) => new()
+        {
+            Id = r.Id,
+            Name = r.Name,
+            EventType = r.EventType,
+            TaskTemplateId = r.TaskTemplateId,
+            NotificationTemplateId = r.NotificationTemplateId,
+            CronExpression = r.CronExpression
+        };
+    }
+}

--- a/backend/DTOs/EventRuleDto.cs
+++ b/backend/DTOs/EventRuleDto.cs
@@ -1,0 +1,25 @@
+using System;
+using AutomotiveClaimsApi.Models;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class EventRuleDto
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? EventType { get; set; }
+        public Guid? TaskTemplateId { get; set; }
+        public Guid? NotificationTemplateId { get; set; }
+        public string? CronExpression { get; set; }
+    }
+
+    public class EventRuleUpsertDto
+    {
+        public Guid? Id { get; set; }
+        public string? Name { get; set; }
+        public string? EventType { get; set; }
+        public Guid? TaskTemplateId { get; set; }
+        public Guid? NotificationTemplateId { get; set; }
+        public string? CronExpression { get; set; }
+    }
+}

--- a/backend/DTOs/NotificationTemplateDto.cs
+++ b/backend/DTOs/NotificationTemplateDto.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using AutomotiveClaimsApi.Models;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class NotificationTemplateDto
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Subject { get; set; } = string.Empty;
+        public string Body { get; set; } = string.Empty;
+        public NotificationChannel Channel { get; set; }
+        public List<string> Recipients { get; set; } = new();
+    }
+
+    public class NotificationTemplateUpsertDto
+    {
+        public Guid? Id { get; set; }
+        public string? Name { get; set; }
+        public string? Subject { get; set; }
+        public string? Body { get; set; }
+        public NotificationChannel Channel { get; set; }
+        public List<string>? Recipients { get; set; }
+    }
+}

--- a/backend/DTOs/TaskTemplateDto.cs
+++ b/backend/DTOs/TaskTemplateDto.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using AutomotiveClaimsApi.Models;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class TaskTemplateDto
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public NotificationChannel Channel { get; set; }
+        public List<string> Recipients { get; set; } = new();
+        public string? CronExpression { get; set; }
+    }
+
+    public class TaskTemplateUpsertDto
+    {
+        public Guid? Id { get; set; }
+        public string? Name { get; set; }
+        public string? Description { get; set; }
+        public NotificationChannel Channel { get; set; }
+        public List<string>? Recipients { get; set; }
+        public string? CronExpression { get; set; }
+    }
+}

--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -28,6 +28,9 @@ namespace AutomotiveClaimsApi.Data
         public DbSet<Client> Clients { get; set; }
         public DbSet<RiskType> RiskTypes { get; set; }
         public DbSet<DamageType> DamageTypes { get; set; }
+        public DbSet<TaskTemplate> TaskTemplates { get; set; }
+        public DbSet<NotificationTemplate> NotificationTemplates { get; set; }
+        public DbSet<EventRule> EventRules { get; set; }
 
         // Dictionary entities
         public DbSet<CaseHandler> CaseHandlers { get; set; }

--- a/backend/Models/EventRule.cs
+++ b/backend/Models/EventRule.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class EventRule
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? EventType { get; set; }
+        public Guid? TaskTemplateId { get; set; }
+        public TaskTemplate? TaskTemplate { get; set; }
+        public Guid? NotificationTemplateId { get; set; }
+        public NotificationTemplate? NotificationTemplate { get; set; }
+        public string? CronExpression { get; set; }
+    }
+}

--- a/backend/Models/NotificationChannel.cs
+++ b/backend/Models/NotificationChannel.cs
@@ -1,0 +1,8 @@
+namespace AutomotiveClaimsApi.Models
+{
+    public enum NotificationChannel
+    {
+        Email,
+        Sms
+    }
+}

--- a/backend/Models/NotificationTemplate.cs
+++ b/backend/Models/NotificationTemplate.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class NotificationTemplate
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Subject { get; set; } = string.Empty;
+        public string Body { get; set; } = string.Empty;
+        public NotificationChannel Channel { get; set; }
+        public string Recipients { get; set; } = string.Empty;
+    }
+}

--- a/backend/Models/TaskTemplate.cs
+++ b/backend/Models/TaskTemplate.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class TaskTemplate
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public NotificationChannel Channel { get; set; }
+        public string Recipients { get; set; } = string.Empty;
+        public string? CronExpression { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add TaskTemplate, NotificationTemplate, and EventRule models with channel, recipient, and cron support
- expose admin CRUD endpoints for templates and rules via RuleManagementController
- register new rule entities in the EF Core context

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fc0856f84832cabcebd10c95cc29d