### PR TITLE
Add support for multiple appeal documents

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -140,7 +140,7 @@ namespace AutomotiveClaimsApi.Controllers
                     .Include(e => e.Participants).ThenInclude(p => p.Drivers)
                     .Include(e => e.Documents.Where(d => !d.IsDeleted))
                     .Include(e => e.Damages)
-                    .Include(e => e.Appeals)
+                    .Include(e => e.Appeals).ThenInclude(a => a.Documents)
                     .Include(e => e.ClientClaims)
                     .Include(e => e.Decisions)
                     .Include(e => e.Recourses)
@@ -269,7 +269,7 @@ namespace AutomotiveClaimsApi.Controllers
                     .Include(e => e.Participants).ThenInclude(p => p.Drivers)
                     .Include(e => e.Documents.Where(d => !d.IsDeleted))
                     .Include(e => e.Damages)
-                    .Include(e => e.Appeals)
+                    .Include(e => e.Appeals).ThenInclude(a => a.Documents)
                     .Include(e => e.ClientClaims)
                     .Include(e => e.Decisions)
                     .Include(e => e.Recourses)
@@ -906,9 +906,6 @@ namespace AutomotiveClaimsApi.Controllers
                 existing.AppealAmount = aDto.AppealAmount;
                 existing.DecisionDate = aDto.DecisionDate;
                 existing.DecisionReason = aDto.DecisionReason;
-                existing.DocumentPath = aDto.DocumentPath;
-                existing.DocumentName = aDto.DocumentName;
-                existing.DocumentDescription = aDto.DocumentDescription;
                 existing.UpdatedAt = DateTime.UtcNow;
                 context.Appeals.Update(existing);
             }
@@ -927,9 +924,6 @@ namespace AutomotiveClaimsApi.Controllers
                     AppealAmount = aDto.AppealAmount,
                     DecisionDate = aDto.DecisionDate,
                     DecisionReason = aDto.DecisionReason,
-                    DocumentPath = aDto.DocumentPath,
-                    DocumentName = aDto.DocumentName,
-                    DocumentDescription = aDto.DocumentDescription,
                     CreatedAt = DateTime.UtcNow,
                     UpdatedAt = DateTime.UtcNow
                 };
@@ -1648,7 +1642,15 @@ namespace AutomotiveClaimsApi.Controllers
                 DecisionDate = a.DecisionDate,
                 DecisionReason = a.DecisionReason,
                 CreatedAt = a.CreatedAt,
-                UpdatedAt = a.UpdatedAt
+                UpdatedAt = a.UpdatedAt,
+                Documents = a.Documents.Select(d => new AppealDocumentDto
+                {
+                    Id = d.Id,
+                    FilePath = d.FilePath,
+                    FileName = d.FileName,
+                    Description = d.Description,
+                    CreatedAt = d.CreatedAt
+                }).ToList()
             }).ToList(),
             ClientClaims = e.ClientClaims.Select(c => new ClientClaimDto
             {

--- a/backend/DTOs/AppealDocumentDto.cs
+++ b/backend/DTOs/AppealDocumentDto.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class AppealDocumentDto
+    {
+        public Guid Id { get; set; }
+        public string FilePath { get; set; } = string.Empty;
+        public string FileName { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}
+

--- a/backend/DTOs/AppealDto.cs
+++ b/backend/DTOs/AppealDto.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace AutomotiveClaimsApi.DTOs
 {
@@ -19,8 +20,6 @@ namespace AutomotiveClaimsApi.DTOs
         public int? DaysSinceSubmission { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
-        public string? DocumentPath { get; set; }
-        public string? DocumentName { get; set; }
-        public string? DocumentDescription { get; set; }
+        public List<AppealDocumentDto>? Documents { get; set; }
     }
 }

--- a/backend/DTOs/AppealUpsertDto.cs
+++ b/backend/DTOs/AppealUpsertDto.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace AutomotiveClaimsApi.DTOs
 {
@@ -16,8 +17,6 @@ namespace AutomotiveClaimsApi.DTOs
         public decimal? AppealAmount { get; set; }
         public DateTime? DecisionDate { get; set; }
         public string? DecisionReason { get; set; }
-        public string? DocumentPath { get; set; }
-        public string? DocumentName { get; set; }
-        public string? DocumentDescription { get; set; }
+        public List<AppealDocumentDto>? Documents { get; set; }
     }
 }

--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -28,6 +28,7 @@ namespace AutomotiveClaimsApi.Data
         public DbSet<Client> Clients { get; set; }
         public DbSet<RiskType> RiskTypes { get; set; }
         public DbSet<DamageType> DamageTypes { get; set; }
+        public DbSet<AppealDocument> AppealDocuments { get; set; }
 
         // Dictionary entities
         public DbSet<CaseHandler> CaseHandlers { get; set; }
@@ -107,6 +108,14 @@ namespace AutomotiveClaimsApi.Data
                 entity.HasOne(ec => ec.Claim)
                       .WithMany(c => c.EmailClaims)
                       .HasForeignKey(ec => ec.ClaimId);
+            });
+
+            modelBuilder.Entity<Appeal>(entity =>
+            {
+                entity.HasMany(a => a.Documents)
+                      .WithOne(d => d.Appeal)
+                      .HasForeignKey(d => d.AppealId)
+                      .OnDelete(DeleteBehavior.Cascade);
             });
         }
     }

--- a/backend/Migrations/20240130000021_AddAppealDocuments.cs
+++ b/backend/Migrations/20240130000021_AddAppealDocuments.cs
@@ -1,0 +1,76 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    public partial class AddAppealDocuments : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DocumentPath",
+                table: "Appeals");
+
+            migrationBuilder.DropColumn(
+                name: "DocumentName",
+                table: "Appeals");
+
+            migrationBuilder.DropColumn(
+                name: "DocumentDescription",
+                table: "Appeals");
+
+            migrationBuilder.CreateTable(
+                name: "AppealDocuments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    AppealId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FilePath = table.Column<string>(type: "text", nullable: false),
+                    FileName = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "NOW()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppealDocuments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AppealDocuments_Appeals_AppealId",
+                        column: x => x.AppealId,
+                        principalTable: "Appeals",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppealDocuments_AppealId",
+                table: "AppealDocuments",
+                column: "AppealId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AppealDocuments");
+
+            migrationBuilder.AddColumn<string>(
+                name: "DocumentPath",
+                table: "Appeals",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DocumentName",
+                table: "Appeals",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DocumentDescription",
+                table: "Appeals",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -544,6 +544,37 @@ namespace AutomotiveClaimsApi.Migrations
                     b.ToTable("Documents");
                 });
 
+            modelBuilder.Entity("AutomotiveClaimsApi.Models.AppealDocument", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasDefaultValueSql("gen_random_uuid()");
+
+                    b.Property<Guid>("AppealId")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("timestamp with time zone")
+                        .HasDefaultValueSql("NOW()");
+
+                    b.Property<string>("Description")
+                        .HasColumnType("text");
+
+                    b.Property<string>("FileName")
+                        .HasColumnType("text");
+
+                    b.Property<string>("FilePath")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AppealId");
+
+                    b.ToTable("AppealDocuments");
+                });
+
             modelBuilder.Entity("AutomotiveClaimsApi.Models.RiskType", b =>
                 {
                     b.Property<Guid>("Id")
@@ -1335,6 +1366,18 @@ namespace AutomotiveClaimsApi.Migrations
                         .IsRequired();
 
                     b.Navigation("Event");
+                    b.Navigation("Documents");
+                });
+
+            modelBuilder.Entity("AutomotiveClaimsApi.Models.AppealDocument", b =>
+                {
+                    b.HasOne("AutomotiveClaimsApi.Models.Appeal", "Appeal")
+                        .WithMany("Documents")
+                        .HasForeignKey("AppealId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Appeal");
                 });
 
             modelBuilder.Entity("AutomotiveClaimsApi.Models.ClientClaim", b =>

--- a/backend/Models/Appeal.cs
+++ b/backend/Models/Appeal.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
 
 namespace AutomotiveClaimsApi.Models
 {
@@ -30,17 +31,13 @@ namespace AutomotiveClaimsApi.Models
 
         public string? DecisionReason { get; set; }
         
-        public string? DocumentPath { get; set; }
-        
-        public string? DocumentName { get; set; }
-        
-        public string? DocumentDescription { get; set; }
-        
         public DateTime CreatedAt { get; set; }
-        
+
         public DateTime UpdatedAt { get; set; }
-        
-        // Navigation property
+
+        // Navigation properties
         public virtual Event? Event { get; set; }
+
+        public virtual ICollection<AppealDocument> Documents { get; set; } = new List<AppealDocument>();
     }
 }

--- a/backend/Models/AppealDocument.cs
+++ b/backend/Models/AppealDocument.cs
@@ -1,0 +1,30 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace AutomotiveClaimsApi.Models
+{
+    public class AppealDocument
+    {
+        [Key]
+        public Guid Id { get; set; }
+
+        [Required]
+        public Guid AppealId { get; set; }
+
+        public Appeal? Appeal { get; set; }
+
+        [Required]
+        [MaxLength(1000)]
+        public string FilePath { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(255)]
+        public string FileName { get; set; } = string.Empty;
+
+        [MaxLength(500)]
+        public string? Description { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+}
+

--- a/backend/Services/IDocumentService.cs
+++ b/backend/Services/IDocumentService.cs
@@ -14,6 +14,9 @@ namespace AutomotiveClaimsApi.Services
         Task<DocumentDto> UploadAndCreateDocumentAsync(IFormFile file, CreateDocumentDto createDto);
         Task<bool> DeleteDocumentAsync(Guid id);
         Task<bool> DeleteDocumentAsync(string filePath);
+        Task<IEnumerable<AppealDocumentDto>> GetAppealDocumentsAsync(Guid appealId);
+        Task<AppealDocumentDto> UploadAppealDocumentAsync(Guid appealId, IFormFile file, string? description);
+        Task<bool> DeleteAppealDocumentAsync(Guid documentId);
         /// <summary>
         /// Retrieves a document for download by its identifier.
         /// </summary>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -106,6 +106,14 @@ export interface DocumentDto {
   canPreview?: boolean
 }
 
+export interface AppealDocumentDto {
+  id: string
+  filePath: string
+  fileName: string
+  description?: string | null
+  createdAt?: string
+}
+
 export interface ClaimNotificationSettings {
   recipients: string[]
   events: string[]
@@ -488,12 +496,10 @@ export interface AppealDto {
   appealNumber?: string
   appealAmount?: number
   decisionReason?: string
-  documentPath?: string
-  documentName?: string
-  documentDescription?: string
   createdAt?: string
   updatedAt?: string
   daysSinceSubmission?: number
+  documents?: AppealDocumentDto[]
 }
 
 export interface AppealUpsertDto {
@@ -509,9 +515,7 @@ export interface AppealUpsertDto {
   appealAmount?: number
   decisionDate?: string
   decisionReason?: string
-  documentPath?: string
-  documentName?: string
-  documentDescription?: string
+  documents?: AppealDocumentDto[]
 }
 
 export interface ClientClaimDto {

--- a/lib/api/appeals.ts
+++ b/lib/api/appeals.ts
@@ -1,4 +1,4 @@
-import { AppealDto, API_BASE_URL } from "../api";
+import { AppealDto, API_BASE_URL, AppealDocumentDto } from "../api";
 
 export interface Appeal {
   id: string;
@@ -7,10 +7,8 @@ export interface Appeal {
   responseDate?: string;
   decisionDate?: string;
   status?: string;
-  documentPath?: string;
-  documentName?: string;
-  documentDescription?: string;
   alertDays?: number;
+  documents?: AppealDocumentDto[];
 }
 
 function formatDate(date?: string | null): string | undefined {
@@ -24,10 +22,8 @@ function mapDtoToAppeal(dto: AppealDto): Appeal {
     extensionDate: formatDate(dto.extensionDate),
     responseDate: formatDate(dto.decisionDate),
     status: dto.status,
-    documentPath: dto.documentPath,
-    documentName: dto.documentName,
-    documentDescription: dto.documentDescription,
     alertDays: dto.daysSinceSubmission,
+    documents: dto.documents,
   };
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -219,6 +219,15 @@ export interface Appeal {
   documentPath?: string
   documentName?: string
   documentDescription?: string
+  documents?: AppealDocument[]
+}
+
+export interface AppealDocument {
+  id: string
+  filePath: string
+  fileName: string
+  description?: string
+  createdAt?: string
 }
 
 export interface ClientClaim {


### PR DESCRIPTION
## Summary
- introduce `AppealDocument` entity and link it to `Appeal`
- expose document collections on appeals DTOs and API endpoints
- add migration creating `AppealDocuments` table and removing single file fields

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fc0adb920832c9601a5a6608fc11b