### PR TITLE
Add automation rule and history tables with migration

### DIFF
--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -28,6 +28,11 @@ namespace AutomotiveClaimsApi.Data
         public DbSet<Client> Clients { get; set; }
         public DbSet<RiskType> RiskTypes { get; set; }
         public DbSet<DamageType> DamageTypes { get; set; }
+        public DbSet<TaskTemplate> TaskTemplates { get; set; }
+        public DbSet<NotificationTemplate> NotificationTemplates { get; set; }
+        public DbSet<EventRule> EventRules { get; set; }
+        public DbSet<TaskHistory> TaskHistories { get; set; }
+        public DbSet<NotificationHistory> NotificationHistories { get; set; }
 
         // Dictionary entities
         public DbSet<CaseHandler> CaseHandlers { get; set; }

--- a/backend/Migrations/20240130000021_AddAutomationTables.cs
+++ b/backend/Migrations/20240130000021_AddAutomationTables.cs
@@ -1,0 +1,265 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using AutomotiveClaimsApi.Services;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAutomationTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TaskTemplates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TaskTemplates", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NotificationTemplates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Subject = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Body = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NotificationTemplates", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "EventRules",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    EventType = table.Column<int>(type: "int", nullable: false),
+                    TaskTemplateId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    NotificationTemplateId = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EventRules", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_EventRules_NotificationTemplates_NotificationTemplateId",
+                        column: x => x.NotificationTemplateId,
+                        principalTable: "NotificationTemplates",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_EventRules_TaskTemplates_TaskTemplateId",
+                        column: x => x.TaskTemplateId,
+                        principalTable: "TaskTemplates",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TaskHistories",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    EventId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DecisionId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    RecourseId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SettlementId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    AppealId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    TaskTemplateId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CompletedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TaskHistories", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TaskHistories_Appeals_AppealId",
+                        column: x => x.AppealId,
+                        principalTable: "Appeals",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_TaskHistories_Decisions_DecisionId",
+                        column: x => x.DecisionId,
+                        principalTable: "Decisions",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_TaskHistories_Events_EventId",
+                        column: x => x.EventId,
+                        principalTable: "Events",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_TaskHistories_Recourses_RecourseId",
+                        column: x => x.RecourseId,
+                        principalTable: "Recourses",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_TaskHistories_Settlements_SettlementId",
+                        column: x => x.SettlementId,
+                        principalTable: "Settlements",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_TaskHistories_TaskTemplates_TaskTemplateId",
+                        column: x => x.TaskTemplateId,
+                        principalTable: "TaskTemplates",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "NotificationHistories",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    EventId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    DecisionId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    RecourseId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SettlementId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    AppealId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    NotificationTemplateId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SentAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NotificationHistories", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_NotificationHistories_Appeals_AppealId",
+                        column: x => x.AppealId,
+                        principalTable: "Appeals",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_NotificationHistories_Decisions_DecisionId",
+                        column: x => x.DecisionId,
+                        principalTable: "Decisions",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_NotificationHistories_Events_EventId",
+                        column: x => x.EventId,
+                        principalTable: "Events",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_NotificationHistories_NotificationTemplates_NotificationTemplateId",
+                        column: x => x.NotificationTemplateId,
+                        principalTable: "NotificationTemplates",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_NotificationHistories_Recourses_RecourseId",
+                        column: x => x.RecourseId,
+                        principalTable: "Recourses",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_NotificationHistories_Settlements_SettlementId",
+                        column: x => x.SettlementId,
+                        principalTable: "Settlements",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EventRules_NotificationTemplateId",
+                table: "EventRules",
+                column: "NotificationTemplateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EventRules_TaskTemplateId",
+                table: "EventRules",
+                column: "TaskTemplateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationHistories_AppealId",
+                table: "NotificationHistories",
+                column: "AppealId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationHistories_DecisionId",
+                table: "NotificationHistories",
+                column: "DecisionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationHistories_EventId",
+                table: "NotificationHistories",
+                column: "EventId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationHistories_NotificationTemplateId",
+                table: "NotificationHistories",
+                column: "NotificationTemplateId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationHistories_RecourseId",
+                table: "NotificationHistories",
+                column: "RecourseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NotificationHistories_SettlementId",
+                table: "NotificationHistories",
+                column: "SettlementId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TaskHistories_AppealId",
+                table: "TaskHistories",
+                column: "AppealId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TaskHistories_DecisionId",
+                table: "TaskHistories",
+                column: "DecisionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TaskHistories_EventId",
+                table: "TaskHistories",
+                column: "EventId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TaskHistories_RecourseId",
+                table: "TaskHistories",
+                column: "RecourseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TaskHistories_SettlementId",
+                table: "TaskHistories",
+                column: "SettlementId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TaskHistories_TaskTemplateId",
+                table: "TaskHistories",
+                column: "TaskTemplateId");
+
+            migrationBuilder.InsertData(
+                table: "EventRules",
+                columns: new[] { "Id", "EventType" },
+                values: new object[] { Guid.NewGuid(), (int)ClaimNotificationEvent.DecisionAdded });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "NotificationHistories");
+
+            migrationBuilder.DropTable(
+                name: "TaskHistories");
+
+            migrationBuilder.DropTable(
+                name: "EventRules");
+
+            migrationBuilder.DropTable(
+                name: "NotificationTemplates");
+
+            migrationBuilder.DropTable(
+                name: "TaskTemplates");
+        }
+    }
+}
+

--- a/backend/Models/EventRule.cs
+++ b/backend/Models/EventRule.cs
@@ -1,0 +1,21 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using AutomotiveClaimsApi.Services;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class EventRule
+    {
+        [Key]
+        public Guid Id { get; set; }
+
+        public ClaimNotificationEvent EventType { get; set; }
+
+        public Guid? TaskTemplateId { get; set; }
+        public TaskTemplate? TaskTemplate { get; set; }
+
+        public Guid? NotificationTemplateId { get; set; }
+        public NotificationTemplate? NotificationTemplate { get; set; }
+    }
+}
+

--- a/backend/Models/NotificationHistory.cs
+++ b/backend/Models/NotificationHistory.cs
@@ -1,0 +1,32 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class NotificationHistory
+    {
+        [Key]
+        public Guid Id { get; set; }
+
+        public Guid EventId { get; set; }
+        public Event Event { get; set; } = null!;
+
+        public Guid? DecisionId { get; set; }
+        public Decision? Decision { get; set; }
+
+        public Guid? RecourseId { get; set; }
+        public Recourse? Recourse { get; set; }
+
+        public Guid? SettlementId { get; set; }
+        public Settlement? Settlement { get; set; }
+
+        public Guid? AppealId { get; set; }
+        public Appeal? Appeal { get; set; }
+
+        public Guid? NotificationTemplateId { get; set; }
+        public NotificationTemplate? NotificationTemplate { get; set; }
+
+        public DateTime SentAt { get; set; } = DateTime.UtcNow;
+    }
+}
+

--- a/backend/Models/NotificationTemplate.cs
+++ b/backend/Models/NotificationTemplate.cs
@@ -1,0 +1,23 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class NotificationTemplate
+    {
+        [Key]
+        public Guid Id { get; set; }
+
+        [MaxLength(200)]
+        public string Name { get; set; } = null!;
+
+        [MaxLength(200)]
+        public string? Subject { get; set; }
+
+        public string? Body { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    }
+}
+

--- a/backend/Models/TaskHistory.cs
+++ b/backend/Models/TaskHistory.cs
@@ -1,0 +1,33 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class TaskHistory
+    {
+        [Key]
+        public Guid Id { get; set; }
+
+        public Guid EventId { get; set; }
+        public Event Event { get; set; } = null!;
+
+        public Guid? DecisionId { get; set; }
+        public Decision? Decision { get; set; }
+
+        public Guid? RecourseId { get; set; }
+        public Recourse? Recourse { get; set; }
+
+        public Guid? SettlementId { get; set; }
+        public Settlement? Settlement { get; set; }
+
+        public Guid? AppealId { get; set; }
+        public Appeal? Appeal { get; set; }
+
+        public Guid? TaskTemplateId { get; set; }
+        public TaskTemplate? TaskTemplate { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime? CompletedAt { get; set; }
+    }
+}
+

--- a/backend/Models/TaskTemplate.cs
+++ b/backend/Models/TaskTemplate.cs
@@ -1,0 +1,21 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class TaskTemplate
+    {
+        [Key]
+        public Guid Id { get; set; }
+
+        [MaxLength(200)]
+        public string Name { get; set; } = null!;
+
+        [MaxLength(1000)]
+        public string? Description { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    }
+}
+

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -104,7 +104,7 @@ using (var scope = app.Services.CreateScope())
 {
     var services = scope.ServiceProvider;
     var context = services.GetRequiredService<ApplicationDbContext>();
-    await context.Database.EnsureCreatedAsync();
+    await context.Database.MigrateAsync();
 
     var roleManager = services.GetRequiredService<RoleManager<IdentityRole>>();
     var userManager = services.GetRequiredService<UserManager<ApplicationUser>>();


### PR DESCRIPTION
## Summary
- introduce TaskTemplate, NotificationTemplate, EventRule, TaskHistory and NotificationHistory models
- add migration to create tables and seed default DecisionAdded rule
- apply database migrations at startup

## Testing
- `dotnet build backend/AutomotiveClaimsApi.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689fc083a5ec832cabd98411edc48cc6