### PR TITLE
Render specific claim forms based on object type

### DIFF
--- a/components/claim-form/property-claim-form.tsx
+++ b/components/claim-form/property-claim-form.tsx
@@ -3,7 +3,14 @@
 import DamageDataSection from "./damage-data-section"
 import PropertyDamageSection from "./property-damage-section"
 import PropertyParticipantsSection from "./property-participants-section"
-import type { Claim } from "@/types"
+import type { Dispatch, SetStateAction } from "react"
+import type {
+  Claim,
+  UploadedFile,
+  RequiredDocument,
+  ParticipantInfo,
+  DriverInfo,
+} from "@/types"
 
 interface RiskType {
   value: string
@@ -19,6 +26,23 @@ interface ClaimStatus {
 interface PropertyClaimFormProps {
   claimFormData: Partial<Claim>
   handleFormChange: (field: keyof Claim, value: any) => void
+  handleParticipantChange: (
+    party: "injuredParty" | "perpetrator",
+    field: keyof Omit<ParticipantInfo, "drivers">,
+    value: any,
+  ) => void
+  handleDriverChange: (
+    party: "injuredParty" | "perpetrator",
+    driverIndex: number,
+    field: keyof DriverInfo,
+    value: any,
+  ) => void
+  handleAddDriver: (party: "injuredParty" | "perpetrator") => void
+  handleRemoveDriver: (party: "injuredParty" | "perpetrator", driverIndex: number) => void
+  uploadedFiles: UploadedFile[]
+  setUploadedFiles: Dispatch<SetStateAction<UploadedFile[]>>
+  requiredDocuments: RequiredDocument[]
+  setRequiredDocuments: Dispatch<SetStateAction<RequiredDocument[]>>
   claimObjectType: string
   setClaimObjectType: (value: string) => void
   riskTypes: RiskType[]
@@ -30,6 +54,14 @@ interface PropertyClaimFormProps {
 export function PropertyClaimForm({
   claimFormData,
   handleFormChange,
+  handleParticipantChange,
+  handleDriverChange,
+  handleAddDriver,
+  handleRemoveDriver,
+  uploadedFiles,
+  setUploadedFiles,
+  requiredDocuments,
+  setRequiredDocuments,
   claimObjectType,
   setClaimObjectType,
   riskTypes,

--- a/components/claim-form/transport-claim-form.tsx
+++ b/components/claim-form/transport-claim-form.tsx
@@ -3,7 +3,14 @@
 import DamageDataSection from "./damage-data-section"
 import { TransportDamageSection } from "./transport-damage-section"
 import SubcontractorSection from "./subcontractor-section"
-import type { Claim } from "@/types"
+import type { Dispatch, SetStateAction } from "react"
+import type {
+  Claim,
+  UploadedFile,
+  RequiredDocument,
+  ParticipantInfo,
+  DriverInfo,
+} from "@/types"
 
 interface RiskType {
   value: string
@@ -19,6 +26,23 @@ interface ClaimStatus {
 interface TransportClaimFormProps {
   claimFormData: Partial<Claim>
   handleFormChange: (field: keyof Claim, value: any) => void
+  handleParticipantChange: (
+    party: "injuredParty" | "perpetrator",
+    field: keyof Omit<ParticipantInfo, "drivers">,
+    value: any,
+  ) => void
+  handleDriverChange: (
+    party: "injuredParty" | "perpetrator",
+    driverIndex: number,
+    field: keyof DriverInfo,
+    value: any,
+  ) => void
+  handleAddDriver: (party: "injuredParty" | "perpetrator") => void
+  handleRemoveDriver: (party: "injuredParty" | "perpetrator", driverIndex: number) => void
+  uploadedFiles: UploadedFile[]
+  setUploadedFiles: Dispatch<SetStateAction<UploadedFile[]>>
+  requiredDocuments: RequiredDocument[]
+  setRequiredDocuments: Dispatch<SetStateAction<RequiredDocument[]>>
   claimObjectType: string
   setClaimObjectType: (value: string) => void
   riskTypes: RiskType[]
@@ -30,6 +54,14 @@ interface TransportClaimFormProps {
 export function TransportClaimForm({
   claimFormData,
   handleFormChange,
+  handleParticipantChange,
+  handleDriverChange,
+  handleAddDriver,
+  handleRemoveDriver,
+  uploadedFiles,
+  setUploadedFiles,
+  requiredDocuments,
+  setRequiredDocuments,
   claimObjectType,
   setClaimObjectType,
   riskTypes,


### PR DESCRIPTION
## Summary
- Dynamically render the appropriate claim form for communication, property, or transport claims
- Expose file state and participant/driver handlers to PropertyClaimForm and TransportClaimForm

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689fb89d3768832c9c9a1a3f2385b4c5