### PR TITLE
Remove unassigned email placeholder

### DIFF
--- a/components/email/unassigned-list.tsx
+++ b/components/email/unassigned-list.tsx
@@ -66,9 +66,6 @@ export function UnassignedEmailList() {
               </div>
             </li>
           ))}
-          {emails.length === 0 && !loading && (
-            <li className="text-gray-500">Brak e-maili do przypisania</li>
-          )}
         </ul>
       )}
 


### PR DESCRIPTION
## Summary
- remove unused notice for missing assignable emails

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Cannot require() ES Module app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689fc5480f00832cb774ec992ff2b710