### PR TITLE
Support multiple appeal documents

### DIFF
--- a/app/api/appeals/[id]/route.ts
+++ b/app/api/appeals/[id]/route.ts
@@ -72,12 +72,16 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
     const formData = await request.formData()
     const backendFormData = new FormData()
 
+    const documents = formData.getAll("documents")
+    documents.forEach((doc) => {
+      if (doc instanceof File) {
+        backendFormData.append("Documents", doc)
+      }
+    })
+
     formData.forEach((value, key) => {
-      if (key === "documents" && value instanceof File) {
-        if (!backendFormData.has("Document")) {
-          backendFormData.append("Document", value)
-        }
-      } else if (key === "extensionDate" && typeof value === "string") {
+      if (key === "documents") return
+      if (key === "extensionDate" && typeof value === "string") {
         backendFormData.append("ExtensionDate", value)
       } else if (typeof value === "string") {
         backendFormData.append(key, value)

--- a/app/api/appeals/route.ts
+++ b/app/api/appeals/route.ts
@@ -47,13 +47,16 @@ export async function POST(request: NextRequest) {
       return fieldMap[key] || `${key.charAt(0).toUpperCase()}${key.slice(1)}`
     }
 
-    formData.forEach((value, key) => {
-      if (key === "documents" && value instanceof File) {
-        if (!backendFormData.has("Document")) {
-          backendFormData.append("Document", value)
-        }
+    const documents = formData.getAll("documents")
+    documents.forEach((doc) => {
+      if (doc instanceof File) {
+        backendFormData.append("Documents", doc)
+      }
+    })
 
-      } else if (key === "claimId" && typeof value === "string") {
+    formData.forEach((value, key) => {
+      if (key === "documents") return
+      if (key === "claimId" && typeof value === "string") {
         backendFormData.append("EventId", value)
       } else if (key === "extensionDate" && typeof value === "string") {
         backendFormData.append("ExtensionDate", value)

--- a/backend/Controllers/AppealsController.cs
+++ b/backend/Controllers/AppealsController.cs
@@ -101,19 +101,32 @@ namespace AutomotiveClaimsApi.Controllers
                     UpdatedAt = DateTime.UtcNow
                 };
 
-                if (createDto.Document != null && createDto.Document.Length > 0)
+                if (createDto.Documents != null && createDto.Documents.Any())
                 {
-                    var documentResult = await _documentService.SaveDocumentAsync(
-                        createDto.Document,
-                        "appeals",
-                        createDto.DocumentDescription
-                    );
+                    foreach (var doc in createDto.Documents)
+                    {
+                        if (doc.Length > 0)
+                        {
+                            var documentResult = await _documentService.SaveDocumentAsync(
+                                doc,
+                                "appeals",
+                                createDto.DocumentDescription
+                            );
 
-                    appeal.DocumentPath = documentResult.FilePath;
-                    appeal.DocumentName = documentResult.OriginalFileName;
-                    appeal.DocumentDescription = createDto.DocumentDescription;
+                            if (string.IsNullOrEmpty(appeal.DocumentPath))
+                            {
+                                appeal.DocumentPath = documentResult.FilePath;
+                                appeal.DocumentName = documentResult.OriginalFileName;
+                                appeal.DocumentDescription = createDto.DocumentDescription;
+                            }
+                        }
+                        else
+                        {
+                            return BadRequest(new { error = "Document file is empty" });
+                        }
+                    }
                 }
-                else if (createDto.Document != null)
+                else if (createDto.Documents != null)
                 {
                     return BadRequest(new { error = "Document file is empty" });
                 }
@@ -172,24 +185,37 @@ namespace AutomotiveClaimsApi.Controllers
                 appeal.DecisionDate = updateDto.DecisionDate;
                 appeal.UpdatedAt = DateTime.UtcNow;
 
-                if (updateDto.Document != null && updateDto.Document.Length > 0)
+                if (updateDto.Documents != null && updateDto.Documents.Any())
                 {
                     if (!string.IsNullOrEmpty(appeal.DocumentPath))
                     {
                         await _documentService.DeleteDocumentAsync(appeal.DocumentPath);
                     }
 
-                    var documentResult = await _documentService.SaveDocumentAsync(
-                        updateDto.Document,
-                        "appeals",
-                        updateDto.DocumentDescription
-                    );
+                    foreach (var doc in updateDto.Documents)
+                    {
+                        if (doc.Length > 0)
+                        {
+                            var documentResult = await _documentService.SaveDocumentAsync(
+                                doc,
+                                "appeals",
+                                updateDto.DocumentDescription
+                            );
 
-                    appeal.DocumentPath = documentResult.FilePath;
-                    appeal.DocumentName = documentResult.OriginalFileName;
-                    appeal.DocumentDescription = updateDto.DocumentDescription;
+                            if (string.IsNullOrEmpty(appeal.DocumentPath))
+                            {
+                                appeal.DocumentPath = documentResult.FilePath;
+                                appeal.DocumentName = documentResult.OriginalFileName;
+                                appeal.DocumentDescription = updateDto.DocumentDescription;
+                            }
+                        }
+                        else
+                        {
+                            return BadRequest(new { error = "Document file is empty" });
+                        }
+                    }
                 }
-                else if (updateDto.Document != null)
+                else if (updateDto.Documents != null)
                 {
                     return BadRequest(new { error = "Document file is empty" });
                 }

--- a/backend/DTOs/CreateAppealDto.cs
+++ b/backend/DTOs/CreateAppealDto.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 
 namespace AutomotiveClaimsApi.DTOs
 {
@@ -25,7 +27,7 @@ namespace AutomotiveClaimsApi.DTOs
         [StringLength(2000)]
         public string? Description { get; set; }
 
-        public IFormFile? Document { get; set; }
+        public List<IFormFile>? Documents { get; set; }
 
         [StringLength(500)]
         public string? DocumentDescription { get; set; }

--- a/backend/DTOs/UpdateAppealDto.cs
+++ b/backend/DTOs/UpdateAppealDto.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 
 namespace AutomotiveClaimsApi.DTOs
 {
@@ -22,7 +24,7 @@ namespace AutomotiveClaimsApi.DTOs
         [StringLength(2000)]
         public string? Description { get; set; }
 
-        public IFormFile? Document { get; set; }
+        public List<IFormFile>? Documents { get; set; }
 
         [StringLength(500)]
         public string? DocumentDescription { get; set; }

--- a/components/claim-form/appeals-section.tsx
+++ b/components/claim-form/appeals-section.tsx
@@ -44,6 +44,7 @@ import {
   updateAppeal,
   deleteAppeal as apiDeleteAppeal,
   Appeal,
+  AppealUpsert,
 } from "@/lib/api/appeals"
 import { API_BASE_URL } from "@/lib/api"
 
@@ -283,34 +284,26 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
 
     setIsLoading(true)
     try {
-      const payload = new FormData()
-      if (!isEditing) {
-        payload.append("EventId", claimId)
-      }
-      payload.append("FilingDate", formData.filingDate)
-      if (formData.extensionDate) {
-        payload.append("ExtensionDate", formData.extensionDate)
-      }
-      if (formData.responseDate) {
-        payload.append("DecisionDate", formData.responseDate)
-      }
       const status = formData.responseDate ? "Zamknięte" : formData.status
-      if (status) {
-        payload.append("Status", status)
+      const payload: AppealUpsert = {
+        filingDate: formData.filingDate,
+        extensionDate: formData.extensionDate || undefined,
+        decisionDate: formData.responseDate || undefined,
+        status,
+        documentDescription: formData.documentDescription || undefined,
       }
-      if (formData.documentDescription) {
-        payload.append("DocumentDescription", formData.documentDescription)
+      if (!isEditing) {
+        payload.eventId = claimId
       }
-      selectedFiles.forEach((file) => payload.append("Document", file))
 
       if (isEditing && editingId) {
-        await updateAppeal(editingId, payload)
+        await updateAppeal(editingId, payload, selectedFiles)
         toast({
           title: "Sukces",
           description: "Odwołanie zostało zaktualizowane",
         })
       } else {
-        await createAppeal(payload)
+        await createAppeal(payload, selectedFiles)
         toast({
           title: "Sukces",
           description: "Odwołanie zostało dodane",


### PR DESCRIPTION
## Summary
- allow uploading multiple appeal documents through Next.js and backend
- update appeal DTOs and controller to accept `Documents[]`
- build FormData with many files in appeal API helpers
- adjust claim form appeals section to use new helpers

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `dotnet test backend` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689fc0aedac4832cbadc8d26ffa3d1f6