### PR TITLE
feat: render claim sections by object type

### DIFF
--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -18,8 +18,6 @@ import { Save, ArrowLeft, Plus, Calendar, Wrench, X } from 'lucide-react'
 import { ClaimFormSidebar } from "@/components/claim-form/claim-form-sidebar"
 import { ClaimTopHeader } from "@/components/claim-form/claim-top-header"
 import { ClaimMainContent } from "@/components/claim-form/claim-main-content"
-import { PropertyClaimForm } from "@/components/claim-form/property-claim-form"
-import { TransportClaimForm } from "@/components/claim-form/transport-claim-form"
 import { useClaimForm } from "@/hooks/use-claim-form"
 import { useClaims } from "@/hooks/use-claims"
 import { useAuth } from "@/hooks/use-auth"
@@ -52,17 +50,6 @@ interface RepairSchedule {
   updatedAt?: string
 }
 
-interface RiskType {
-  value: string
-  label: string
-}
-
-interface ClaimStatus {
-  id: number
-  name: string
-  description: string
-}
-
 export default function NewClaimPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -84,10 +71,6 @@ export default function NewClaimPage() {
   const [repairDetailFormData, setRepairDetailFormData] = useState<Partial<RepairDetail>>({})
   const [employeesForSelectedBranch, setEmployeesForSelectedBranch] = useState<Employee[]>([])
 
-  const [riskTypes, setRiskTypes] = useState<RiskType[]>([])
-  const [loadingRiskTypes, setLoadingRiskTypes] = useState(false)
-  const [claimStatuses, setClaimStatuses] = useState<ClaimStatus[]>([])
-  const [loadingStatuses, setLoadingStatuses] = useState(false)
 
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([
     {
@@ -172,55 +155,11 @@ export default function NewClaimPage() {
   }, [searchParams, setClaimFormData])
 
   useEffect(() => {
-    loadRiskTypes()
-    loadClaimStatuses()
-  }, [claimObjectType])
-
-  const loadRiskTypes = async () => {
-    setLoadingRiskTypes(true)
-    try {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/dictionaries/risk-types?claimObjectTypeId=${claimObjectType}`,
-        {
-          method: "GET",
-          credentials: "include",
-        },
-      )
-      if (response.ok) {
-        const data = await response.json()
-        const riskTypeOptions = (data.items || []).map((item: any) => ({
-          value: String(item.id),
-          label: item.name,
-        }))
-        setRiskTypes(riskTypeOptions)
-      }
-    } catch (error) {
-      console.error("Error loading risk types:", error)
-    } finally {
-      setLoadingRiskTypes(false)
+    if (claimFormData.objectTypeId) {
+      setClaimObjectType(claimFormData.objectTypeId.toString())
     }
-  }
+  }, [claimFormData.objectTypeId])
 
-  const loadClaimStatuses = async () => {
-    setLoadingStatuses(true)
-    try {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/dictionaries/claim-statuses`,
-        {
-          method: "GET",
-          credentials: "include",
-        },
-      )
-      if (response.ok) {
-        const data = await response.json()
-        setClaimStatuses(data.items ?? [])
-      }
-    } catch (error) {
-      console.error("Error loading claim statuses:", error)
-    } finally {
-      setLoadingStatuses(false)
-    }
-  }
 
   const getInitialScheduleData = (): Partial<RepairSchedule> => ({
     eventId: "new",
@@ -487,62 +426,20 @@ export default function NewClaimPage() {
 
         <div className="flex-1 overflow-y-auto bg-gray-50">
           <div className="p-6 min-h-full">
-            {claimObjectType === "1" && (
-              <ClaimMainContent
-                activeClaimSection={activeClaimSection}
-                claimFormData={claimFormData}
-                handleFormChange={handleFormChange}
-                handleParticipantChange={handleParticipantChange}
-                handleDriverChange={handleDriverChange}
-                handleAddDriver={handleAddDriver}
-                handleRemoveDriver={handleRemoveDriver}
-                uploadedFiles={uploadedFiles}
-                setUploadedFiles={setUploadedFiles}
-                requiredDocuments={requiredDocuments}
-                setRequiredDocuments={setRequiredDocuments}
-                initialClaimObjectType={claimObjectType}
-              />
-            )}
-            {claimObjectType === "2" && (
-              <PropertyClaimForm
-                claimFormData={claimFormData}
-                handleFormChange={handleFormChange}
-                handleParticipantChange={handleParticipantChange}
-                handleDriverChange={handleDriverChange}
-                handleAddDriver={handleAddDriver}
-                handleRemoveDriver={handleRemoveDriver}
-                uploadedFiles={uploadedFiles}
-                setUploadedFiles={setUploadedFiles}
-                requiredDocuments={requiredDocuments}
-                setRequiredDocuments={setRequiredDocuments}
-                claimObjectType={claimObjectType}
-                setClaimObjectType={setClaimObjectType}
-                riskTypes={riskTypes}
-                loadingRiskTypes={loadingRiskTypes}
-                claimStatuses={claimStatuses}
-                loadingStatuses={loadingStatuses}
-              />
-            )}
-            {claimObjectType === "3" && (
-              <TransportClaimForm
-                claimFormData={claimFormData}
-                handleFormChange={handleFormChange}
-                handleParticipantChange={handleParticipantChange}
-                handleDriverChange={handleDriverChange}
-                handleAddDriver={handleAddDriver}
-                handleRemoveDriver={handleRemoveDriver}
-                uploadedFiles={uploadedFiles}
-                setUploadedFiles={setUploadedFiles}
-                requiredDocuments={requiredDocuments}
-                setRequiredDocuments={setRequiredDocuments}
-                claimObjectType={claimObjectType}
-                setClaimObjectType={setClaimObjectType}
-                riskTypes={riskTypes}
-                loadingRiskTypes={loadingRiskTypes}
-                claimStatuses={claimStatuses}
-                loadingStatuses={loadingStatuses}
-              />
-            )}
+            <ClaimMainContent
+              activeClaimSection={activeClaimSection}
+              claimFormData={claimFormData}
+              handleFormChange={handleFormChange}
+              handleParticipantChange={handleParticipantChange}
+              handleDriverChange={handleDriverChange}
+              handleAddDriver={handleAddDriver}
+              handleRemoveDriver={handleRemoveDriver}
+              uploadedFiles={uploadedFiles}
+              setUploadedFiles={setUploadedFiles}
+              requiredDocuments={requiredDocuments}
+              setRequiredDocuments={setRequiredDocuments}
+              initialClaimObjectType={claimObjectType}
+            />
 
             {/* Repair Schedules and Details Section */}
             {activeClaimSection === "harmonogram-naprawy" && (

--- a/components/claim-form/claim-form-sidebar.tsx
+++ b/components/claim-form/claim-form-sidebar.tsx
@@ -2,7 +2,23 @@
 
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
-import { FileText, AlertTriangle, Users, File, MessageSquare, FileCheck, Mail, Calendar, Wrench, Gavel, Shield, DollarSign, HandHeart, FileSignature } from 'lucide-react'
+import {
+  FileText,
+  AlertTriangle,
+  Users,
+  File,
+  MessageSquare,
+  FileCheck,
+  Mail,
+  Calendar,
+  Wrench,
+  Gavel,
+  Shield,
+  DollarSign,
+  HandHeart,
+  FileSignature,
+  UserCheck,
+} from 'lucide-react'
 
 interface ClaimFormSidebarProps {
   activeClaimSection: string
@@ -29,6 +45,11 @@ const sidebarSections = [
         id: "uczestnicy",
         label: "Uczestnicy zdarzenia",
         icon: Users,
+      },
+      {
+        id: "podwykonawca",
+        label: "Podwykonawca",
+        icon: UserCheck,
       },
       {
         id: "dokumenty",
@@ -102,12 +123,15 @@ const sidebarSections = [
 ]
 
 function ClaimFormSidebar({ activeClaimSection, setActiveClaimSection, claimObjectType }: ClaimFormSidebarProps) {
-  const sections = sidebarSections.map((section) => ({
-    ...section,
-    items: section.items.filter(
-      (item) => !(item.id === "uczestnicy" && claimObjectType === "3")
-    ),
-  }))
+  const sections = sidebarSections.map((section) => {
+    let items = section.items
+    if (claimObjectType === "3") {
+      items = items.filter((item) => item.id !== "uczestnicy")
+    } else {
+      items = items.filter((item) => item.id !== "podwykonawca")
+    }
+    return { ...section, items }
+  })
   return (
     <div className="w-64 bg-white border-r border-gray-200 h-full overflow-y-auto">
       <div className="p-3">

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -38,6 +38,11 @@ import { RepairScheduleSection } from "./repair-schedule-section"
 import { RepairDetailsSection } from "./repair-details-section"
 import { DamageDataSection } from "./damage-data-section"
 import type { RepairDetail } from "@/lib/repair-details-store"
+import { PropertyDamageSection } from "./property-damage-section"
+import { TransportDamageSection } from "./transport-damage-section"
+import { PropertyParticipantsSection } from "./property-participants-section"
+import InjuredPartySection from "./injured-party-section"
+import SubcontractorSection from "./subcontractor-section"
 
 interface RiskType {
   value: string
@@ -1575,90 +1580,113 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
             </CardContent>
           </Card>
 
-          {/* Uszkodzenia samochodu Card */}
-          <Card className="overflow-hidden shadow-sm border-gray-200 rounded-xl">
-            <CardHeader className="flex flex-row items-center space-x-4 bg-gradient-to-r from-blue-600 to-blue-700 text-white p-4">
-              <div className="w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center">
-                <Car className="h-4 w-4" />
-              </div>
-              <CardTitle className="text-lg font-semibold">Uszkodzenia samochodu</CardTitle>
-            </CardHeader>
-            <CardContent className="p-6 bg-white grid grid-cols-1 lg:grid-cols-2 gap-8">
-              <div className="space-y-6">
-                <div>
-                  <div className="relative z-10">
-                    <Label htmlFor="vehicleType" className="text-sm font-medium text-gray-700 mb-2 block">
-                      Rodzaj pojazdu
+          {claimObjectType === "1" && (
+            <Card className="overflow-hidden shadow-sm border-gray-200 rounded-xl">
+              <CardHeader className="flex flex-row items-center space-x-4 bg-gradient-to-r from-blue-600 to-blue-700 text-white p-4">
+                <div className="w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center">
+                  <Car className="h-4 w-4" />
+                </div>
+                <CardTitle className="text-lg font-semibold">Uszkodzenia samochodu</CardTitle>
+              </CardHeader>
+              <CardContent className="p-6 bg-white grid grid-cols-1 lg:grid-cols-2 gap-8">
+                <div className="space-y-6">
+                  <div>
+                    <div className="relative z-10">
+                      <Label htmlFor="vehicleType" className="text-sm font-medium text-gray-700 mb-2 block">
+                        Rodzaj pojazdu
+                      </Label>
+                      <div className="relative">
+                        <VehicleTypeDropdown
+                          selectedVehicleTypeId={claimFormData.vehicleTypeId}
+                          onVehicleTypeSelected={(event: VehicleTypeSelectionEvent) => {
+                            handleFormChange("vehicleType", event.vehicleTypeName)
+                            handleFormChange("vehicleTypeId", event.vehicleTypeId)
+                            handleFormChange("vehicleTypeCode", event.vehicleTypeCode)
+                          }}
+                          className="relative z-20"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div>
+                    <Label htmlFor="damageDescription" className="text-sm font-medium text-gray-700">
+                      Powstałe uszkodzenia opis
                     </Label>
-                    <div className="relative">
-                      <VehicleTypeDropdown
-                        selectedVehicleTypeId={claimFormData.vehicleTypeId}
-                        onVehicleTypeSelected={(event: VehicleTypeSelectionEvent) => {
-                          handleFormChange("vehicleType", event.vehicleTypeName)
-                          handleFormChange("vehicleTypeId", event.vehicleTypeId)
-                          handleFormChange("vehicleTypeCode", event.vehicleTypeCode)
-                        }}
-                        className="relative z-20"
-                      />
+                    <Textarea
+                      id="damageDescription"
+                      placeholder="Opisz uszkodzenia..."
+                      rows={3}
+                      value={claimFormData.damageDescription || ""}
+                      onChange={(e) => handleFormChange("damageDescription", e.target.value)}
+                      className="mt-1"
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-sm font-medium text-gray-700">Powstałe uszkodzenia</Label>
+                    <div className="p-4 border rounded-lg bg-gray-50 space-y-2 mt-2 max-h-60 overflow-y-auto">
+                      {claimFormData.damages && claimFormData.damages.length > 0 ? (
+                        claimFormData.damages.map((damage, index) => (
+                          <div
+                            key={damage.id || `${damage.description}-${damage.detail}`}
+                            className="flex items-center justify-between text-sm hover:bg-gray-100 p-2 rounded bg-white border"
+                          >
+                            <span className="font-medium">
+                              {index + 1}. {damage.description} {"-"}
+                              <span className="text-gray-600 font-normal">{damage.detail}</span>
+                            </span>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-6 w-6"
+                              onClick={() => removeDamageItem(damage.description)}
+                            >
+                              <X className="h-4 w-4 text-red-500" />
+                            </Button>
+                          </div>
+                        ))
+                      ) : (
+                        <p className="text-sm text-gray-500 text-center py-4">Wybierz uszkodzone części na diagramie.</p>
+                      )}
                     </div>
                   </div>
                 </div>
                 <div>
-                  <Label htmlFor="damageDescription" className="text-sm font-medium text-gray-700">
-                    Powstałe uszkodzenia opis
-                  </Label>
-                  <Textarea
-                    id="damageDescription"
-                    placeholder="Opisz uszkodzenia..."
-                    rows={3}
-                    value={claimFormData.damageDescription || ""}
-                    onChange={(e) => handleFormChange("damageDescription", e.target.value)}
-                    className="mt-1"
+                  <DamageDiagram
+                    damagedParts={(claimFormData.damages || []).map((d) => d.description)}
+                    onPartClick={handleDamagePartToggle}
                   />
                 </div>
-                <div>
-                  <Label className="text-sm font-medium text-gray-700">Powstałe uszkodzenia</Label>
-                  <div className="p-4 border rounded-lg bg-gray-50 space-y-2 mt-2 max-h-60 overflow-y-auto">
-                    {claimFormData.damages && claimFormData.damages.length > 0 ? (
-                      claimFormData.damages.map((damage, index) => (
-                        <div
-                          key={damage.id || `${damage.description}-${damage.detail}`}
-                          className="flex items-center justify-between text-sm hover:bg-gray-100 p-2 rounded bg-white border"
-                        >
-                          <span className="font-medium">
-                            {index + 1}. {damage.description} -{" "}
-                            <span className="text-gray-600 font-normal">{damage.detail}</span>
-                          </span>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-6 w-6"
-                            onClick={() => removeDamageItem(damage.description)}
-                          >
-                            <X className="h-4 w-4 text-red-500" />
-                          </Button>
-                        </div>
-                      ))
-                    ) : (
-                      <p className="text-sm text-gray-500 text-center py-4">Wybierz uszkodzone części na diagramie.</p>
-                    )}
-                  </div>
-                </div>
-              </div>
-              <div>
-                <DamageDiagram
-                  damagedParts={(claimFormData.damages || []).map((d) => d.description)}
-                  onPartClick={handleDamagePartToggle}
-                />
-              </div>
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
+          )}
+          {claimObjectType === "2" && (
+            <PropertyDamageSection
+              claimFormData={claimFormData}
+              handleFormChange={(field, value) => handleFormChange(field as keyof Claim, value)}
+            />
+          )}
+          {claimObjectType === "3" && (
+            <TransportDamageSection
+              claimFormData={claimFormData}
+              handleFormChange={(field, value) => handleFormChange(field as keyof Claim, value)}
+            />
+          )}
         </div>
       )
 
     case "uczestnicy":
       if (claimObjectType === "3") {
         return null
+      }
+      if (claimObjectType === "2") {
+        return (
+          <div className="space-y-4">
+            <PropertyParticipantsSection
+              claimFormData={claimFormData}
+              handleFormChange={(field, value) => handleFormChange(field as keyof Claim, value)}
+            />
+          </div>
+        )
       }
       return (
         <div className="space-y-4">
@@ -1686,28 +1714,32 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
           </Card>
 
           {/* Poszkodowany Card */}
-          <Card className="overflow-hidden shadow-sm border-gray-200 rounded-xl">
-            <CardHeader className="flex flex-row items-center space-x-4 bg-gradient-to-r from-blue-600 to-blue-700 text-white p-4">
-              <div className="w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center">
-                <User className="h-4 w-4" />
-              </div>
-              <CardTitle className="text-lg font-semibold">Poszkodowany</CardTitle>
-            </CardHeader>
-            <CardContent className="p-6 bg-white">
-              <ParticipantForm
-                title="Poszkodowany"
-                icon={<User className="h-5 w-5 text-blue-600" />}
-                participantData={getParticipantData("injuredParty")}
-                onParticipantChange={(field, value) => handleParticipantChange("injuredParty", field, value)}
-                onDriverChange={(driverIndex, field, value) =>
-                  handleDriverChange("injuredParty", driverIndex, field, value)
-                }
-                onAddDriver={() => handleAddDriver("injuredParty")}
-                onRemoveDriver={(index) => handleRemoveDriver("injuredParty", index)}
-                showInspectionContact
-              />
-            </CardContent>
-          </Card>
+          <InjuredPartySection
+            participantData={getParticipantData("injuredParty")}
+            onParticipantChange={(field, value) =>
+              handleParticipantChange("injuredParty", field, value)
+            }
+            onDriverChange={(driverIndex, field, value) =>
+              handleDriverChange("injuredParty", driverIndex, field, value)
+            }
+            onAddDriver={() => handleAddDriver("injuredParty")}
+            onRemoveDriver={(index) =>
+              handleRemoveDriver("injuredParty", index)
+            }
+          />
+        </div>
+      )
+
+    case "podwykonawca":
+      if (claimObjectType !== "3") {
+        return null
+      }
+      return (
+        <div className="space-y-4">
+          <SubcontractorSection
+            claimFormData={claimFormData}
+            handleFormChange={handleFormChange}
+          />
         </div>
       )
 

--- a/components/claim-form/injured-party-section.tsx
+++ b/components/claim-form/injured-party-section.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { User } from "lucide-react"
+import { ParticipantForm } from "./participant-form"
+import type { ParticipantInfo, DriverInfo } from "@/types"
+
+interface InjuredPartySectionProps {
+  participantData: ParticipantInfo
+  onParticipantChange: (field: keyof Omit<ParticipantInfo, "drivers">, value: any) => void
+  onDriverChange: (driverIndex: number, field: keyof DriverInfo, value: any) => void
+  onAddDriver: () => void
+  onRemoveDriver: (driverIndex: number) => void
+}
+
+export function InjuredPartySection({
+  participantData,
+  onParticipantChange,
+  onDriverChange,
+  onAddDriver,
+  onRemoveDriver,
+}: InjuredPartySectionProps) {
+  return (
+    <Card className="overflow-hidden shadow-sm border-gray-200 rounded-xl">
+      <CardHeader className="flex flex-row items-center space-x-4 bg-gradient-to-r from-blue-600 to-blue-700 text-white p-4">
+        <div className="w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center">
+          <User className="h-4 w-4" />
+        </div>
+        <CardTitle className="text-lg font-semibold">Poszkodowany</CardTitle>
+      </CardHeader>
+      <CardContent className="p-6 bg-white">
+        <ParticipantForm
+          title="Poszkodowany"
+          icon={<User className="h-5 w-5 text-blue-600" />}
+          participantData={participantData}
+          onParticipantChange={onParticipantChange}
+          onDriverChange={onDriverChange}
+          onAddDriver={onAddDriver}
+          onRemoveDriver={onRemoveDriver}
+          isVictim
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+export default InjuredPartySection
+


### PR DESCRIPTION
## Summary
- toggle sidebar to show Podwykonawca for transport claims and hide Participants
- conditionally render damage and participant sections based on selected claim object type
- use common ClaimMainContent for new claims and sync object type with form data
- extract injured party card into dedicated component

## Testing
- `pnpm lint` *(fails: requires interactive ESLint configuration)*
- `pnpm test` *(fails: tests failing in `use-damages.test.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a54dfee8832c864eae666ef9c224