### PR TITLE
Add rule service and history templates

### DIFF
--- a/backend/Controllers/AppealsController.cs
+++ b/backend/Controllers/AppealsController.cs
@@ -23,19 +23,22 @@ namespace AutomotiveClaimsApi.Controllers
         private readonly ILogger<AppealsController> _logger;
         private readonly UserManager<ApplicationUser>? _userManager;
         private readonly INotificationService? _notificationService;
+        private readonly IRuleService? _ruleService;
 
         public AppealsController(
             ApplicationDbContext context,
             IDocumentService documentService,
             ILogger<AppealsController> logger,
             UserManager<ApplicationUser>? userManager = null,
-            INotificationService? notificationService = null)
+            INotificationService? notificationService = null,
+            IRuleService? ruleService = null)
         {
             _context = context;
             _documentService = documentService;
             _logger = logger;
             _userManager = userManager;
             _notificationService = notificationService;
+            _ruleService = ruleService;
         }
 
         [HttpGet("event/{eventId}")]
@@ -121,7 +124,11 @@ namespace AutomotiveClaimsApi.Controllers
                 _context.Appeals.Add(appeal);
                 await _context.SaveChangesAsync();
 
-                if (_notificationService != null)
+                if (_ruleService != null)
+                {
+                    await _ruleService.ProcessAsync(ClaimNotificationEvent.SettlementAppealAdded, appeal.Id);
+                }
+                else if (_notificationService != null)
                 {
                     ApplicationUser? currentUser = null;
                     bool isHandler = false;

--- a/backend/Controllers/DecisionsController.cs
+++ b/backend/Controllers/DecisionsController.cs
@@ -23,16 +23,19 @@ namespace AutomotiveClaimsApi.Controllers
         private readonly ILogger<DecisionsController> _logger;
         private readonly UserManager<ApplicationUser>? _userManager;
         private readonly INotificationService? _notificationService;
+        private readonly IRuleService? _ruleService;
 
         public DecisionsController(ApplicationDbContext context, IDocumentService documentService, ILogger<DecisionsController> logger,
             UserManager<ApplicationUser>? userManager = null,
-            INotificationService? notificationService = null)
+            INotificationService? notificationService = null,
+            IRuleService? ruleService = null)
         {
             _context = context;
             _documentService = documentService;
             _logger = logger;
             _userManager = userManager;
             _notificationService = notificationService;
+            _ruleService = ruleService;
         }
 
         [HttpGet]
@@ -128,7 +131,11 @@ namespace AutomotiveClaimsApi.Controllers
                 _context.Decisions.Add(decision);
                 await _context.SaveChangesAsync();
 
-                if (_notificationService != null)
+                if (_ruleService != null)
+                {
+                    await _ruleService.ProcessAsync(ClaimNotificationEvent.DecisionAdded, decision.Id);
+                }
+                else if (_notificationService != null)
                 {
                     ApplicationUser? currentUser = null;
                     bool isHandler = false;

--- a/backend/Controllers/RecoursesController.cs
+++ b/backend/Controllers/RecoursesController.cs
@@ -18,16 +18,19 @@ namespace AutomotiveClaimsApi.Controllers
         private readonly ILogger<RecoursesController> _logger;
         private readonly UserManager<ApplicationUser>? _userManager;
         private readonly INotificationService? _notificationService;
+        private readonly IRuleService? _ruleService;
 
         public RecoursesController(ApplicationDbContext context, IDocumentService documentService, ILogger<RecoursesController> logger,
             UserManager<ApplicationUser>? userManager = null,
-            INotificationService? notificationService = null)
+            INotificationService? notificationService = null,
+            IRuleService? ruleService = null)
         {
             _context = context;
             _documentService = documentService;
             _logger = logger;
             _userManager = userManager;
             _notificationService = notificationService;
+            _ruleService = ruleService;
         }
 
         [HttpGet]
@@ -91,7 +94,11 @@ namespace AutomotiveClaimsApi.Controllers
                 _context.Recourses.Add(recourse);
                 await _context.SaveChangesAsync();
 
-                if (_notificationService != null)
+                if (_ruleService != null)
+                {
+                    await _ruleService.ProcessAsync(ClaimNotificationEvent.RecourseAdded, recourse.Id);
+                }
+                else if (_notificationService != null)
                 {
                     ApplicationUser? currentUser = null;
                     bool isHandler = false;

--- a/backend/Controllers/SettlementsController.cs
+++ b/backend/Controllers/SettlementsController.cs
@@ -24,16 +24,19 @@ namespace AutomotiveClaimsApi.Controllers
         private readonly ILogger<SettlementsController> _logger;
         private readonly UserManager<ApplicationUser>? _userManager;
         private readonly INotificationService? _notificationService;
+        private readonly IRuleService? _ruleService;
 
         public SettlementsController(ApplicationDbContext context, IDocumentService documentService, ILogger<SettlementsController> logger,
             UserManager<ApplicationUser>? userManager = null,
-            INotificationService? notificationService = null)
+            INotificationService? notificationService = null,
+            IRuleService? ruleService = null)
         {
             _context = context;
             _documentService = documentService;
             _logger = logger;
             _userManager = userManager;
             _notificationService = notificationService;
+            _ruleService = ruleService;
         }
 
         [HttpGet("event/{eventId}")]
@@ -105,7 +108,11 @@ namespace AutomotiveClaimsApi.Controllers
             _context.Settlements.Add(settlement);
             await _context.SaveChangesAsync();
 
-            if (_notificationService != null)
+            if (_ruleService != null)
+            {
+                await _ruleService.ProcessAsync(ClaimNotificationEvent.SettlementAdded, settlement.Id);
+            }
+            else if (_notificationService != null)
             {
                 ApplicationUser? currentUser = null;
                 bool isHandler = false;

--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -25,6 +25,11 @@ namespace AutomotiveClaimsApi.Data
         public DbSet<Email> Emails { get; set; }
         public DbSet<EmailAttachment> EmailAttachments { get; set; }
         public DbSet<EmailClaim> EmailClaims { get; set; }
+        public DbSet<TaskTemplate> TaskTemplates { get; set; }
+        public DbSet<NotificationTemplate> NotificationTemplates { get; set; }
+        public DbSet<EventRule> EventRules { get; set; }
+        public DbSet<TaskHistory> TaskHistories { get; set; }
+        public DbSet<NotificationHistory> NotificationHistories { get; set; }
         public DbSet<Client> Clients { get; set; }
         public DbSet<RiskType> RiskTypes { get; set; }
         public DbSet<DamageType> DamageTypes { get; set; }
@@ -72,6 +77,8 @@ namespace AutomotiveClaimsApi.Data
                       .OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.Notes).WithOne(n => n.Event).HasForeignKey(n => n.EventId).OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.Documents).WithOne(d => d.Event).HasForeignKey(d => d.EventId).OnDelete(DeleteBehavior.Restrict);
+                entity.HasMany(e => e.TaskHistories).WithOne(th => th.Event).HasForeignKey(th => th.EventId).OnDelete(DeleteBehavior.Cascade);
+                entity.HasMany(e => e.NotificationHistories).WithOne(nh => nh.Event).HasForeignKey(nh => nh.EventId).OnDelete(DeleteBehavior.Cascade);
 
             });
 

--- a/backend/Models/Event.cs
+++ b/backend/Models/Event.cs
@@ -175,5 +175,7 @@ namespace AutomotiveClaimsApi.Models
         public virtual ICollection<Settlement> Settlements { get; set; } = new List<Settlement>();
         public virtual ICollection<Email> Emails { get; set; } = new List<Email>();
         public virtual ICollection<Note> Notes { get; set; } = new List<Note>();
+        public virtual ICollection<TaskHistory> TaskHistories { get; set; } = new List<TaskHistory>();
+        public virtual ICollection<NotificationHistory> NotificationHistories { get; set; } = new List<NotificationHistory>();
     }
 }

--- a/backend/Models/EventRule.cs
+++ b/backend/Models/EventRule.cs
@@ -1,0 +1,17 @@
+using System;
+using AutomotiveClaimsApi.Services;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class EventRule
+    {
+        public Guid Id { get; set; }
+        public ClaimNotificationEvent EventType { get; set; }
+        public Guid? TaskTemplateId { get; set; }
+        public Guid? NotificationTemplateId { get; set; }
+        public string? CronExpression { get; set; }
+
+        public TaskTemplate? TaskTemplate { get; set; }
+        public NotificationTemplate? NotificationTemplate { get; set; }
+    }
+}

--- a/backend/Models/NotificationHistory.cs
+++ b/backend/Models/NotificationHistory.cs
@@ -1,0 +1,19 @@
+using System;
+using AutomotiveClaimsApi.Services;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class NotificationHistory
+    {
+        public Guid Id { get; set; }
+        public Guid EventId { get; set; }
+        public ClaimNotificationEvent EventType { get; set; }
+        public Guid? DecisionId { get; set; }
+        public Guid? RecourseId { get; set; }
+        public Guid? SettlementId { get; set; }
+        public Guid? AppealId { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public Event Event { get; set; } = null!;
+    }
+}

--- a/backend/Models/NotificationTemplate.cs
+++ b/backend/Models/NotificationTemplate.cs
@@ -1,0 +1,13 @@
+using System;
+using AutomotiveClaimsApi.Services;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class NotificationTemplate
+    {
+        public Guid Id { get; set; }
+        public ClaimNotificationEvent EventType { get; set; }
+        public string Subject { get; set; } = string.Empty;
+        public string Body { get; set; } = string.Empty;
+    }
+}

--- a/backend/Models/TaskHistory.cs
+++ b/backend/Models/TaskHistory.cs
@@ -1,0 +1,19 @@
+using System;
+using AutomotiveClaimsApi.Services;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class TaskHistory
+    {
+        public Guid Id { get; set; }
+        public Guid EventId { get; set; }
+        public ClaimNotificationEvent EventType { get; set; }
+        public Guid? DecisionId { get; set; }
+        public Guid? RecourseId { get; set; }
+        public Guid? SettlementId { get; set; }
+        public Guid? AppealId { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public Event Event { get; set; } = null!;
+    }
+}

--- a/backend/Models/TaskTemplate.cs
+++ b/backend/Models/TaskTemplate.cs
@@ -1,0 +1,13 @@
+using System;
+using AutomotiveClaimsApi.Services;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class TaskTemplate
+    {
+        public Guid Id { get; set; }
+        public ClaimNotificationEvent EventType { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -67,6 +67,7 @@ builder.Services.AddScoped<IDocumentService, DocumentService>();
 builder.Services.AddScoped<IGoogleCloudStorageService, GoogleCloudStorageService>();
 builder.Services.AddScoped<IRiskTypeService, RiskTypeService>();
 builder.Services.AddScoped<IDamageTypeService, DamageTypeService>();
+builder.Services.AddScoped<IRuleService, RuleService>();
 
 // Add background services
 builder.Services.AddHostedService<EmailBackgroundService>();

--- a/backend/Services/RuleService.cs
+++ b/backend/Services/RuleService.cs
@@ -1,0 +1,98 @@
+using System;
+using AutomotiveClaimsApi.Data;
+using AutomotiveClaimsApi.Models;
+
+namespace AutomotiveClaimsApi.Services
+{
+    public interface IRuleService
+    {
+        Task ProcessAsync(ClaimNotificationEvent eventType, Guid entityId);
+    }
+
+    public class RuleService : IRuleService
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly INotificationService? _notificationService;
+
+        public RuleService(ApplicationDbContext context, INotificationService? notificationService = null)
+        {
+            _context = context;
+            _notificationService = notificationService;
+        }
+
+        public async Task ProcessAsync(ClaimNotificationEvent eventType, Guid entityId)
+        {
+            Guid? eventId = null;
+            Guid? decisionId = null;
+            Guid? recourseId = null;
+            Guid? settlementId = null;
+            Guid? appealId = null;
+
+            switch (eventType)
+            {
+                case ClaimNotificationEvent.DecisionAdded:
+                    var decision = await _context.Decisions.FindAsync(entityId);
+                    eventId = decision?.EventId;
+                    decisionId = entityId;
+                    break;
+                case ClaimNotificationEvent.RecourseAdded:
+                    var recourse = await _context.Recourses.FindAsync(entityId);
+                    eventId = recourse?.EventId;
+                    recourseId = entityId;
+                    break;
+                case ClaimNotificationEvent.SettlementAdded:
+                    var settlement = await _context.Settlements.FindAsync(entityId);
+                    eventId = settlement?.EventId;
+                    settlementId = entityId;
+                    break;
+                case ClaimNotificationEvent.SettlementAppealAdded:
+                    var appeal = await _context.Appeals.FindAsync(entityId);
+                    eventId = appeal?.EventId;
+                    appealId = entityId;
+                    break;
+            }
+
+            if (eventId == null)
+            {
+                return;
+            }
+
+            var taskHistory = new TaskHistory
+            {
+                Id = Guid.NewGuid(),
+                EventId = eventId.Value,
+                EventType = eventType,
+                DecisionId = decisionId,
+                RecourseId = recourseId,
+                SettlementId = settlementId,
+                AppealId = appealId,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            var notificationHistory = new NotificationHistory
+            {
+                Id = Guid.NewGuid(),
+                EventId = eventId.Value,
+                EventType = eventType,
+                DecisionId = decisionId,
+                RecourseId = recourseId,
+                SettlementId = settlementId,
+                AppealId = appealId,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            _context.TaskHistories.Add(taskHistory);
+            _context.NotificationHistories.Add(notificationHistory);
+            await _context.SaveChangesAsync();
+
+            if (_notificationService != null)
+            {
+                var eventEntity = await _context.Events.FindAsync(eventId.Value);
+                if (eventEntity != null)
+                {
+                    await _notificationService.NotifyAsync(eventEntity, null, eventType);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define task and notification templates with event type hooks
- track event-triggered actions via task and notification histories
- add rule service to dispatch notifications and record history entries
- invoke rule service after creating decisions, recourses, settlements, and appeals

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fc08298d8832cb014e2058ce082d6