### PR TITLE
feat: improve document management

### DIFF
--- a/app/api/appeals/[id]/documents/[docId]/download/route.ts
+++ b/app/api/appeals/[id]/documents/[docId]/download/route.ts
@@ -4,11 +4,11 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { appealId: string; docId: string } },
+  { params }: { params: { id: string; docId: string } },
 ) {
   try {
     const response = await fetch(
-      `${API_BASE_URL}/appeals/${params.appealId}/documents/${params.docId}/preview`,
+      `${API_BASE_URL}/appeals/${params.id}/documents/${params.docId}/download`,
       {
         method: "GET",
       },
@@ -24,17 +24,21 @@ export async function GET(
 
     const fileData = await response.arrayBuffer()
     const contentType = response.headers.get("content-type") || "application/octet-stream"
+    const contentDisposition = response.headers.get("content-disposition")
 
     const fileResponse = new NextResponse(fileData)
     fileResponse.headers.set("Content-Type", contentType)
-    fileResponse.headers.set("Content-Disposition", "inline")
+
+    if (contentDisposition) {
+      fileResponse.headers.set("Content-Disposition", contentDisposition)
+    }
 
     return fileResponse
   } catch (error) {
-    console.error("Error previewing appeal document:", error)
+    console.error("Error downloading appeal document:", error)
     return NextResponse.json(
       {
-        error: "Failed to preview document",
+        error: "Failed to download document",
         details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 },

--- a/app/api/appeals/[id]/documents/[docId]/preview/route.ts
+++ b/app/api/appeals/[id]/documents/[docId]/preview/route.ts
@@ -4,11 +4,11 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { appealId: string; docId: string } },
+  { params }: { params: { id: string; docId: string } },
 ) {
   try {
     const response = await fetch(
-      `${API_BASE_URL}/appeals/${params.appealId}/documents/${params.docId}/download`,
+      `${API_BASE_URL}/appeals/${params.id}/documents/${params.docId}/preview`,
       {
         method: "GET",
       },
@@ -24,21 +24,17 @@ export async function GET(
 
     const fileData = await response.arrayBuffer()
     const contentType = response.headers.get("content-type") || "application/octet-stream"
-    const contentDisposition = response.headers.get("content-disposition")
 
     const fileResponse = new NextResponse(fileData)
     fileResponse.headers.set("Content-Type", contentType)
-
-    if (contentDisposition) {
-      fileResponse.headers.set("Content-Disposition", contentDisposition)
-    }
+    fileResponse.headers.set("Content-Disposition", "inline")
 
     return fileResponse
   } catch (error) {
-    console.error("Error downloading appeal document:", error)
+    console.error("Error previewing appeal document:", error)
     return NextResponse.json(
       {
-        error: "Failed to download document",
+        error: "Failed to preview document",
         details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 },

--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -1605,6 +1605,7 @@ namespace AutomotiveClaimsApi.Controllers
                 FileName = d.FileName,
                 OriginalFileName = d.OriginalFileName,
                 FilePath = d.FilePath,
+                CloudUrl = d.CloudUrl,
                 FileSize = d.FileSize,
                 ContentType = d.ContentType,
                 Category = d.DocumentType,

--- a/backend/Controllers/DocumentsController.cs
+++ b/backend/Controllers/DocumentsController.cs
@@ -44,6 +44,7 @@ namespace AutomotiveClaimsApi.Controllers
             [FromQuery] Guid? damageId,
             [FromQuery] string? documentType,
             [FromQuery] string? status,
+            [FromQuery] string? search,
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 50)
         {
@@ -57,6 +58,12 @@ namespace AutomotiveClaimsApi.Controllers
                 query = query.Where(d => d.DocumentType == documentType);
             if (!string.IsNullOrEmpty(status))
                 query = query.Where(d => d.Status == status);
+            if (!string.IsNullOrEmpty(search))
+                query = query.Where(d =>
+                    d.FileName.Contains(search) ||
+                    d.OriginalFileName.Contains(search) ||
+                    (d.Description ?? "").Contains(search) ||
+                    (d.DocumentType ?? "").Contains(search));
 
             var totalCount = await query.CountAsync();
             var documents = await query
@@ -184,6 +191,7 @@ namespace AutomotiveClaimsApi.Controllers
                 FileName = doc.FileName,
                 OriginalFileName = doc.OriginalFileName,
                 FilePath = doc.FilePath,
+                CloudUrl = doc.CloudUrl,
                 FileSize = doc.FileSize,
                 ContentType = doc.ContentType,
                 Category = doc.DocumentType,

--- a/backend/DTOs/DocumentDto.cs
+++ b/backend/DTOs/DocumentDto.cs
@@ -9,6 +9,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string FileName { get; set; } = string.Empty;
         public string? OriginalFileName { get; set; }
         public string FilePath { get; set; } = string.Empty;
+        public string? CloudUrl { get; set; }
         public long FileSize { get; set; }
         public string ContentType { get; set; } = string.Empty;
         public string? Category { get; set; }

--- a/backend/Models/Document.cs
+++ b/backend/Models/Document.cs
@@ -27,6 +27,9 @@ namespace AutomotiveClaimsApi.Models
         [MaxLength(1000)]
         public string FilePath { get; set; } = string.Empty;
 
+        [MaxLength(1000)]
+        public string? CloudUrl { get; set; }
+
         public long FileSize { get; set; }
 
         [MaxLength(100)]

--- a/backend/Services/DocumentService.cs
+++ b/backend/Services/DocumentService.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -18,12 +19,21 @@ namespace AutomotiveClaimsApi.Services
         private readonly ApplicationDbContext _context;
         private readonly ILogger<DocumentService> _logger;
         private readonly string _uploadsPath;
+        private readonly IGoogleCloudStorageService? _cloudStorage;
+        private readonly bool _cloudEnabled;
 
-        public DocumentService(ApplicationDbContext context, ILogger<DocumentService> logger, IWebHostEnvironment environment)
+        public DocumentService(
+            ApplicationDbContext context,
+            ILogger<DocumentService> logger,
+            IWebHostEnvironment environment,
+            IGoogleCloudStorageService? cloudStorage = null,
+            IOptions<GoogleCloudStorageSettings>? cloudSettings = null)
         {
             _context = context;
             _logger = logger;
             _uploadsPath = Path.Combine(environment.ContentRootPath, "uploads");
+            _cloudStorage = cloudStorage;
+            _cloudEnabled = cloudSettings?.Value.Enabled ?? false;
 
             if (!Directory.Exists(_uploadsPath))
             {
@@ -75,6 +85,13 @@ namespace AutomotiveClaimsApi.Services
                 await file.CopyToAsync(stream);
             }
 
+            string? cloudUrl = null;
+            if (_cloudEnabled && _cloudStorage != null)
+            {
+                await using var uploadStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+                cloudUrl = await _cloudStorage.UploadFileAsync(uploadStream, uniqueFileName, file.ContentType);
+            }
+
             var document = new Document
             {
                 Id = Guid.NewGuid(),
@@ -86,6 +103,7 @@ namespace AutomotiveClaimsApi.Services
                 OriginalFileName = file.FileName,
                 FilePath = Path.Combine("uploads", createDto.Category ?? "other", uniqueFileName)
                     .Replace("\\", "/"),
+                CloudUrl = cloudUrl,
                 FileSize = file.Length,
                 ContentType = file.ContentType,
                 DocumentType = createDto.Category ?? "other",
@@ -125,6 +143,11 @@ namespace AutomotiveClaimsApi.Services
                         "File deletion failed for Document ID {DocumentId} at {FilePath}",
                         id, document.FilePath);
                 }
+
+                if (_cloudEnabled && _cloudStorage != null && !string.IsNullOrEmpty(document.CloudUrl))
+                {
+                    await _cloudStorage.DeleteFileAsync(document.CloudUrl);
+                }
             }
             catch (Exception ex)
             {
@@ -145,6 +168,17 @@ namespace AutomotiveClaimsApi.Services
             if (document == null)
             {
                 return null;
+            }
+
+            if (_cloudEnabled && _cloudStorage != null && !string.IsNullOrEmpty(document.CloudUrl))
+            {
+                var stream = await _cloudStorage.GetFileStreamAsync(document.CloudUrl);
+                return new DocumentDownloadResult
+                {
+                    FileStream = stream,
+                    ContentType = document.ContentType,
+                    FileName = document.OriginalFileName ?? document.FileName
+                };
             }
 
             var fullPath = Path.Combine(_uploadsPath, document.FilePath.Replace("uploads/", ""));
@@ -175,9 +209,15 @@ namespace AutomotiveClaimsApi.Services
 
         public async Task<bool> DeleteDocumentAsync(string filePath)
         {
-            var fullPath = Path.Combine(_uploadsPath, NormalizePath(filePath));
             try
             {
+                if (_cloudEnabled && _cloudStorage != null && Uri.IsWellFormedUriString(filePath, UriKind.Absolute))
+                {
+                    await _cloudStorage.DeleteFileAsync(filePath);
+                    return true;
+                }
+
+                var fullPath = Path.Combine(_uploadsPath, NormalizePath(filePath));
                 if (File.Exists(fullPath))
                 {
                     await Task.Run(() => File.Delete(fullPath));
@@ -193,6 +233,17 @@ namespace AutomotiveClaimsApi.Services
 
         public async Task<DocumentDownloadResult?> GetDocumentAsync(string filePath)
         {
+            if (_cloudEnabled && _cloudStorage != null && Uri.IsWellFormedUriString(filePath, UriKind.Absolute))
+            {
+                var stream = await _cloudStorage.GetFileStreamAsync(filePath);
+                return new DocumentDownloadResult
+                {
+                    FileStream = stream,
+                    ContentType = GetContentType(filePath),
+                    FileName = Path.GetFileName(filePath)
+                };
+            }
+
             var fullPath = Path.Combine(_uploadsPath, NormalizePath(filePath));
             if (!File.Exists(fullPath)) return null;
 
@@ -207,6 +258,11 @@ namespace AutomotiveClaimsApi.Services
 
         public async Task<Stream> GetDocumentStreamAsync(string filePath)
         {
+            if (_cloudEnabled && _cloudStorage != null && Uri.IsWellFormedUriString(filePath, UriKind.Absolute))
+            {
+                return await _cloudStorage.GetFileStreamAsync(filePath);
+            }
+
             var fullPath = Path.Combine(_uploadsPath, NormalizePath(filePath));
             if (!File.Exists(fullPath)) throw new FileNotFoundException("Document not found", filePath);
             return new MemoryStream(await File.ReadAllBytesAsync(fullPath));
@@ -238,6 +294,7 @@ namespace AutomotiveClaimsApi.Services
                 FileName = doc.FileName,
                 OriginalFileName = doc.OriginalFileName,
                 FilePath = doc.FilePath,
+                CloudUrl = doc.CloudUrl,
                 FileSize = doc.FileSize,
                 ContentType = doc.ContentType,
                 Category = doc.DocumentType,

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -1729,6 +1729,7 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
                   requiredDocuments={requiredDocuments}
                   setRequiredDocuments={setRequiredDocuments}
                   eventId={eventId}
+                  storageKey={`main-documents-${eventId}`}
                 />
               )}
             </CardContent>
@@ -2495,6 +2496,7 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
                   setRequiredDocuments={() => {}}
                   eventId={eventId}
                   hideRequiredDocuments={true}
+                  storageKey={`summary-documents-${eventId}`}
                 />
               )}
             </div>

--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -391,6 +391,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
               requiredDocuments={requiredDocuments}
               setRequiredDocuments={setRequiredDocuments}
               eventId={formData.id}
+              storageKey={`claim-form-${formData.id || 'new'}`}
             />
 
           </CardContent>

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -44,9 +44,18 @@ export const DocumentsSection = ({
   pendingFiles = [],
   setPendingFiles,
   hideRequiredDocuments = false,
+  storageKey,
 }: DocumentsSectionProps & { hideRequiredDocuments?: boolean }) => {
   const { toast } = useToast()
-  const [viewMode, setViewMode] = useState<"list" | "grid">("list")
+  const [viewMode, setViewMode] = useState<"list" | "grid">(() => {
+    if (storageKey && typeof window !== "undefined") {
+      const stored = localStorage.getItem(`documents-view-${storageKey}`)
+      if (stored === "list" || stored === "grid") {
+        return stored
+      }
+    }
+    return "list"
+  })
   const fileInputRef = React.useRef<HTMLInputElement>(null)
   const [openCategories, setOpenCategories] = useState<Record<string, boolean>>({ "Inne dokumenty": true })
   const [uploadingForCategory, setUploadingForCategory] = useState<string | null>(null)
@@ -61,6 +70,7 @@ export const DocumentsSection = ({
   const [dragActive, setDragActive] = useState(false)
   const [dragCategory, setDragCategory] = useState<string | null>(null)
   const [selectedDocumentIds, setSelectedDocumentIds] = useState<string[]>([])
+  const [searchQuery, setSearchQuery] = useState("")
 
   // Preview modal states
   const [previewZoom, setPreviewZoom] = useState(1)
@@ -70,6 +80,13 @@ export const DocumentsSection = ({
   const [previewDocuments, setPreviewDocuments] = useState<Document[]>([])
 
   const previewContainerRef = React.useRef<HTMLDivElement>(null)
+
+  // Persist view mode per section when storageKey provided
+  useEffect(() => {
+    if (storageKey) {
+      localStorage.setItem(`documents-view-${storageKey}`, viewMode)
+    }
+  }, [viewMode, storageKey])
 
   const closePreview = useCallback(() => {
     if (document.fullscreenElement) {
@@ -115,6 +132,7 @@ export const DocumentsSection = ({
     contentType: file.file?.type || "",
     fileSize: file.size,
     filePath: file.url,
+    cloudUrl: file.cloudUrl,
     description: file.description,
     status: "pending",
     uploadedBy: "Current User",
@@ -138,10 +156,13 @@ export const DocumentsSection = ({
 
   // Load documents from API
   useEffect(() => {
-    if (eventId && isGuid(eventId)) {
+    if (!eventId || !isGuid(eventId)) return
+
+    const handler = setTimeout(() => {
       loadDocuments()
-    }
-  }, [eventId])
+    }, 300)
+    return () => clearTimeout(handler)
+  }, [eventId, searchQuery])
 
   const mapCategoryCodeToName = (code?: string) =>
     requiredDocuments.find((d) => d.category === code)?.name || code || "Inne dokumenty"
@@ -154,8 +175,12 @@ export const DocumentsSection = ({
 
     setLoading(true)
     try {
-      console.log("Loading documents for eventId:", eventId)
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents?eventId=${eventId}`, {
+      const params = new URLSearchParams({ eventId })
+      if (searchQuery) {
+        params.append("search", searchQuery)
+      }
+      console.log("Loading documents for eventId:", eventId, "params:", params.toString())
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents?${params.toString()}`, {
         method: "GET",
         credentials: "include",
       })
@@ -404,6 +429,7 @@ export const DocumentsSection = ({
               : "other",
             uploadedAt: doc.createdAt,
             url: doc.previewUrl || doc.downloadUrl,
+            cloudUrl: doc.cloudUrl,
             category: doc.documentType,
             categoryCode: doc.categoryCode,
             description: doc.description,
@@ -718,6 +744,8 @@ export const DocumentsSection = ({
     e.stopPropagation()
     setDragActive(false)
     setDragCategory(null)
+    // If the section was collapsed open it so user sees upload progress
+    setOpenCategories((prev) => ({ ...prev, [category]: true }))
 
     console.log("Files dropped:", e.dataTransfer.files.length, "files for category:", category)
     if (e.dataTransfer.files && e.dataTransfer.files[0]) {
@@ -928,7 +956,12 @@ export const DocumentsSection = ({
             <div className="flex items-center justify-between">
               <div className="relative w-full max-w-md">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-                <Input placeholder="Wyszukaj dokumenty (nazwa typu, nazwa pliku, opis)..." className="pl-10" />
+                <Input
+                  placeholder="Wyszukaj dokumenty (nazwa typu, nazwa pliku, opis)..."
+                  className="pl-10"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                />
               </div>
               <Button variant="outline">
                 <Filter className="mr-2 h-4 w-4" />
@@ -983,7 +1016,18 @@ export const DocumentsSection = ({
           )
 
           return (
-            <Card key={category}>
+            <Card
+              key={category}
+              onDragEnter={(e) => {
+                handleDrag(e)
+                setDragCategory(category)
+              }}
+              onDragOver={(e) => {
+                handleDrag(e)
+                setDragCategory(category)
+              }}
+              onDrop={(e) => handleDrop(e, category)}
+            >
               <CardHeader
                 className="flex flex-row items-center justify-between p-4 cursor-pointer"
                 onClick={() => setOpenCategories((prev) => ({ ...prev, [category]: !isCategoryOpen }))}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -92,6 +92,7 @@ export interface DocumentDto {
   fileName: string
   originalFileName?: string
   filePath: string
+  cloudUrl?: string
   fileSize: number
   contentType: string
   category?: string

--- a/types/index.ts
+++ b/types/index.ts
@@ -263,6 +263,7 @@ export interface UploadedFile {
   type: "image" | "pdf" | "doc" | "video" | "other"
   uploadedAt: string // ISO timestamp when the file was uploaded
   url: string
+  cloudUrl?: string
   /** Human readable category name for UI display */
   category?: string
   /** Machine readable category code for API communication */
@@ -291,5 +292,10 @@ export interface DocumentsSectionProps {
   pendingFiles?: UploadedFile[]
   setPendingFiles?: React.Dispatch<React.SetStateAction<UploadedFile[]>>
 
-
+  /**
+   * Optional key used to persist user preferences (e.g. view mode) for each
+   * section separately. When provided, UI state is stored in localStorage under
+   * this key so changing the view in one section doesn't affect others.
+   */
+  storageKey?: string
 }


### PR DESCRIPTION
## Summary
- support document search against backend API
- persist view mode per document section
- allow dragging files onto collapsed sections
- integrate Google Cloud Storage for document uploads
- unify appeals document routes under a single [id] slug

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a9728cac832ca3ec7fb6ef7c63e6