### PR TITLE
feat: warn on unsaved form data

### DIFF
--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -14,6 +14,7 @@ import { useClaims } from '@/hooks/use-claims'
 import { useDamages } from '@/hooks/use-damages'
 import { useRouter } from 'next/navigation'
 import { useToast } from '@/hooks/use-toast'
+import { useUnsavedChangesWarning, UNSAVED_CHANGES_MESSAGE } from '@/hooks/use-unsaved-changes-warning'
 import type { Claim, ParticipantInfo, UploadedFile, RequiredDocument } from '@/types'
 
 interface ClaimFormProps {
@@ -25,6 +26,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
   const router = useRouter()
   const { createClaim, updateClaim, initializeClaim, loading, error } = useClaims()
   const { toast } = useToast()
+  useUnsavedChangesWarning(mode !== 'view')
   const initialized = useRef(false)
   const [formData, setFormData] = useState<Claim>({
     spartaNumber: '',
@@ -402,7 +404,11 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
             <Button
               type="button"
               variant="outline"
-              onClick={() => router.back()}
+              onClick={() => {
+                if (confirm(UNSAVED_CHANGES_MESSAGE)) {
+                  router.back()
+                }
+              }}
             >
               Anuluj
             </Button>

--- a/hooks/use-unsaved-changes-warning.ts
+++ b/hooks/use-unsaved-changes-warning.ts
@@ -1,0 +1,34 @@
+"use client"
+
+import { useEffect } from "react"
+
+export const UNSAVED_CHANGES_MESSAGE =
+  "Uwaga, twoje dane nie zostaną zapisane. Naciśnij OK, aby kontynuować, lub wróć do formularza."
+
+export function useUnsavedChangesWarning(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) return
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+      e.returnValue = UNSAVED_CHANGES_MESSAGE
+      return UNSAVED_CHANGES_MESSAGE
+    }
+
+    const handlePopState = () => {
+      if (!confirm(UNSAVED_CHANGES_MESSAGE)) {
+        history.pushState(null, "", window.location.href)
+      }
+    }
+
+    window.addEventListener("beforeunload", handleBeforeUnload)
+    window.addEventListener("popstate", handlePopState)
+    history.pushState(null, "", window.location.href)
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload)
+      window.removeEventListener("popstate", handlePopState)
+    }
+  }, [enabled])
+}
+


### PR DESCRIPTION
## Summary
- add custom hook to warn about unsaved changes and block browser back/refresh
- confirm cancellation before leaving the claim form

## Testing
- `npm test` *(fails: 1 failing test)*
- `npm run lint` *(prompted for configuration, no lint results)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a1062af0832c91eb341681849def