### PR TITLE
Add property and transport claim summaries

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -43,6 +43,8 @@ import { TransportDamageSection } from "./transport-damage-section"
 import { PropertyParticipantsSection } from "./property-participants-section"
 import InjuredPartySection from "./injured-party-section"
 import SubcontractorSection from "./subcontractor-section"
+import { PropertyClaimSummary } from "./property-claim-summary"
+import { TransportClaimSummary } from "./transport-claim-summary"
 
 interface RiskType {
   value: string
@@ -2293,8 +2295,34 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
       )
 
     case "teczka-szkodowa": {
-    const visibleNotes = notes.filter((note) => !note.type || note.type === "note")
-    return (
+    switch (claimObjectType) {
+      case "2":
+        return (
+          <PropertyClaimSummary
+            claimFormData={claimFormData}
+            notes={notes}
+            uploadedFiles={uploadedFiles}
+            setUploadedFiles={setUploadedFiles}
+            eventId={eventId}
+            claimStatuses={claimStatuses}
+            riskTypes={riskTypes}
+          />
+        )
+      case "3":
+        return (
+          <TransportClaimSummary
+            claimFormData={claimFormData}
+            notes={notes}
+            uploadedFiles={uploadedFiles}
+            setUploadedFiles={setUploadedFiles}
+            eventId={eventId}
+            claimStatuses={claimStatuses}
+            riskTypes={riskTypes}
+          />
+        )
+      default: {
+        const visibleNotes = notes.filter((note) => !note.type || note.type === "note")
+        return (
       <div className="space-y-4">
         <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
           {/* Left Column - DANE SZKODY I ZDARZENIA */}
@@ -2825,6 +2853,8 @@ const renderParticipantDetails = (participant: ParticipantInfo | undefined, titl
         </div>
       </div>
     )
+      }
+    }
     }
 
     default:

--- a/components/claim-form/property-claim-summary.tsx
+++ b/components/claim-form/property-claim-summary.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { FileText, MessageSquare } from "lucide-react"
+import { DocumentsSection } from "../documents-section"
+import { PropertyDamageSection } from "./property-damage-section"
+import { PropertyParticipantsSection } from "./property-participants-section"
+import type { Claim, Note, UploadedFile } from "@/types"
+
+interface RiskType {
+  value: string
+  label: string
+}
+
+interface ClaimStatus {
+  id: number
+  name: string
+  description: string
+}
+
+interface PropertyClaimSummaryProps {
+  claimFormData: Partial<Claim>
+  notes: Note[]
+  uploadedFiles: UploadedFile[]
+  setUploadedFiles: React.Dispatch<React.SetStateAction<UploadedFile[]>>
+  eventId?: string
+  claimStatuses: ClaimStatus[]
+  riskTypes: RiskType[]
+}
+
+export function PropertyClaimSummary({
+  claimFormData,
+  notes,
+  uploadedFiles,
+  setUploadedFiles,
+  eventId,
+}: PropertyClaimSummaryProps) {
+  const visibleNotes = notes.filter((note) => !note.type || note.type === "note")
+
+  return (
+    <div className="space-y-4">
+      <PropertyParticipantsSection
+        claimFormData={claimFormData}
+        handleFormChange={() => {}}
+      />
+
+      <PropertyDamageSection
+        claimFormData={claimFormData}
+        handleFormChange={() => {}}
+      />
+
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
+          <div className="flex items-center space-x-2">
+            <FileText className="h-4 w-4 text-blue-600" />
+            <h3 className="text-sm font-semibold text-gray-900">Dokumenty</h3>
+          </div>
+        </div>
+        <div className="p-4">
+          {eventId && (
+            <DocumentsSection
+              uploadedFiles={uploadedFiles}
+              setUploadedFiles={setUploadedFiles}
+              requiredDocuments={[]}
+              setRequiredDocuments={() => {}}
+              eventId={eventId}
+              hideRequiredDocuments={true}
+              storageKey={`summary-documents-${eventId}`}
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
+          <div className="flex items-center space-x-2">
+            <MessageSquare className="h-4 w-4 text-blue-600" />
+            <h3 className="text-sm font-semibold text-gray-900">Notatki</h3>
+          </div>
+        </div>
+        <div className="p-4">
+          {visibleNotes.length > 0 ? (
+            <div className="space-y-3">
+              {visibleNotes.map((note) => (
+                <div
+                  key={note.id}
+                  className="border-l-4 border-blue-500 pl-4 py-2 bg-gray-50 rounded-r-lg"
+                >
+                  <h4 className="font-medium text-gray-900 text-sm">{note.title}</h4>
+                  <p className="text-sm text-gray-600 mt-1">{note.description}</p>
+                  <div className="flex items-center space-x-4 text-xs text-gray-500 mt-2">
+                    {note.user && <span>{note.user}</span>}
+                    {note.createdAt && (
+                      <span>{new Date(note.createdAt).toLocaleDateString("pl-PL")}</span>
+                    )}
+                    {note.dueDate && (
+                      <span>Termin: {new Date(note.dueDate).toLocaleDateString("pl-PL")}</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-8">
+              <MessageSquare className="h-12 w-12 text-gray-300 mx-auto mb-4" />
+              <p className="text-gray-500">Brak notatek</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PropertyClaimSummary
+

--- a/components/claim-form/transport-claim-summary.tsx
+++ b/components/claim-form/transport-claim-summary.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import { FileText, MessageSquare } from "lucide-react"
+import { DocumentsSection } from "../documents-section"
+import { TransportDamageSection } from "./transport-damage-section"
+import { TransportParticipantsSection } from "./transport-participants-section"
+import type { Claim, Note, UploadedFile } from "@/types"
+
+interface RiskType {
+  value: string
+  label: string
+}
+
+interface ClaimStatus {
+  id: number
+  name: string
+  description: string
+}
+
+interface TransportClaimSummaryProps {
+  claimFormData: Partial<Claim>
+  notes: Note[]
+  uploadedFiles: UploadedFile[]
+  setUploadedFiles: React.Dispatch<React.SetStateAction<UploadedFile[]>>
+  eventId?: string
+  claimStatuses: ClaimStatus[]
+  riskTypes: RiskType[]
+}
+
+export function TransportClaimSummary({
+  claimFormData,
+  notes,
+  uploadedFiles,
+  setUploadedFiles,
+  eventId,
+}: TransportClaimSummaryProps) {
+  const visibleNotes = notes.filter((note) => !note.type || note.type === "note")
+
+  return (
+    <div className="space-y-4">
+      <TransportParticipantsSection
+        claimFormData={claimFormData}
+        handleFormChange={() => {}}
+      />
+
+      <TransportDamageSection
+        claimFormData={claimFormData}
+        handleFormChange={() => {}}
+        disabled
+      />
+
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
+          <div className="flex items-center space-x-2">
+            <FileText className="h-4 w-4 text-blue-600" />
+            <h3 className="text-sm font-semibold text-gray-900">Dokumenty</h3>
+          </div>
+        </div>
+        <div className="p-4">
+          {eventId && (
+            <DocumentsSection
+              uploadedFiles={uploadedFiles}
+              setUploadedFiles={setUploadedFiles}
+              requiredDocuments={[]}
+              setRequiredDocuments={() => {}}
+              eventId={eventId}
+              hideRequiredDocuments={true}
+              storageKey={`summary-documents-${eventId}`}
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
+          <div className="flex items-center space-x-2">
+            <MessageSquare className="h-4 w-4 text-blue-600" />
+            <h3 className="text-sm font-semibold text-gray-900">Notatki</h3>
+          </div>
+        </div>
+        <div className="p-4">
+          {visibleNotes.length > 0 ? (
+            <div className="space-y-3">
+              {visibleNotes.map((note) => (
+                <div
+                  key={note.id}
+                  className="border-l-4 border-blue-500 pl-4 py-2 bg-gray-50 rounded-r-lg"
+                >
+                  <h4 className="font-medium text-gray-900 text-sm">{note.title}</h4>
+                  <p className="text-sm text-gray-600 mt-1">{note.description}</p>
+                  <div className="flex items-center space-x-4 text-xs text-gray-500 mt-2">
+                    {note.user && <span>{note.user}</span>}
+                    {note.createdAt && (
+                      <span>{new Date(note.createdAt).toLocaleDateString("pl-PL")}</span>
+                    )}
+                    {note.dueDate && (
+                      <span>Termin: {new Date(note.dueDate).toLocaleDateString("pl-PL")}</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-8">
+              <MessageSquare className="h-12 w-12 text-gray-300 mx-auto mb-4" />
+              <p className="text-gray-500">Brak notatek</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TransportClaimSummary
+


### PR DESCRIPTION
## Summary
- Add dedicated property claim summary component with participants, damages, documents, and notes sections
- Add dedicated transport claim summary component mirroring property structure
- Extend claim main content to choose summary based on claim object type

## Testing
- `pnpm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f557be8c832c82a2322209676203