### PR TITLE
Refactor repair sections UI

### DIFF
--- a/backend/Controllers/RepairSchedulesController.cs
+++ b/backend/Controllers/RepairSchedulesController.cs
@@ -37,23 +37,19 @@ namespace AutomotiveClaimsApi.Controllers
         [HttpPost]
         public ActionResult<RepairScheduleDto> CreateSchedule([FromBody] CreateRepairScheduleDto createDto)
         {
-            if (string.IsNullOrWhiteSpace(createDto.VehicleFleetNumber) ||
-                string.IsNullOrWhiteSpace(createDto.VehicleRegistration) ||
-                string.IsNullOrWhiteSpace(createDto.DamageDate))
+            if (string.IsNullOrWhiteSpace(createDto.VehicleFleetNumber))
             {
-                return BadRequest("VehicleFleetNumber, VehicleRegistration, and DamageDate are required.");
+                return BadRequest("VehicleFleetNumber is required.");
             }
 
             var schedule = new RepairSchedule
             {
                 Id = Guid.NewGuid(),
                 EventId = createDto.EventId,
+                BranchId = createDto.BranchId,
                 CompanyName = createDto.CompanyName,
-                DamageNumber = createDto.DamageNumber,
                 VehicleFleetNumber = createDto.VehicleFleetNumber,
                 VehicleRegistration = createDto.VehicleRegistration,
-                DamageDate = createDto.DamageDate,
-                DamageTime = createDto.DamageTime,
                 ExpertWaitingDate = createDto.ExpertWaitingDate,
                 AdditionalInspections = createDto.AdditionalInspections,
                 RepairStartDate = createDto.RepairStartDate,
@@ -81,17 +77,11 @@ namespace AutomotiveClaimsApi.Controllers
 
             if (updateDto.VehicleFleetNumber != null && string.IsNullOrWhiteSpace(updateDto.VehicleFleetNumber))
                 return BadRequest("VehicleFleetNumber is required.");
-            if (updateDto.VehicleRegistration != null && string.IsNullOrWhiteSpace(updateDto.VehicleRegistration))
-                return BadRequest("VehicleRegistration is required.");
-            if (updateDto.DamageDate != null && string.IsNullOrWhiteSpace(updateDto.DamageDate))
-                return BadRequest("DamageDate is required.");
 
             if (updateDto.CompanyName != null) schedule.CompanyName = updateDto.CompanyName;
-            if (updateDto.DamageNumber != null) schedule.DamageNumber = updateDto.DamageNumber;
+            if (updateDto.BranchId != null) schedule.BranchId = updateDto.BranchId;
             if (updateDto.VehicleFleetNumber != null) schedule.VehicleFleetNumber = updateDto.VehicleFleetNumber;
             if (updateDto.VehicleRegistration != null) schedule.VehicleRegistration = updateDto.VehicleRegistration;
-            if (updateDto.DamageDate != null) schedule.DamageDate = updateDto.DamageDate;
-            if (updateDto.DamageTime != null) schedule.DamageTime = updateDto.DamageTime;
             if (updateDto.ExpertWaitingDate != null) schedule.ExpertWaitingDate = updateDto.ExpertWaitingDate;
             if (updateDto.AdditionalInspections != null) schedule.AdditionalInspections = updateDto.AdditionalInspections;
             if (updateDto.RepairStartDate != null) schedule.RepairStartDate = updateDto.RepairStartDate;

--- a/backend/DTOs/CreateRepairScheduleDto.cs
+++ b/backend/DTOs/CreateRepairScheduleDto.cs
@@ -6,15 +6,11 @@ namespace AutomotiveClaimsApi.DTOs
     public class CreateRepairScheduleDto
     {
         public Guid EventId { get; set; }
+        public string? BranchId { get; set; }
         public string? CompanyName { get; set; }
-        public string? DamageNumber { get; set; }
         [Required]
         public string VehicleFleetNumber { get; set; } = string.Empty;
-        [Required]
-        public string VehicleRegistration { get; set; } = string.Empty;
-        [Required]
-        public string DamageDate { get; set; } = string.Empty;
-        public string? DamageTime { get; set; }
+        public string? VehicleRegistration { get; set; }
         public string? ExpertWaitingDate { get; set; }
         public string? AdditionalInspections { get; set; }
         public string? RepairStartDate { get; set; }

--- a/backend/DTOs/RepairScheduleDto.cs
+++ b/backend/DTOs/RepairScheduleDto.cs
@@ -7,12 +7,10 @@ namespace AutomotiveClaimsApi.DTOs
     {
         public Guid Id { get; set; }
         public Guid EventId { get; set; }
+        public string? BranchId { get; set; }
         public string? CompanyName { get; set; }
-        public string? DamageNumber { get; set; }
         public string? VehicleFleetNumber { get; set; }
         public string? VehicleRegistration { get; set; }
-        public string? DamageDate { get; set; }
-        public string? DamageTime { get; set; }
         public string? ExpertWaitingDate { get; set; }
         public string? AdditionalInspections { get; set; }
         public string? RepairStartDate { get; set; }
@@ -32,12 +30,10 @@ namespace AutomotiveClaimsApi.DTOs
             {
                 Id = schedule.Id,
                 EventId = schedule.EventId,
+                BranchId = schedule.BranchId,
                 CompanyName = schedule.CompanyName,
-                DamageNumber = schedule.DamageNumber,
                 VehicleFleetNumber = schedule.VehicleFleetNumber,
                 VehicleRegistration = schedule.VehicleRegistration,
-                DamageDate = schedule.DamageDate,
-                DamageTime = schedule.DamageTime,
                 ExpertWaitingDate = schedule.ExpertWaitingDate,
                 AdditionalInspections = schedule.AdditionalInspections,
                 RepairStartDate = schedule.RepairStartDate,

--- a/backend/DTOs/UpdateRepairScheduleDto.cs
+++ b/backend/DTOs/UpdateRepairScheduleDto.cs
@@ -5,11 +5,9 @@ namespace AutomotiveClaimsApi.DTOs
     public class UpdateRepairScheduleDto
     {
         public string? CompanyName { get; set; }
-        public string? DamageNumber { get; set; }
+        public string? BranchId { get; set; }
         public string? VehicleFleetNumber { get; set; }
         public string? VehicleRegistration { get; set; }
-        public string? DamageDate { get; set; }
-        public string? DamageTime { get; set; }
         public string? ExpertWaitingDate { get; set; }
         public string? AdditionalInspections { get; set; }
         public string? RepairStartDate { get; set; }

--- a/backend/Models/RepairSchedule.cs
+++ b/backend/Models/RepairSchedule.cs
@@ -6,12 +6,10 @@ namespace AutomotiveClaimsApi.Models
     {
         public Guid Id { get; set; }
         public Guid EventId { get; set; }
+        public string? BranchId { get; set; }
         public string? CompanyName { get; set; }
-        public string? DamageNumber { get; set; }
         public string? VehicleFleetNumber { get; set; }
         public string? VehicleRegistration { get; set; }
-        public string? DamageDate { get; set; }
-        public string? DamageTime { get; set; }
         public string? ExpertWaitingDate { get; set; }
         public string? AdditionalInspections { get; set; }
         public string? RepairStartDate { get; set; }

--- a/components/claim-form/repair-details-section.tsx
+++ b/components/claim-form/repair-details-section.tsx
@@ -1,125 +1,109 @@
 "use client"
 
-import type React from "react"
-import { useState, useEffect } from "react"
+import React, { useEffect, useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Badge } from "@/components/ui/badge"
-import { Trash2, Plus, Save, Edit, X } from 'lucide-react'
 import { useToast } from "@/hooks/use-toast"
 import {
-  getRepairDetails,
   createRepairDetail,
-  updateRepairDetail,
   deleteRepairDetail,
+  getRepairDetails,
+  updateRepairDetail,
   repairDetailUpsertSchema,
   type RepairDetail,
 } from "@/lib/api/repair-details"
 import { pksData, type Employee } from "@/lib/pks-data"
+import {
+  Plus,
+  Trash2,
+  Save,
+  Edit,
+  X,
+  Building2,
+  User,
+  Car,
+  Calendar,
+  Timer,
+  Wrench,
+  FileText,
+  CheckCircle2,
+  AlertTriangle,
+} from "lucide-react"
 
 interface RepairDetailsSectionProps {
   eventId: string
-  autoShowForm?: boolean
-  onAutoShowFormHandled?: () => void
 }
 
-export function RepairDetailsSection({
-  eventId,
-  autoShowForm,
-  onAutoShowFormHandled,
-}: RepairDetailsSectionProps) {
-  const [repairDetails, setRepairDetails] = useState<RepairDetail[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [editingId, setEditingId] = useState<string | null>(null)
-  const [employeesForSelectedBranch, setEmployeesForSelectedBranch] = useState<Employee[]>([])
-  const [isFormVisible, setIsFormVisible] = useState(false)
+const initialFormData: Omit<RepairDetail, "id" | "eventId" | "createdAt" | "updatedAt"> = {
+  branchId: "",
+  employeeEmail: "",
+  replacementVehicleRequired: false,
+  replacementVehicleInfo: "",
+  vehicleTabNumber: "",
+  vehicleRegistration: "",
+  damageDateTime: "",
+  appraiserWaitingDate: "",
+  repairStartDate: "",
+  repairEndDate: "",
+  otherVehiclesAvailable: false,
+  otherVehiclesInfo: "",
+  bodyworkHours: 0,
+  paintingHours: 0,
+  assemblyHours: 0,
+  otherWorkHours: 0,
+  otherWorkDescription: "",
+  damageDescription: "",
+  additionalDescription: "",
+  status: "draft",
+}
+
+export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ eventId }) => {
   const { toast } = useToast()
-
-  const getInitialFormData = (): Omit<RepairDetail, "id" | "eventId" | "createdAt" | "updatedAt"> => ({
-    branchId: "",
-    employeeEmail: "",
-    replacementVehicleRequired: false,
-    replacementVehicleInfo: "",
-    vehicleTabNumber: "",
-    vehicleRegistration: "",
-    damageDateTime: "",
-    appraiserWaitingDate: "",
-    repairStartDate: "",
-    repairEndDate: "",
-    otherVehiclesAvailable: false,
-    otherVehiclesInfo: "",
-    bodyworkHours: 0,
-    paintingHours: 0,
-    assemblyHours: 0,
-    otherWorkHours: 0,
-    otherWorkDescription: "",
-    damageDescription: "",
-    additionalDescription: "",
-    status: "draft" as const,
-  })
-
-  const [formData, setFormData] = useState(getInitialFormData())
+  const [details, setDetails] = useState<RepairDetail[]>([])
+  const [loading, setLoading] = useState(true)
+  const [editing, setEditing] = useState<RepairDetail | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [formData, setFormData] = useState(initialFormData)
+  const [employees, setEmployees] = useState<Employee[]>([])
 
   useEffect(() => {
-    fetchRepairDetails()
+    loadDetails()
   }, [eventId])
 
-  useEffect(() => {
-    if (formData.branchId) {
-      const selectedBranch = pksData.find((branch) => branch.id === formData.branchId)
-      setEmployeesForSelectedBranch(selectedBranch ? selectedBranch.employees : [])
-    } else {
-      setEmployeesForSelectedBranch([])
+  const loadDetails = async () => {
+    try {
+      setLoading(true)
+      const data = await getRepairDetails(eventId)
+      setDetails(data)
+    } catch (error) {
+      console.error("Error loading repair details:", error)
+      toast({ title: "Błąd", description: "Nie udało się załadować szczegółów naprawy", variant: "destructive" })
+    } finally {
+      setLoading(false)
     }
-  }, [formData.branchId])
+  }
 
   const handleBranchChange = (branchId: string) => {
-    setFormData({ ...formData, branchId, employeeEmail: "" })
+    const branch = pksData.find((b) => b.id === branchId)
+    setEmployees(branch ? branch.employees : [])
+    setFormData((prev) => ({ ...prev, branchId, employeeEmail: "" }))
   }
 
-  const fetchRepairDetails = async () => {
-    try {
-      setIsLoading(true)
-      const data = await getRepairDetails(eventId)
-      setRepairDetails(data)
-    } catch (error) {
-      console.error("Error fetching repair details:", error)
-      toast({
-        title: "Błąd",
-        description: error instanceof Error ? error.message : "Nie udało się pobrać szczegółów naprawy",
-        variant: "destructive",
-      })
-    } finally {
-      setIsLoading(false)
-    }
+  const resetForm = () => {
+    setFormData(initialFormData)
+    setEditing(null)
+    setShowForm(false)
   }
-
-  const handleAddNewClick = () => {
-    resetForm()
-    setIsFormVisible(true)
-  }
-
-  const handleCancelClick = () => {
-    resetForm()
-    setIsFormVisible(false)
-  }
-
-  useEffect(() => {
-    if (autoShowForm) {
-      handleAddNewClick()
-      onAutoShowFormHandled?.()
-    }
-  }, [autoShowForm])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     const validation = repairDetailUpsertSchema.safeParse({ ...formData, eventId })
-
     if (!validation.success) {
       toast({
         title: "Błąd",
@@ -130,712 +114,546 @@ export function RepairDetailsSection({
     }
 
     try {
-      if (editingId) {
-        await updateRepairDetail(editingId, { ...formData, eventId })
-        toast({
-          title: "Sukces",
-          description: "Opis naprawy został zaktualizowany",
-        })
+      if (editing) {
+        await updateRepairDetail(editing.id, { ...formData, eventId })
+        toast({ title: "Sukces", description: "Opis naprawy został zaktualizowany" })
       } else {
         await createRepairDetail({ ...formData, eventId })
-        toast({
-          title: "Sukces",
-          description: "Opis naprawy został dodany",
-        })
+        toast({ title: "Sukces", description: "Opis naprawy został dodany" })
       }
       resetForm()
-      fetchRepairDetails()
-      setIsFormVisible(false)
+      loadDetails()
     } catch (error) {
-      console.error("Error saving repair details:", error)
-      toast({
-        title: "Błąd",
-        description: error instanceof Error ? error.message : "Nie udało się zapisać opisu naprawy",
-        variant: "destructive",
-      })
+      console.error("Error saving repair detail:", error)
+      toast({ title: "Błąd", description: "Nie udało się zapisać opisu", variant: "destructive" })
     }
   }
 
   const handleEdit = (detail: RepairDetail) => {
     setFormData({
-      ...detail,
-      damageDateTime: detail.damageDateTime ? new Date(detail.damageDateTime).toISOString().slice(0, 16) : "",
-      appraiserWaitingDate: detail.appraiserWaitingDate
-        ? new Date(detail.appraiserWaitingDate).toISOString().slice(0, 10)
+      branchId: detail.branchId,
+      employeeEmail: detail.employeeEmail,
+      replacementVehicleRequired: detail.replacementVehicleRequired,
+      replacementVehicleInfo: detail.replacementVehicleInfo || "",
+      vehicleTabNumber: detail.vehicleTabNumber,
+      vehicleRegistration: detail.vehicleRegistration,
+      damageDateTime: detail.damageDateTime
+        ? new Date(detail.damageDateTime).toISOString().slice(0, 16)
         : "",
-      repairStartDate: detail.repairStartDate ? new Date(detail.repairStartDate).toISOString().slice(0, 10) : "",
-      repairEndDate: detail.repairEndDate ? new Date(detail.repairEndDate).toISOString().slice(0, 10) : "",
+      appraiserWaitingDate: detail.appraiserWaitingDate ? detail.appraiserWaitingDate.slice(0, 10) : "",
+      repairStartDate: detail.repairStartDate ? detail.repairStartDate.slice(0, 10) : "",
+      repairEndDate: detail.repairEndDate ? detail.repairEndDate.slice(0, 10) : "",
+      otherVehiclesAvailable: detail.otherVehiclesAvailable,
+      otherVehiclesInfo: detail.otherVehiclesInfo || "",
+      bodyworkHours: detail.bodyworkHours,
+      paintingHours: detail.paintingHours,
+      assemblyHours: detail.assemblyHours,
+      otherWorkHours: detail.otherWorkHours,
+      otherWorkDescription: detail.otherWorkDescription || "",
+      damageDescription: detail.damageDescription || "",
+      additionalDescription: detail.additionalDescription || "",
+      status: detail.status,
     })
-    setEditingId(detail.id)
-    setIsFormVisible(true)
+    handleBranchChange(detail.branchId)
+    setEditing(detail)
+    setShowForm(true)
   }
 
   const handleDelete = async (id: string) => {
-    if (!confirm("Czy na pewno chcesz usunąć ten opis naprawy?")) return
-
+    if (!confirm("Czy na pewno chcesz usunąć opis?")) return
     try {
       await deleteRepairDetail(id)
-      toast({
-        title: "Sukces",
-        description: "Opis naprawy został usunięty",
-      })
-      fetchRepairDetails()
+      toast({ title: "Sukces", description: "Opis naprawy został usunięty" })
+      loadDetails()
     } catch (error) {
-      console.error("Error deleting repair details:", error)
-      toast({
-        title: "Błąd",
-        description: error instanceof Error ? error.message : "Nie udało się usunąć opisu naprawy",
-        variant: "destructive",
-      })
+      console.error("Error deleting repair detail:", error)
+      toast({ title: "Błąd", description: "Nie udało się usunąć opisu", variant: "destructive" })
     }
-  }
-
-  const resetForm = () => {
-    setFormData(getInitialFormData())
-    setEditingId(null)
   }
 
   const getStatusBadge = (status: RepairDetail["status"]) => {
     const statusConfig = {
-      draft: { label: "Szkic", variant: "secondary" as const },
-      "in-progress": { label: "W trakcie", variant: "default" as const },
-      completed: { label: "Zakończony", variant: "default" as const },
+      draft: { label: "Szkic", icon: FileText, className: "status-draft" },
+      "in-progress": { label: "W trakcie", icon: Timer, className: "status-in-progress" },
+      completed: { label: "Zakończony", icon: CheckCircle2, className: "status-completed" },
     }
-
     const config = statusConfig[status]
-    return <Badge variant={config.variant}>{config.label}</Badge>
-  }
-
-  const getTotalHours = () => {
-    return formData.bodyworkHours + formData.paintingHours + formData.assemblyHours + formData.otherWorkHours
-  }
-
-  if (isLoading) {
+    const Icon = config.icon
     return (
-      <div className="flex items-center justify-center p-8">
-        <div className="text-center space-y-2">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mx-auto"></div>
-          <p className="text-gray-500">Ładowanie...</p>
+      <Badge className={`${config.className} flex items-center gap-1 px-2 py-1 rounded-lg`}> 
+        <Icon className="h-3 w-3" /> {config.label}
+      </Badge>
+    )
+  }
+
+  const formatDate = (value: string) => {
+    if (!value) return "-"
+    return new Date(value).toLocaleDateString("pl-PL")
+  }
+
+  const getTotalHours = (detail: RepairDetail) => {
+    return detail.bodyworkHours + detail.paintingHours + detail.assemblyHours + detail.otherWorkHours
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="text-center space-y-4">
+          <div className="w-16 h-16 border-4 border-primary/20 border-t-primary rounded-full animate-spin mx-auto" />
+          <p className="text-muted-foreground">Ładowanie szczegółów naprawy...</p>
         </div>
       </div>
     )
   }
 
   return (
-    <div className="space-y-6">
-      <div className="px-6">
-        {!isFormVisible && (
-          <div className="mb-6 flex justify-end">
-            <Button onClick={handleAddNewClick} className="bg-[#1a3a6c] hover:bg-[#15305a]">
-              <Plus className="h-4 w-4 mr-2" />
-              Dodaj nowy opis
-            </Button>
+    <div className="space-y-8 animate-fade-in">
+      <div className="relative overflow-hidden rounded-2xl bg-card p-8 border border-border shadow-sm">
+        <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-8">
+          <div className="flex items-center gap-3">
+            <div className="p-3 bg-primary/10 rounded-xl border border-primary/20">
+              <Wrench className="h-8 w-8 text-primary" />
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold text-foreground">Szczegóły naprawy</h1>
+              <p className="text-muted-foreground text-lg">Opis wykonanych prac</p>
+            </div>
           </div>
-        )}
+          <Button onClick={() => setShowForm(true)} className="bg-primary hover:bg-primary/90 text-primary-foreground px-6 py-3 rounded-xl shadow">
+            <Plus className="h-5 w-5 mr-2" /> Nowy opis
+          </Button>
+        </div>
+      </div>
 
-        {/* Form Section */}
-        {isFormVisible && (
-          <Card className="border-gray-200 shadow-sm mb-6">
-            <CardHeader className="bg-gray-50 border-b">
-              <div className="flex justify-between items-center">
-                <CardTitle className="text-lg text-gray-700">
-                  {editingId ? "Edytuj opis naprawy" : "Dodaj opis naprawy"}
-                </CardTitle>
+      {showForm && (
+        <Card className="border shadow-lg bg-card animate-scale-in">
+          <CardHeader className="bg-muted/30 border-b border-border rounded-t-xl">
+            <div className="flex items-center justify-between">
+              <CardTitle className="flex items-center gap-4 text-2xl">
+                <div className="p-3 bg-primary/15 rounded-xl border border-primary/20">
+                  <FileText className="h-6 w-6 text-primary" />
+                </div>
+                <div>{editing ? "Edytuj opis naprawy" : "Nowy opis naprawy"}</div>
+              </CardTitle>
+              <Button variant="ghost" size="icon" onClick={resetForm} className="rounded-xl hover:bg-destructive/10 hover:text-destructive">
+                <X className="h-5 w-5" />
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="p-8">
+            <form onSubmit={handleSubmit} className="space-y-8">
+              {/* Basic information */}
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                  <Car className="h-5 w-5 text-primary" />
+                  Informacje podstawowe
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div className="space-y-3">
+                    <Label htmlFor="branch" className="flex items-center gap-2 text-sm font-semibold">
+                      <Building2 className="h-4 w-4 text-primary" /> Oddział
+                    </Label>
+                    <Select value={formData.branchId} onValueChange={handleBranchChange}>
+                      <SelectTrigger id="branch" className="h-12 rounded-xl border-border">
+                        <SelectValue placeholder="Wybierz oddział" />
+                      </SelectTrigger>
+                      <SelectContent className="rounded-xl">
+                        {pksData.map((branch) => (
+                          <SelectItem key={branch.id} value={branch.id} className="rounded-lg">
+                            {branch.company} - {branch.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-3">
+                    <Label htmlFor="employee" className="flex items-center gap-2 text-sm font-semibold">
+                      <User className="h-4 w-4 text-primary" /> Pracownik
+                    </Label>
+                    <Select
+                      value={formData.employeeEmail}
+                      onValueChange={(value) => setFormData((p) => ({ ...p, employeeEmail: value }))}
+                      disabled={!formData.branchId}
+                    >
+                      <SelectTrigger id="employee" className="h-12 rounded-xl border-border">
+                        <SelectValue placeholder="Wybierz pracownika" />
+                      </SelectTrigger>
+                      <SelectContent className="rounded-xl">
+                        {employees.map((emp) => (
+                          <SelectItem key={emp.email} value={emp.email} className="rounded-lg">
+                            {emp.name} ({emp.role})
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-3">
+                    <Label htmlFor="vehicleTabNumber">Nr taborowy</Label>
+                    <Input
+                      id="vehicleTabNumber"
+                      value={formData.vehicleTabNumber}
+                      onChange={(e) => setFormData((p) => ({ ...p, vehicleTabNumber: e.target.value }))}
+                      className="h-12 rounded-xl border-border"
+                      required
+                    />
+                  </div>
+                  <div className="space-y-3">
+                    <Label htmlFor="vehicleRegistration">Nr rejestracyjny</Label>
+                    <Input
+                      id="vehicleRegistration"
+                      value={formData.vehicleRegistration}
+                      onChange={(e) => setFormData((p) => ({ ...p, vehicleRegistration: e.target.value }))}
+                      className="h-12 rounded-xl border-border"
+                      required
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {/* Dates */}
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                  <Calendar className="h-5 w-5 text-primary" /> Daty i terminy
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div className="space-y-3">
+                    <Label htmlFor="damageDateTime">Data i godzina szkody</Label>
+                    <Input
+                      id="damageDateTime"
+                      type="datetime-local"
+                      value={formData.damageDateTime}
+                      onChange={(e) => setFormData((p) => ({ ...p, damageDateTime: e.target.value }))}
+                      className="h-12 rounded-xl border-border"
+                      required
+                    />
+                  </div>
+                  <div className="space-y-3">
+                    <Label htmlFor="appraiserWaitingDate">Oczekiwanie na rzeczoznawcę</Label>
+                    <Input
+                      id="appraiserWaitingDate"
+                      type="date"
+                      value={formData.appraiserWaitingDate}
+                      onChange={(e) => setFormData((p) => ({ ...p, appraiserWaitingDate: e.target.value }))}
+                      className="h-12 rounded-xl border-border"
+                      required
+                    />
+                  </div>
+                  <div className="space-y-3">
+                    <Label htmlFor="repairStartDate">Przystąpienie do naprawy</Label>
+                    <Input
+                      id="repairStartDate"
+                      type="date"
+                      value={formData.repairStartDate}
+                      onChange={(e) => setFormData((p) => ({ ...p, repairStartDate: e.target.value }))}
+                      className="h-12 rounded-xl border-border"
+                      required
+                    />
+                  </div>
+                  <div className="space-y-3">
+                    <Label htmlFor="repairEndDate">Zakończenie naprawy</Label>
+                    <Input
+                      id="repairEndDate"
+                      type="date"
+                      value={formData.repairEndDate}
+                      onChange={(e) => setFormData((p) => ({ ...p, repairEndDate: e.target.value }))}
+                      className="h-12 rounded-xl border-border"
+                      required
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {/* Damage description */}
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                  <AlertTriangle className="h-5 w-5 text-accent" /> Opis uszkodzeń
+                </h3>
+                <Textarea
+                  id="damageDescription"
+                  value={formData.damageDescription}
+                  onChange={(e) => setFormData((p) => ({ ...p, damageDescription: e.target.value }))}
+                  placeholder="Opisz uszkodzenia..."
+                  rows={4}
+                  className="rounded-xl border-border focus:border-primary/50"
+                />
+              </div>
+
+              {/* Vehicle options */}
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                  <Car className="h-5 w-5 text-primary" /> Opcje pojazdów
+                </h3>
+                <div className="space-y-6">
+                  <div className="space-y-3">
+                    <div className="flex items-center space-x-3">
+                      <Checkbox
+                        id="otherVehiclesAvailable"
+                        checked={formData.otherVehiclesAvailable}
+                        onCheckedChange={(checked) =>
+                          setFormData((p) => ({ ...p, otherVehiclesAvailable: !!checked }))
+                        }
+                      />
+                      <Label htmlFor="otherVehiclesAvailable">Były dostępne inne pojazdy</Label>
+                    </div>
+                    {formData.otherVehiclesAvailable && (
+                      <Textarea
+                        id="otherVehiclesInfo"
+                        value={formData.otherVehiclesInfo}
+                        onChange={(e) => setFormData((p) => ({ ...p, otherVehiclesInfo: e.target.value }))}
+                        placeholder="Opisz dostępne pojazdy..."
+                        rows={3}
+                        className="rounded-xl border-border"
+                      />
+                    )}
+                  </div>
+                  <div className="space-y-3">
+                    <div className="flex items-center space-x-3">
+                      <Checkbox
+                        id="replacementVehicleRequired"
+                        checked={formData.replacementVehicleRequired}
+                        onCheckedChange={(checked) =>
+                          setFormData((p) => ({ ...p, replacementVehicleRequired: !!checked }))
+                        }
+                      />
+                      <Label htmlFor="replacementVehicleRequired">Potrzebny pojazd zastępczy</Label>
+                    </div>
+                    {formData.replacementVehicleRequired && (
+                      <Textarea
+                        id="replacementVehicleInfo"
+                        value={formData.replacementVehicleInfo}
+                        onChange={(e) =>
+                          setFormData((p) => ({ ...p, replacementVehicleInfo: e.target.value }))
+                        }
+                        placeholder="Opis pojazdu zastępczego..."
+                        rows={3}
+                        className="rounded-xl border-border"
+                      />
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* Work hours */}
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                  <Timer className="h-5 w-5 text-primary" /> Godziny pracy
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div className="space-y-3">
+                    <Label htmlFor="bodyworkHours">Blacharskie</Label>
+                    <Input
+                      id="bodyworkHours"
+                      type="number"
+                      step="0.1"
+                      value={formData.bodyworkHours}
+                      onChange={(e) => setFormData((p) => ({ ...p, bodyworkHours: parseFloat(e.target.value) || 0 }))}
+                      className="h-12 rounded-xl border-border"
+                    />
+                  </div>
+                  <div className="space-y-3">
+                    <Label htmlFor="paintingHours">Lakiernicze</Label>
+                    <Input
+                      id="paintingHours"
+                      type="number"
+                      step="0.1"
+                      value={formData.paintingHours}
+                      onChange={(e) => setFormData((p) => ({ ...p, paintingHours: parseFloat(e.target.value) || 0 }))}
+                      className="h-12 rounded-xl border-border"
+                    />
+                  </div>
+                  <div className="space-y-3">
+                    <Label htmlFor="assemblyHours">Montażowe</Label>
+                    <Input
+                      id="assemblyHours"
+                      type="number"
+                      step="0.1"
+                      value={formData.assemblyHours}
+                      onChange={(e) => setFormData((p) => ({ ...p, assemblyHours: parseFloat(e.target.value) || 0 }))}
+                      className="h-12 rounded-xl border-border"
+                    />
+                  </div>
+                  <div className="space-y-3">
+                    <Label htmlFor="otherWorkHours">Inne</Label>
+                    <Input
+                      id="otherWorkHours"
+                      type="number"
+                      step="0.1"
+                      value={formData.otherWorkHours}
+                      onChange={(e) => setFormData((p) => ({ ...p, otherWorkHours: parseFloat(e.target.value) || 0 }))}
+                      className="h-12 rounded-xl border-border"
+                    />
+                  </div>
+                </div>
+                <div className="space-y-3">
+                  <Label htmlFor="otherWorkDescription">Opis innych prac</Label>
+                  <Input
+                    id="otherWorkDescription"
+                    value={formData.otherWorkDescription}
+                    onChange={(e) => setFormData((p) => ({ ...p, otherWorkDescription: e.target.value }))}
+                    className="h-12 rounded-xl border-border"
+                  />
+                </div>
+                <div className="bg-muted/50 p-4 rounded-xl flex justify-between">
+                  <span className="text-sm font-medium">Łącznie:</span>
+                  <span className="font-bold text-primary">
+                    {(formData.bodyworkHours + formData.paintingHours + formData.assemblyHours + formData.otherWorkHours).toFixed(1)} rbh
+                  </span>
+                </div>
+              </div>
+
+              {/* Additional info */}
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                  <FileText className="h-5 w-5 text-muted-foreground" /> Informacje dodatkowe
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <Textarea
+                    id="additionalDescription"
+                    value={formData.additionalDescription}
+                    onChange={(e) => setFormData((p) => ({ ...p, additionalDescription: e.target.value }))}
+                    placeholder="Dodatkowe informacje..."
+                    rows={3}
+                    className="rounded-xl border-border"
+                  />
+                  <div className="space-y-3">
+                    <Label htmlFor="status">Status</Label>
+                    <Select
+                      value={formData.status}
+                      onValueChange={(value) => setFormData((p) => ({ ...p, status: value as RepairDetail["status"] }))}
+                    >
+                      <SelectTrigger id="status" className="h-12 rounded-xl border-border">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent className="rounded-xl">
+                        <SelectItem value="draft" className="rounded-lg">
+                          Szkic
+                        </SelectItem>
+                        <SelectItem value="in-progress" className="rounded-lg">
+                          W trakcie
+                        </SelectItem>
+                        <SelectItem value="completed" className="rounded-lg">
+                          Zakończony
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex justify-between items-center pt-8 border-t border-border">
                 <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={handleCancelClick}
-                  className="text-gray-500 hover:text-gray-800 hover:bg-gray-100"
+                  type="button"
+                  variant="outline"
+                  onClick={resetForm}
+                  className="px-8 py-3 rounded-xl border-border hover:bg-destructive/10 hover:text-destructive"
                 >
-                  <X className="h-5 w-5" />
+                  <X className="h-4 w-4 mr-2" /> Anuluj
+                </Button>
+                <Button
+                  type="submit"
+                  className="bg-primary hover:bg-primary/90 text-primary-foreground px-8 py-3 rounded-xl shadow"
+                >
+                  <Save className="h-4 w-4 mr-2" /> {editing ? "Zaktualizuj" : "Zapisz"}
                 </Button>
               </div>
-            </CardHeader>
-            <CardContent className="p-6">
-              <form onSubmit={handleSubmit} className="space-y-8">
-                {/* Basic Information Section */}
-                <div className="space-y-4">
-                  <h3 className="text-base font-semibold text-gray-700 border-b pb-2">Informacje podstawowe</h3>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div className="space-y-2">
-                      <Label htmlFor="branch" className="text-sm font-medium">
-                        Oddział
-                      </Label>
-                      <Select value={formData.branchId} onValueChange={handleBranchChange}>
-                        <SelectTrigger id="branch">
-                          <SelectValue placeholder="Wybierz oddział" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {pksData.map((branch) => (
-                            <SelectItem key={branch.id} value={branch.id}>
-                              {branch.company} - {branch.name}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="employee" className="text-sm font-medium">
-                        Pracownik
-                      </Label>
-                      <Select
-                        value={formData.employeeEmail}
-                        onValueChange={(value) => setFormData({ ...formData, employeeEmail: value })}
-                        disabled={!formData.branchId}
-                      >
-                        <SelectTrigger id="employee">
-                          <SelectValue placeholder="Wybierz pracownika" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {employeesForSelectedBranch.map((employee) => (
-                            <SelectItem key={employee.email} value={employee.email}>
-                              {employee.name} ({employee.role})
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="vehicleTabNumber" className="text-sm font-medium">
-                        Nr taborowy pojazdu
-                      </Label>
-                      <Input
-                        id="vehicleTabNumber"
-                        value={formData.vehicleTabNumber}
-                        onChange={(e) => setFormData({ ...formData, vehicleTabNumber: e.target.value })}
-                        required
-                        className="w-full"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="vehicleRegistration" className="text-sm font-medium">
-                        Nr rejestracyjny
-                      </Label>
-                      <Input
-                        id="vehicleRegistration"
-                        value={formData.vehicleRegistration}
-                        onChange={(e) => setFormData({ ...formData, vehicleRegistration: e.target.value })}
-                        required
-                        className="w-full"
-                      />
-                    </div>
-                  </div>
+            </form>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="space-y-6">
+        {details.length === 0 ? (
+          <Card className="border-2 border-dashed border-border bg-muted/20 rounded-2xl">
+            <CardContent className="text-center py-16">
+              <div className="space-y-6">
+                <div className="p-6 bg-primary/10 rounded-2xl w-fit mx-auto border border-border">
+                  <FileText className="h-16 w-16 text-primary" />
                 </div>
-
-                {/* Dates Section */}
-                <div className="space-y-4">
-                  <h3 className="text-base font-semibold text-gray-700 border-b pb-2">Daty i terminy</h3>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div className="space-y-2">
-                      <Label htmlFor="damageDateTime" className="text-sm font-medium">
-                        Data i godzina szkody
-                      </Label>
-                      <Input
-                        id="damageDateTime"
-                        type="datetime-local"
-                        value={formData.damageDateTime}
-                        onChange={(e) => setFormData({ ...formData, damageDateTime: e.target.value })}
-                        className="w-full"
-                        required
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="appraiserWaitingDate" className="text-sm font-medium">
-                        Oczekiwanie na rzeczoznawcę
-                      </Label>
-                      <Input
-                        id="appraiserWaitingDate"
-                        type="date"
-                        value={formData.appraiserWaitingDate}
-                        onChange={(e) => setFormData({ ...formData, appraiserWaitingDate: e.target.value })}
-                        className="w-full"
-                        required
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="repairStartDate" className="text-sm font-medium">
-                        Przystąpienie do naprawy
-                      </Label>
-                      <Input
-                        id="repairStartDate"
-                        type="date"
-                        value={formData.repairStartDate}
-                        onChange={(e) => setFormData({ ...formData, repairStartDate: e.target.value })}
-                        className="w-full"
-                        required
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="repairEndDate" className="text-sm font-medium">
-                        Zakończenie naprawy
-                      </Label>
-                      <Input
-                        id="repairEndDate"
-                        type="date"
-                        value={formData.repairEndDate}
-                        onChange={(e) => setFormData({ ...formData, repairEndDate: e.target.value })}
-                        className="w-full"
-                        required
-                      />
-                    </div>
-                  </div>
-                </div>
-
-                {/* Damage Description Section */}
-                <div className="space-y-4">
-                  <h3 className="text-base font-semibold text-gray-700 border-b pb-2">Opis uszkodzeń</h3>
-                  <div className="space-y-2">
-                    <Label htmlFor="damageDescription" className="text-sm font-medium">
-                      Szczegółowy opis uszkodzeń
-                    </Label>
-                    <Textarea
-                      id="damageDescription"
-                      value={formData.damageDescription}
-                      onChange={(e) => setFormData({ ...formData, damageDescription: e.target.value })}
-                      placeholder="Opisz szczegółowo jakie były uszkodzenia..."
-                      rows={4}
-                      className="w-full resize-none"
-                    />
-                  </div>
-                </div>
-
-                {/* Vehicle Options Section */}
-                <div className="space-y-4">
-                  <h3 className="text-base font-semibold text-gray-700 border-b pb-2">Opcje pojazdów</h3>
-                  <div className="space-y-6">
-                    <div className="space-y-3">
-                      <div className="flex items-center space-x-3">
-                        <Checkbox
-                          id="otherVehiclesAvailable"
-                          checked={formData.otherVehiclesAvailable}
-                          onCheckedChange={(checked) => setFormData({ ...formData, otherVehiclesAvailable: !!checked })}
-                        />
-                        <Label htmlFor="otherVehiclesAvailable" className="text-sm font-medium">
-                          Były dostępne inne pojazdy do użytku
-                        </Label>
-                      </div>
-                      {formData.otherVehiclesAvailable && (
-                        <div className="ml-6 space-y-2">
-                          <Label htmlFor="otherVehiclesInfo" className="text-sm font-medium">
-                            Informacje o dostępnych pojazdach
-                          </Label>
-                          <Textarea
-                            id="otherVehiclesInfo"
-                            value={formData.otherVehiclesInfo}
-                            onChange={(e) => setFormData({ ...formData, otherVehiclesInfo: e.target.value })}
-                            placeholder="Opisz dostępne pojazdy..."
-                            rows={3}
-                            className="w-full resize-none"
-                          />
-                        </div>
-                      )}
-                    </div>
-
-                    <div className="space-y-3">
-                      <div className="flex items-center space-x-3">
-                        <Checkbox
-                          id="replacementVehicleRequired"
-                          checked={formData.replacementVehicleRequired}
-                          onCheckedChange={(checked) =>
-                            setFormData({ ...formData, replacementVehicleRequired: !!checked })
-                          }
-                        />
-                        <Label htmlFor="replacementVehicleRequired" className="text-sm font-medium">
-                          Pojazd zastępczy wymagany
-                        </Label>
-                      </div>
-                      {formData.replacementVehicleRequired && (
-                        <div className="ml-6 space-y-2">
-                          <Label htmlFor="replacementVehicleInfo" className="text-sm font-medium">
-                            Informacje o pojeździe zastępczym
-                          </Label>
-                          <Textarea
-                            id="replacementVehicleInfo"
-                            value={formData.replacementVehicleInfo}
-                            onChange={(e) => setFormData({ ...formData, replacementVehicleInfo: e.target.value })}
-                            placeholder="Opisz pojazd zastępczy..."
-                            rows={3}
-                            className="w-full resize-none"
-                          />
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </div>
-
-                {/* Repair Time Section */}
-                <div className="space-y-4">
-                  <h3 className="text-base font-semibold text-gray-700 border-b pb-2">Czas naprawy (roboczogodziny)</h3>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-                    <div className="space-y-2">
-                      <Label htmlFor="bodyworkHours" className="text-sm font-medium">
-                        Prace blacharskie
-                      </Label>
-                      <div className="relative">
-                        <Input
-                          id="bodyworkHours"
-                          type="number"
-                          min="0"
-                          step="0.1"
-                          value={formData.bodyworkHours}
-                          onChange={(e) =>
-                            setFormData({ ...formData, bodyworkHours: Number.parseFloat(e.target.value) || 0 })
-                          }
-                          className="w-full pr-12"
-                        />
-                        <span className="absolute right-3 top-1/2 transform -translate-y-1/2 text-sm text-gray-500">
-                          rbh
-                        </span>
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="paintingHours" className="text-sm font-medium">
-                        Prace lakiernicze
-                      </Label>
-                      <div className="relative">
-                        <Input
-                          id="paintingHours"
-                          type="number"
-                          min="0"
-                          step="0.1"
-                          value={formData.paintingHours}
-                          onChange={(e) =>
-                            setFormData({ ...formData, paintingHours: Number.parseFloat(e.target.value) || 0 })
-                          }
-                          className="w-full pr-12"
-                        />
-                        <span className="absolute right-3 top-1/2 transform -translate-y-1/2 text-sm text-gray-500">
-                          rbh
-                        </span>
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="assemblyHours" className="text-sm font-medium">
-                        Prace montażowe
-                      </Label>
-                      <div className="relative">
-                        <Input
-                          id="assemblyHours"
-                          type="number"
-                          min="0"
-                          step="0.1"
-                          value={formData.assemblyHours}
-                          onChange={(e) =>
-                            setFormData({ ...formData, assemblyHours: Number.parseFloat(e.target.value) || 0 })
-                          }
-                          className="w-full pr-12"
-                        />
-                        <span className="absolute right-3 top-1/2 transform -translate-y-1/2 text-sm text-gray-500">
-                          rbh
-                        </span>
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="otherWorkHours" className="text-sm font-medium">
-                        Inne prace
-                      </Label>
-                      <div className="relative">
-                        <Input
-                          id="otherWorkHours"
-                          type="number"
-                          min="0"
-                          step="0.1"
-                          value={formData.otherWorkHours}
-                          onChange={(e) =>
-                            setFormData({ ...formData, otherWorkHours: Number.parseFloat(e.target.value) || 0 })
-                          }
-                          className="w-full pr-12"
-                        />
-                        <span className="absolute right-3 top-1/2 transform -translate-y-1/2 text-sm text-gray-500">
-                          rbh
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="otherWorkDescription" className="text-sm font-medium">
-                      Opis innych prac
-                    </Label>
-                    <Input
-                      id="otherWorkDescription"
-                      value={formData.otherWorkDescription}
-                      onChange={(e) => setFormData({ ...formData, otherWorkDescription: e.target.value })}
-                      placeholder="Opisz inne rodzaje prac naprawczych..."
-                      className="w-full"
-                    />
-                  </div>
-
-                  <div className="bg-gray-50 p-4 rounded-lg">
-                    <div className="flex justify-between items-center">
-                      <span className="text-sm font-medium text-gray-600">Łączne godziny pracy:</span>
-                      <span className="text-xl font-bold text-[#1a3a6c]">{getTotalHours().toFixed(1)} rbh</span>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Additional Information Section */}
-                <div className="space-y-4">
-                  <h3 className="text-base font-semibold text-gray-700 border-b pb-2">Informacje dodatkowe</h3>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-end">
-                    <div className="space-y-2">
-                      <Label htmlFor="additionalDescription" className="text-sm font-medium">
-                        Dodatkowy opis
-                      </Label>
-                      <Textarea
-                        id="additionalDescription"
-                        value={formData.additionalDescription}
-                        onChange={(e) => setFormData({ ...formData, additionalDescription: e.target.value })}
-                        placeholder="Dodatkowe informacje..."
-                        rows={3}
-                        className="w-full resize-none"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="status" className="text-sm font-medium">
-                        Status
-                      </Label>
-                      <Select
-                        value={formData.status}
-                        onValueChange={(value: any) => setFormData({ ...formData, status: value })}
-                      >
-                        <SelectTrigger id="status">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="draft">Szkic</SelectItem>
-                          <SelectItem value="in-progress">W trakcie</SelectItem>
-                          <SelectItem value="completed">Zakończony</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Form Actions */}
-                <div className="flex justify-end gap-3 pt-6 border-t">
-                  <Button type="button" variant="outline" onClick={handleCancelClick}>
-                    Anuluj
-                  </Button>
-                  <Button type="submit" className="bg-[#1a3a6c] hover:bg-[#15305a]">
-                    <Save className="h-4 w-4 mr-2" />
-                    {editingId ? "Zaktualizuj" : "Dodaj"}
-                  </Button>
-                </div>
-              </form>
+                <p className="text-xl font-semibold text-foreground">Brak opisów naprawy</p>
+                <p className="text-muted-foreground">Dodaj pierwszy opis, aby rozpocząć</p>
+                <Button
+                  onClick={() => setShowForm(true)}
+                  className="bg-primary hover:bg-primary/90 text-primary-foreground mt-6 px-8 py-3 rounded-xl shadow"
+                >
+                  <Plus className="h-5 w-5 mr-2" /> Dodaj opis
+                </Button>
+              </div>
             </CardContent>
           </Card>
-        )}
-
-        {/* Repair Details List Section */}
-        <div className="space-y-4">
-          <h3 className="text-xl font-semibold text-gray-700">Zapisane opisy naprawy</h3>
-          {repairDetails.length === 0 ? (
-            <div className="text-center py-12 border-2 border-dashed border-gray-300 rounded-lg bg-gray-50">
-              <div className="space-y-3">
-                <div className="mx-auto h-12 w-12 text-gray-400">
-                  <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={1}
-                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                    />
-                  </svg>
-                </div>
-                <div className="space-y-1">
-                  <p className="text-gray-500 font-medium">Brak opisów naprawy</p>
-                  <p className="text-sm text-gray-400">Dodaj pierwszy opis naprawy dla tego zdarzenia</p>
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              {repairDetails.map((detail) => (
-                <Card key={detail.id} className="shadow-sm hover:shadow-md transition-shadow border-gray-200">
-                  <CardContent className="p-6">
-                    {/* Card Header */}
-                    <div className="flex justify-between items-start mb-6">
-                      <div className="space-y-1">
-                        <h4 className="text-lg font-semibold text-gray-800">
-                          {detail.vehicleTabNumber} ({detail.vehicleRegistration})
-                        </h4>
-                        <p className="text-sm text-gray-500">
-                          Utworzono: {new Date(detail.createdAt).toLocaleDateString("pl-PL")}
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        {getStatusBadge(detail.status)}
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          onClick={() => handleEdit(detail)}
-                          className="h-8 w-8 hover:bg-gray-100"
-                        >
-                          <Edit className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          onClick={() => handleDelete(detail.id)}
-                          className="h-8 w-8 text-red-500 hover:text-red-600 hover:bg-red-50"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
+        ) : (
+          details.map((detail, index) => (
+            <Card
+              key={detail.id}
+              className="hover:shadow-lg transition-all duration-300 border bg-card rounded-2xl overflow-hidden animate-slide-up"
+              style={{ animationDelay: `${index * 100}ms` }}
+            >
+              <CardHeader className="pb-4">
+                <div className="flex items-start justify-between">
+                  <div className="flex items-start gap-4">
+                    <div className="p-4 bg-primary/10 rounded-2xl border">
+                      <Wrench className="h-7 w-7 text-primary" />
                     </div>
-
-                    {/* Basic Information */}
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3 text-sm mb-6">
-                      <div className="flex justify-between">
-                        <span className="text-gray-500 font-medium">Oddział:</span>
-                        <span className="text-gray-800">
-                          {pksData.find((b) => b.id === detail.branchId)?.name || "Nieznany"}
+                    <div className="space-y-2">
+                      <CardTitle className="text-2xl font-bold text-foreground">
+                        {detail.vehicleRegistration}
+                      </CardTitle>
+                      <div className="flex items-center gap-6 text-sm text-muted-foreground">
+                        <span className="flex items-center gap-2 bg-muted/50 px-3 py-1 rounded-lg">
+                          <FileText className="h-3 w-3" /> Nr tab. {detail.vehicleTabNumber}
                         </span>
                       </div>
-                      <div className="flex justify-between">
-                        <span className="text-gray-500 font-medium">Pracownik:</span>
-                        <span className="text-gray-800">{detail.employeeEmail}</span>
-                      </div>
-                      {detail.damageDateTime && (
-                        <div className="flex justify-between">
-                          <span className="text-gray-500 font-medium">Data szkody:</span>
-                          <span className="text-gray-800">
-                            {new Date(detail.damageDateTime).toLocaleString("pl-PL")}
-                          </span>
-                        </div>
-                      )}
-                      {detail.appraiserWaitingDate && (
-                        <div className="flex justify-between">
-                          <span className="text-gray-500 font-medium">Oczek. na rzeczoznawcę:</span>
-                          <span className="text-gray-800">
-                            {new Date(detail.appraiserWaitingDate).toLocaleDateString("pl-PL")}
-                          </span>
-                        </div>
-                      )}
-                      {detail.repairStartDate && (
-                        <div className="flex justify-between">
-                          <span className="text-gray-500 font-medium">Początek naprawy:</span>
-                          <span className="text-gray-800">
-                            {new Date(detail.repairStartDate).toLocaleDateString("pl-PL")}
-                          </span>
-                        </div>
-                      )}
-                      {detail.repairEndDate && (
-                        <div className="flex justify-between">
-                          <span className="text-gray-500 font-medium">Koniec naprawy:</span>
-                          <span className="text-gray-800">
-                            {new Date(detail.repairEndDate).toLocaleDateString("pl-PL")}
-                          </span>
-                        </div>
-                      )}
                     </div>
-
-                    {/* Damage Description */}
-                    {detail.damageDescription && (
-                      <div className="mb-6 p-4 bg-gray-50 rounded-lg">
-                        <h5 className="text-sm font-semibold text-gray-700 mb-2">Opis uszkodzeń:</h5>
-                        <p className="text-sm text-gray-700 whitespace-pre-wrap leading-relaxed">
-                          {detail.damageDescription}
-                        </p>
-                      </div>
-                    )}
-
-                    {/* Vehicle Options */}
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-                      <div className="space-y-2">
-                        <h5 className="text-sm font-semibold text-gray-700">Inne pojazdy dostępne:</h5>
-                        <p className="text-sm text-gray-800 font-medium">
-                          {detail.otherVehiclesAvailable ? "Tak" : "Nie"}
-                        </p>
-                        {detail.otherVehiclesAvailable && detail.otherVehiclesInfo && (
-                          <p className="text-sm text-gray-600 bg-gray-50 p-3 rounded whitespace-pre-wrap">
-                            {detail.otherVehiclesInfo}
-                          </p>
-                        )}
-                      </div>
-                      <div className="space-y-2">
-                        <h5 className="text-sm font-semibold text-gray-700">Pojazd zastępczy:</h5>
-                        <p className="text-sm text-gray-800 font-medium">
-                          {detail.replacementVehicleRequired ? "Tak" : "Nie"}
-                        </p>
-                        {detail.replacementVehicleRequired && detail.replacementVehicleInfo && (
-                          <p className="text-sm text-gray-600 bg-gray-50 p-3 rounded whitespace-pre-wrap">
-                            {detail.replacementVehicleInfo}
-                          </p>
-                        )}
-                      </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    {getStatusBadge(detail.status)}
+                    <div className="flex gap-2">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleEdit(detail)}
+                        className="h-10 w-10 rounded-xl hover:bg-primary/10 hover:text-primary"
+                      >
+                        <Edit className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleDelete(detail.id)}
+                        className="h-10 w-10 rounded-xl hover:bg-destructive/10 hover:text-destructive"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
                     </div>
-
-                    {/* Repair Time */}
-                    <div className="mb-6">
-                      <h5 className="text-sm font-semibold text-gray-700 mb-4">Czas naprawy</h5>
-                      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-                        <div className="text-center p-3 bg-gray-50 rounded-lg">
-                          <p className="text-xs text-gray-500 mb-1">Blacharskie</p>
-                          <p className="text-lg font-bold text-[#1a3a6c]">
-                            {detail.bodyworkHours} <span className="text-sm font-normal text-gray-600">rbh</span>
-                          </p>
-                        </div>
-                        <div className="text-center p-3 bg-gray-50 rounded-lg">
-                          <p className="text-xs text-gray-500 mb-1">Lakiernicze</p>
-                          <p className="text-lg font-bold text-[#1a3a6c]">
-                            {detail.paintingHours} <span className="text-sm font-normal text-gray-600">rbh</span>
-                          </p>
-                        </div>
-                        <div className="text-center p-3 bg-gray-50 rounded-lg">
-                          <p className="text-xs text-gray-500 mb-1">Montażowe</p>
-                          <p className="text-lg font-bold text-[#1a3a6c]">
-                            {detail.assemblyHours} <span className="text-sm font-normal text-gray-600">rbh</span>
-                          </p>
-                        </div>
-                        <div className="text-center p-3 bg-gray-50 rounded-lg">
-                          <p className="text-xs text-gray-500 mb-1">Inne</p>
-                          <p className="text-lg font-bold text-[#1a3a6c]">
-                            {detail.otherWorkHours} <span className="text-sm font-normal text-gray-600">rbh</span>
-                          </p>
-                        </div>
-                      </div>
-                      <div className="mt-4 p-3 bg-[#1a3a6c] text-white rounded-lg">
-                        <div className="flex justify-between items-center">
-                          <span className="font-medium">Łącznie:</span>
-                          <span className="text-xl font-bold">
-                            {(
-                              detail.bodyworkHours +
-                              detail.paintingHours +
-                              detail.assemblyHours +
-                              detail.otherWorkHours
-                            ).toFixed(1)}{" "}
-                            rbh
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* Additional Information */}
-                    {(detail.otherWorkDescription || detail.additionalDescription) && (
-                      <div className="space-y-4">
-                        {detail.otherWorkDescription && (
-                          <div className="p-4 bg-gray-50 rounded-lg">
-                            <h5 className="text-sm font-semibold text-gray-700 mb-2">Opis innych prac:</h5>
-                            <p className="text-sm text-gray-700">{detail.otherWorkDescription}</p>
-                          </div>
-                        )}
-                        {detail.additionalDescription && (
-                          <div className="p-4 bg-gray-50 rounded-lg">
-                            <h5 className="text-sm font-semibold text-gray-700 mb-2">Dodatkowy opis:</h5>
-                            <p className="text-sm text-gray-700 whitespace-pre-wrap">{detail.additionalDescription}</p>
-                          </div>
-                        )}
-                      </div>
-                    )}
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          )}
-        </div>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div className="space-y-2">
+                    <p className="text-xs text-muted-foreground">Przystąpienie do naprawy</p>
+                    <p className="font-medium">{formatDate(detail.repairStartDate)}</p>
+                  </div>
+                  <div className="space-y-2">
+                    <p className="text-xs text-muted-foreground">Zakończenie naprawy</p>
+                    <p className="font-medium">{formatDate(detail.repairEndDate)}</p>
+                  </div>
+                </div>
+                {detail.damageDescription && (
+                  <div className="p-5 bg-muted/50 rounded-2xl">
+                    <p className="text-xs text-muted-foreground mb-2">Opis uszkodzeń</p>
+                    <p className="text-sm">{detail.damageDescription}</p>
+                  </div>
+                )}
+                <div className="flex items-center justify-between pt-6 border-t border-border text-xs text-muted-foreground">
+                  <span>Łączne godziny pracy: {getTotalHours(detail).toFixed(1)} rbh</span>
+                  <span>{detail.employeeEmail}</span>
+                </div>
+              </CardContent>
+            </Card>
+          ))
+        )}
       </div>
     </div>
   )
 }
+

--- a/components/claim-form/repair-schedule-section.tsx
+++ b/components/claim-form/repair-schedule-section.tsx
@@ -10,22 +10,45 @@ import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Badge } from "@/components/ui/badge"
-import { Separator } from "@/components/ui/separator"
 import { useToast } from "@/hooks/use-toast"
-import { Calendar, Clock, Car, User, Mail, Plus, Trash2, Save, Edit, X } from 'lucide-react'
+import {
+  Calendar,
+  Car,
+  User,
+  Mail,
+  Plus,
+  Trash2,
+  Save,
+  Edit,
+  X,
+  Building2,
+  AlertTriangle,
+  CheckCircle2,
+  Timer,
+  FileText,
+  Phone,
+  Wrench,
+  TrendingUp,
+  Activity,
+  CircleCheck,
+  CircleAlert,
+  PlayCircle,
+} from "lucide-react"
 import { pksData } from "@/lib/pks-data"
-import { getRepairSchedules, createRepairSchedule, updateRepairSchedule, deleteRepairSchedule } from "@/lib/api/repair-schedules"
+import {
+  getRepairSchedules,
+  createRepairSchedule,
+  updateRepairSchedule,
+  deleteRepairSchedule,
+} from "@/lib/api/repair-schedules"
 
 interface RepairSchedule {
   id?: string
   eventId: string
   branchId?: string
   companyName: string
-  damageNumber: string
   vehicleFleetNumber: string
-  vehicleRegistration: string
-  damageDate: string
-  damageTime: string
+  vehicleRegistration?: string
   expertWaitingDate: string
   additionalInspections: string
   repairStartDate: string
@@ -40,6 +63,24 @@ interface RepairSchedule {
   updatedAt?: string
 }
 
+interface RepairScheduleFormData {
+  id?: string
+  eventId: string
+  branchId?: string
+  companyName: string
+  vehicleFleetNumber: string
+  expertWaitingDate: string
+  additionalInspections: string
+  repairStartDate: string
+  repairEndDate: string
+  whyNotOperational: string
+  alternativeVehiclesAvailable: boolean
+  alternativeVehiclesDescription: string
+  contactDispatcher: string
+  contactManager: string
+  status: "draft" | "submitted" | "approved" | "completed"
+}
+
 interface RepairScheduleSectionProps {
   eventId: string
 }
@@ -51,16 +92,11 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
   const [editingSchedule, setEditingSchedule] = useState<RepairSchedule | null>(null)
   const [showForm, setShowForm] = useState(false)
 
-  // Form state
-  const [formData, setFormData] = useState<Partial<RepairSchedule>>({
+  const [formData, setFormData] = useState<RepairScheduleFormData>({
     eventId,
     branchId: "",
     companyName: "Przedsiębiorstwo Komunikacji Samochodowej w Grodzisku Maz. Sp. z o.o.",
-    damageNumber: "1",
     vehicleFleetNumber: "",
-    vehicleRegistration: "",
-    damageDate: "",
-    damageTime: "",
     expertWaitingDate: "",
     additionalInspections: "brak",
     repairStartDate: "",
@@ -107,7 +143,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
 
   const handleSubmit = async () => {
     try {
-      if (!formData.vehicleFleetNumber || !formData.vehicleRegistration || !formData.damageDate) {
+      if (!formData.vehicleFleetNumber) {
         toast({
           title: "Błąd walidacji",
           description: "Wypełnij wszystkie wymagane pola",
@@ -118,7 +154,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
 
       const savedSchedule = editingSchedule
         ? await updateRepairSchedule(editingSchedule.id!, formData)
-        : await createRepairSchedule(formData as any)
+        : await createRepairSchedule(formData)
 
       if (editingSchedule) {
         setSchedules((prev) => prev.map((s) => (s.id === savedSchedule.id ? savedSchedule : s)))
@@ -146,7 +182,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
   }
 
   const handleDelete = async (scheduleId: string) => {
-    if (!confirm('Czy na pewno chcesz usunąć harmonogram?')) return;
+    if (!confirm("Czy na pewno chcesz usunąć harmonogram?")) return
     try {
       await deleteRepairSchedule(scheduleId)
       setSchedules((prev) => prev.filter((s) => s.id !== scheduleId))
@@ -169,11 +205,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
       eventId,
       branchId: "",
       companyName: "Przedsiębiorstwo Komunikacji Samochodowej w Grodzisku Maz. Sp. z o.o.",
-      damageNumber: "1",
       vehicleFleetNumber: "",
-      vehicleRegistration: "",
-      damageDate: "",
-      damageTime: "",
       expertWaitingDate: "",
       additionalInspections: "brak",
       repairStartDate: "",
@@ -190,21 +222,92 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
   }
 
   const handleEdit = (schedule: RepairSchedule) => {
-    setFormData(schedule)
+    setFormData({
+      id: schedule.id,
+      eventId: schedule.eventId,
+      branchId: schedule.branchId,
+      companyName: schedule.companyName,
+      vehicleFleetNumber: schedule.vehicleFleetNumber,
+      expertWaitingDate: schedule.expertWaitingDate,
+      additionalInspections: schedule.additionalInspections,
+      repairStartDate: schedule.repairStartDate,
+      repairEndDate: schedule.repairEndDate,
+      whyNotOperational: schedule.whyNotOperational,
+      alternativeVehiclesAvailable: schedule.alternativeVehiclesAvailable,
+      alternativeVehiclesDescription: schedule.alternativeVehiclesDescription,
+      contactDispatcher: schedule.contactDispatcher,
+      contactManager: schedule.contactManager,
+      status: schedule.status,
+    })
     setEditingSchedule(schedule)
     setShowForm(true)
   }
 
   const getStatusBadge = (status: string) => {
     const statusConfig = {
-      draft: { label: "Szkic", color: "bg-gray-100 text-gray-800" },
-      submitted: { label: "Przesłany", color: "bg-blue-100 text-blue-800" },
-      approved: { label: "Zatwierdzony", color: "bg-green-100 text-green-800" },
-      completed: { label: "Zakończony", color: "bg-purple-100 text-purple-800" },
+      draft: {
+        label: "Szkic",
+        icon: FileText,
+        className: "status-draft",
+      },
+      submitted: {
+        label: "Przesłany",
+        icon: PlayCircle,
+        className: "status-submitted",
+      },
+      approved: {
+        label: "Zatwierdzony",
+        icon: CircleCheck,
+        className: "status-approved",
+      },
+      completed: {
+        label: "Zakończony",
+        icon: CheckCircle2,
+        className: "status-completed",
+      },
+      "in-progress": {
+        label: "W trakcie",
+        icon: Timer,
+        className: "status-in-progress",
+      },
+      delayed: {
+        label: "Opóźniony",
+        icon: CircleAlert,
+        className: "status-delayed",
+      },
     }
 
     const config = statusConfig[status as keyof typeof statusConfig] || statusConfig.draft
-    return <Badge className={config.color}>{config.label}</Badge>
+    const IconComponent = config.icon
+
+    return (
+      <Badge
+        className={`${config.className} flex items-center gap-2 px-3 py-1.5 text-sm font-medium border rounded-lg`}
+      >
+        <IconComponent className="h-4 w-4" />
+        {config.label}
+      </Badge>
+    )
+  }
+
+  const getStatusIndicator = (schedule: RepairSchedule) => {
+    const now = new Date()
+    const repairStart = schedule.repairStartDate ? new Date(schedule.repairStartDate) : null
+    const repairEnd = schedule.repairEndDate ? new Date(schedule.repairEndDate) : null
+
+    if (schedule.status === "completed") {
+      return { status: "completed", color: "text-green-600", bgColor: "bg-green-100", icon: CheckCircle2 }
+    }
+
+    if (repairStart && now > repairStart && !repairEnd) {
+      return { status: "in-progress", color: "text-orange-600", bgColor: "bg-orange-100", icon: Timer }
+    }
+
+    if (repairStart && now > repairStart && (!repairEnd || now > repairEnd)) {
+      return { status: "delayed", color: "text-red-600", bgColor: "bg-red-100", icon: CircleAlert }
+    }
+
+    return { status: schedule.status, color: "text-blue-600", bgColor: "bg-blue-100", icon: PlayCircle }
   }
 
   const formatDate = (dateString: string) => {
@@ -212,377 +315,626 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
     return new Date(dateString).toLocaleDateString("pl-PL")
   }
 
+  const getProgressPercentage = (schedule: RepairSchedule) => {
+    let progress = 0
+    if (schedule.expertWaitingDate) progress += 33
+    if (schedule.repairStartDate) progress += 33
+    if (schedule.repairEndDate) progress += 34
+    return progress
+  }
+
+  const getRepairStages = (schedule: RepairSchedule) => {
+    const stages = [
+      {
+        id: "draft",
+        label: "Szkic",
+        icon: FileText,
+        completed: schedule.status !== "draft",
+        date: schedule.createdAt,
+      },
+      {
+        id: "submitted",
+        label: "Przesłany",
+        icon: PlayCircle,
+        completed: ["submitted", "approved", "completed"].includes(schedule.status),
+        date: schedule.updatedAt,
+      },
+      {
+        id: "approved",
+        label: "Zatwierdzony",
+        icon: CircleCheck,
+        completed: ["approved", "completed"].includes(schedule.status),
+        date: schedule.repairStartDate,
+      },
+      {
+        id: "completed",
+        label: "Zakończony",
+        icon: CheckCircle2,
+        completed: schedule.status === "completed",
+        date: schedule.repairEndDate,
+      },
+    ]
+    return stages
+  }
+
+  const RepairProgressStages = ({ schedule }: { schedule: RepairSchedule }) => {
+    const stages = getRepairStages(schedule)
+
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between text-sm mb-3">
+          <span className="font-medium text-foreground flex items-center gap-2">
+            <TrendingUp className="h-4 w-4 text-primary" />
+            Postęp naprawy - 4 etapy
+          </span>
+          <span className="font-bold text-primary">{stages.filter((s) => s.completed).length}/4 etapów</span>
+        </div>
+
+        <div className="flex items-center justify-between relative">
+          <div className="absolute top-6 left-6 right-6 h-0.5 bg-muted"></div>
+          <div
+            className="absolute top-6 left-6 h-0.5 bg-primary transition-all duration-1000 ease-out"
+            style={{
+              width: `${Math.max(0, (stages.filter((s) => s.completed).length - 1) * (100 / (stages.length - 1)))}%`,
+            }}
+          ></div>
+
+          {stages.map((stage) => {
+            const IconComponent = stage.icon
+            return (
+              <div key={stage.id} className="flex flex-col items-center space-y-2 relative z-10">
+                <div
+                  className={`
+                  w-12 h-12 rounded-full border-2 flex items-center justify-center transition-all duration-300
+                  ${
+                    stage.completed
+                      ? "bg-primary border-primary text-primary-foreground shadow-lg"
+                      : "bg-background border-muted-foreground/30 text-muted-foreground"
+                  }
+                `}
+                >
+                  <IconComponent className="h-5 w-5" />
+                </div>
+                <div className="text-center">
+                  <div className={`text-xs font-medium ${stage.completed ? "text-primary" : "text-muted-foreground"}`}>
+                    {stage.label}
+                  </div>
+                  {stage.date && <div className="text-xs text-muted-foreground mt-1">{formatDate(stage.date)}</div>}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <div className="text-center">
-          <Clock className="h-8 w-8 animate-spin text-blue-600 mx-auto mb-2" />
-          <p className="text-gray-600">Ładowanie harmonogramów napraw...</p>
+      <div className="flex items-center justify-center py-16">
+        <div className="text-center space-y-6 animate-fade-in">
+          <div className="relative">
+            <div className="w-16 h-16 border-4 border-primary/20 border-t-primary rounded-full animate-spin mx-auto"></div>
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-center gap-2">
+              <Activity className="h-5 w-5 text-primary animate-pulse" />
+              <p className="text-xl font-semibold text-foreground">Ładowanie harmonogramów</p>
+            </div>
+            <p className="text-muted-foreground">Przygotowujemy dane dla Ciebie...</p>
+          </div>
         </div>
       </div>
     )
   }
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex justify-end">
-        <Button onClick={() => setShowForm(true)} className="bg-blue-600 hover:bg-blue-700 text-white">
-          <Plus className="h-4 w-4 mr-2" />
-          Dodaj harmonogram
-        </Button>
+    <div className="space-y-8 animate-fade-in">
+      <div className="relative overflow-hidden rounded-2xl bg-card p-8 border border-border shadow-sm">
+        <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-8">
+          <div className="space-y-3">
+            <div className="flex items-center gap-3">
+              <div className="p-3 bg-primary/10 rounded-xl border border-primary/20">
+                <Wrench className="h-8 w-8 text-primary" />
+              </div>
+              <div>
+                <h1 className="text-3xl font-bold text-foreground">Harmonogramy napraw</h1>
+                <p className="text-muted-foreground text-lg">Zarządzanie flotą pojazdów</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-6">
+            <div className="hidden md:flex items-center gap-6">
+              <div className="rounded-xl p-4 border border-border bg-card text-center min-w-[80px]">
+                <div className="flex items-center justify-center gap-2 mb-1">
+                  <Activity className="h-4 w-4 text-primary" />
+                  <div className="text-2xl font-bold text-primary">{schedules.length}</div>
+                </div>
+                <div className="text-xs text-muted-foreground font-medium">Łącznie</div>
+              </div>
+              <div className="rounded-xl p-4 border border-border bg-card text-center min-w-[80px]">
+                <div className="flex items-center justify-center gap-2 mb-1">
+                  <Timer className="h-4 w-4 text-accent" />
+                  <div className="text-2xl font-bold text-accent">
+                    {schedules.filter((s) => s.status === "submitted").length}
+                  </div>
+                </div>
+                <div className="text-xs text-muted-foreground font-medium">W trakcie</div>
+              </div>
+              <div className="rounded-xl p-4 border border-border bg-card text-center min-w-[80px]">
+                <div className="flex items-center justify-center gap-2 mb-1">
+                  <CheckCircle2 className="h-4 w-4 text-green-500" />
+                  <div className="text-2xl font-bold text-green-500">
+                    {schedules.filter((s) => s.status === "completed").length}
+                  </div>
+                </div>
+                <div className="text-xs text-muted-foreground font-medium">Zakończone</div>
+              </div>
+            </div>
+
+            <Button
+              onClick={() => setShowForm(true)}
+              className="bg-primary hover:bg-primary/90 text-primary-foreground shadow-lg hover:shadow-xl transition-all duration-200 px-6 py-3 rounded-xl font-medium"
+            >
+              <Plus className="h-5 w-5 mr-2" />
+              Nowy harmonogram
+            </Button>
+          </div>
+        </div>
       </div>
 
-      {/* Form */}
       {showForm && (
-        <Card className="border-2 border-blue-200">
-          <CardHeader className="bg-blue-50">
-            <CardTitle className="flex items-center space-x-2">
-              <Calendar className="h-5 w-5 text-blue-600" />
-              <span>{editingSchedule ? "Edytuj harmonogram" : "Nowy harmonogram"}</span>
-            </CardTitle>
+        <Card className="border shadow-lg bg-card animate-scale-in">
+          <CardHeader className="bg-muted/30 border-b border-border rounded-t-xl">
+            <div className="flex items-center justify-between">
+              <CardTitle className="flex items-center gap-4 text-2xl">
+                <div className="p-3 bg-primary/15 rounded-xl border border-primary/20">
+                  <Calendar className="h-6 w-6 text-primary" />
+                </div>
+                <div>
+                  <div className="text-foreground">
+                    {editingSchedule ? "Edytuj harmonogram" : "Nowy harmonogram naprawy"}
+                  </div>
+                </div>
+              </CardTitle>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={resetForm}
+                className="rounded-xl hover:bg-destructive/10 hover:text-destructive"
+              >
+                <X className="h-5 w-5" />
+              </Button>
+            </div>
           </CardHeader>
-          <CardContent className="p-6 space-y-6">
-            {/* Basic Information */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div>
-                <Label htmlFor="branch">Oddział</Label>
-                <Select value={formData.branchId} onValueChange={handleBranchChange}>
-                  <SelectTrigger id="branch" className="mt-1">
-                    <SelectValue placeholder="Wybierz oddział" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {pksData.map((branch) => (
-                      <SelectItem key={branch.id} value={branch.id}>
-                        {branch.company} - {branch.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <Label htmlFor="companyName">Nazwa przedsiębiorstwa</Label>
-                <Input
-                  id="companyName"
-                  value={formData.companyName || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, companyName: e.target.value }))}
-                  className="mt-1"
-                />
-              </div>
-              <div>
-                <Label htmlFor="damageNumber">Nr szkody *</Label>
-                <Input
-                  id="damageNumber"
-                  value={formData.damageNumber || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, damageNumber: e.target.value }))}
-                  className="mt-1"
-                  required
-                />
-              </div>
-              <div>
-                <Label htmlFor="vehicleFleetNumber">Nr taborowy *</Label>
-                <Input
-                  id="vehicleFleetNumber"
-                  value={formData.vehicleFleetNumber || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, vehicleFleetNumber: e.target.value }))}
-                  className="mt-1"
-                  required
-                />
-              </div>
-              <div>
-                <Label htmlFor="vehicleRegistration">Nr rejestracyjny *</Label>
-                <Input
-                  id="vehicleRegistration"
-                  value={formData.vehicleRegistration || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, vehicleRegistration: e.target.value }))}
-                  className="mt-1"
-                  required
-                />
-              </div>
-              <div>
-                <Label htmlFor="damageDate">Data szkody *</Label>
-                <Input
-                  id="damageDate"
-                  type="date"
-                  value={formData.damageDate || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, damageDate: e.target.value }))}
-                  className="mt-1"
-                  required
-                />
-              </div>
-              <div>
-                <Label htmlFor="damageTime">Godzina szkody</Label>
-                <Input
-                  id="damageTime"
-                  type="time"
-                  value={formData.damageTime || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, damageTime: e.target.value }))}
-                  className="mt-1"
-                />
-              </div>
-            </div>
 
-            <Separator />
-
-            {/* Timeline */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div>
-                <Label htmlFor="expertWaitingDate">Oczekiwanie na rzeczoznawcę</Label>
-                <Input
-                  id="expertWaitingDate"
-                  type="date"
-                  value={formData.expertWaitingDate || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, expertWaitingDate: e.target.value }))}
-                  className="mt-1"
-                />
-              </div>
-              <div>
-                <Label htmlFor="additionalInspections">Kolejne wyceny oględziny</Label>
-                <Input
-                  id="additionalInspections"
-                  value={formData.additionalInspections || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, additionalInspections: e.target.value }))}
-                  className="mt-1"
-                  placeholder="np. brak, planowane na..."
-                />
-              </div>
-              <div>
-                <Label htmlFor="repairStartDate">Przystąpienie do naprawy</Label>
-                <Input
-                  id="repairStartDate"
-                  type="date"
-                  value={formData.repairStartDate || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, repairStartDate: e.target.value }))}
-                  className="mt-1"
-                />
-              </div>
-              <div>
-                <Label htmlFor="repairEndDate">Zakończenie naprawy</Label>
-                <Input
-                  id="repairEndDate"
-                  type="date"
-                  value={formData.repairEndDate || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, repairEndDate: e.target.value }))}
-                  className="mt-1"
-                />
-              </div>
-            </div>
-
-            <Separator />
-
-            {/* Operational Status */}
-            <div className="space-y-4">
-              <div>
-                <Label htmlFor="whyNotOperational">Dlaczego nie mógł jeździć na linii</Label>
-                <Textarea
-                  id="whyNotOperational"
-                  value={formData.whyNotOperational || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, whyNotOperational: e.target.value }))}
-                  className="mt-1"
-                  placeholder="np. poważne uszkodzenia, niebezpieczne dla pasażerów..."
-                  rows={3}
-                />
-              </div>
-
-              <div>
-                <Label className="text-base font-medium">Czy były pojazdy inne które można było użytkować?</Label>
-                <RadioGroup
-                  value={formData.alternativeVehiclesAvailable ? "tak" : "nie"}
-                  onValueChange={(value) =>
-                    setFormData((prev) => ({
-                      ...prev,
-                      alternativeVehiclesAvailable: value === "tak",
-                    }))
-                  }
-                  className="flex space-x-6 mt-2"
-                >
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem value="tak" id="alt-vehicles-yes" />
-                    <Label htmlFor="alt-vehicles-yes">Tak</Label>
+          <CardContent className="p-8">
+            <div className="space-y-8 animate-slide-up">
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                  <Car className="h-5 w-5 text-primary" />
+                  Podstawowe informacje
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div className="space-y-3">
+                    <Label htmlFor="branch" className="flex items-center gap-2 text-sm font-semibold">
+                      <Building2 className="h-4 w-4 text-primary" />
+                      Oddział
+                    </Label>
+                    <Select value={formData.branchId} onValueChange={handleBranchChange}>
+                      <SelectTrigger
+                        id="branch"
+                        className="h-12 rounded-xl border-border focus:border-primary/50 focus:ring-primary/20"
+                      >
+                        <SelectValue placeholder="Wybierz oddział" />
+                      </SelectTrigger>
+                      <SelectContent className="rounded-xl">
+                        {pksData.map((branch) => (
+                          <SelectItem key={branch.id} value={branch.id} className="rounded-lg">
+                            {branch.company} - {branch.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   </div>
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem value="nie" id="alt-vehicles-no" />
-                    <Label htmlFor="alt-vehicles-no">Nie</Label>
-                  </div>
-                </RadioGroup>
 
-                {formData.alternativeVehiclesAvailable && (
-                  <div className="mt-3">
-                    <Label htmlFor="alternativeVehiclesDescription">Opis dostępnych pojazdów</Label>
-                    <Textarea
-                      id="alternativeVehiclesDescription"
-                      value={formData.alternativeVehiclesDescription || ""}
-                      onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, alternativeVehiclesDescription: e.target.value }))
-                      }
-                      className="mt-1"
-                      placeholder="Opisz jakie pojazdy były dostępne..."
-                      rows={2}
+                  <div className="space-y-3">
+                    <Label htmlFor="companyName">Nazwa przedsiębiorstwa</Label>
+                    <Input
+                      id="companyName"
+                      value={formData.companyName}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, companyName: e.target.value }))}
+                      className="h-12 rounded-xl border-border focus:border-primary/50 focus:ring-primary/20"
                     />
                   </div>
-                )}
+
+                  <div className="space-y-3">
+                    <Label htmlFor="vehicleFleetNumber" className="flex items-center gap-2 text-sm font-semibold">
+                      <Car className="h-4 w-4 text-primary" />
+                      Nr taborowy *
+                    </Label>
+                    <Input
+                      id="vehicleFleetNumber"
+                      value={formData.vehicleFleetNumber}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, vehicleFleetNumber: e.target.value }))}
+                      className="h-12 rounded-xl border-border focus:border-primary/50 focus:ring-primary/20"
+                      required
+                    />
+                  </div>
+                </div>
               </div>
-            </div>
 
-            <Separator />
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                  <Calendar className="h-5 w-5 text-primary" />
+                  Harmonogram napraw
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div className="space-y-3">
+                    <Label htmlFor="expertWaitingDate" className="flex items-center gap-2 text-sm font-semibold">
+                      <Timer className="h-4 w-4 text-primary" />
+                      Oczekiwanie na rzeczoznawcę
+                    </Label>
+                    <Input
+                      id="expertWaitingDate"
+                      type="date"
+                      value={formData.expertWaitingDate}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, expertWaitingDate: e.target.value }))}
+                      className="h-12 rounded-xl border-border focus:border-primary/50 focus:ring-primary/20"
+                    />
+                  </div>
 
-            {/* Contacts */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div>
-                <Label htmlFor="contactDispatcher">Kontakt - Dyspozytor</Label>
-                <Input
-                  id="contactDispatcher"
-                  type="email"
-                  value={formData.contactDispatcher || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, contactDispatcher: e.target.value }))}
-                  className="mt-1"
-                  placeholder="email@example.com"
-                />
+                  <div className="space-y-3">
+                    <Label htmlFor="additionalInspections">Kolejne wyceny oględziny</Label>
+                    <Input
+                      id="additionalInspections"
+                      value={formData.additionalInspections}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, additionalInspections: e.target.value }))}
+                      className="h-12 rounded-xl border-border focus:border-primary/50 focus:ring-primary/20"
+                      placeholder="np. brak, planowane na..."
+                    />
+                  </div>
+
+                  <div className="space-y-3">
+                    <Label htmlFor="repairStartDate" className="flex items-center gap-2 text-sm font-semibold">
+                      <Wrench className="h-4 w-4 text-accent" />
+                      Przystąpienie do naprawy
+                    </Label>
+                    <Input
+                      id="repairStartDate"
+                      type="date"
+                      value={formData.repairStartDate}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, repairStartDate: e.target.value }))}
+                      className="h-12 rounded-xl border-border focus:border-primary/50 focus:ring-primary/20"
+                    />
+                  </div>
+
+                  <div className="space-y-3">
+                    <Label htmlFor="repairEndDate" className="flex items-center gap-2 text-sm font-semibold">
+                      <CheckCircle2 className="h-4 w-4 text-green-600" />
+                      Zakończenie naprawy
+                    </Label>
+                    <Input
+                      id="repairEndDate"
+                      type="date"
+                      value={formData.repairEndDate}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, repairEndDate: e.target.value }))}
+                      className="h-12 rounded-xl border-border focus:border-primary/50 focus:ring-primary/20"
+                    />
+                  </div>
+                </div>
               </div>
-              <div>
-                <Label htmlFor="contactManager">Kontakt - Kierownik</Label>
-                <Input
-                  id="contactManager"
-                  type="email"
-                  value={formData.contactManager || ""}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, contactManager: e.target.value }))}
-                  className="mt-1"
-                  placeholder="email@example.com"
-                />
+
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                  <AlertTriangle className="h-5 w-5 text-accent" />
+                  Status operacyjny
+                </h3>
+                <div className="space-y-6">
+                  <div className="space-y-3">
+                    <Label htmlFor="whyNotOperational" className="flex items-center gap-2 text-sm font-semibold">
+                      <AlertTriangle className="h-4 w-4 text-accent" />
+                      Dlaczego nie mógł jeździć na linii
+                    </Label>
+                    <Textarea
+                      id="whyNotOperational"
+                      value={formData.whyNotOperational}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, whyNotOperational: e.target.value }))}
+                      placeholder="np. poważne uszkodzenia, niebezpieczne dla pasażerów..."
+                      rows={4}
+                      className="resize-none h-28 rounded-xl border-border focus:border-primary/50 focus:ring-primary/20"
+                    />
+                  </div>
+
+                  <div className="space-y-4">
+                    <Label className="text-base font-medium flex items-center gap-2">
+                      <Car className="h-4 w-4 text-primary" />
+                      Czy były pojazdy inne które można było używać?
+                    </Label>
+                    <RadioGroup
+                      value={formData.alternativeVehiclesAvailable ? "tak" : "nie"}
+                      onValueChange={(value) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          alternativeVehiclesAvailable: value === "tak",
+                        }))
+                      }
+                      className="flex gap-8"
+                    >
+                      <div className="flex items-center space-x-3">
+                        <RadioGroupItem
+                          value="tak"
+                          id="alt-vehicles-yes"
+                          className="h-5 w-5 rounded-full border-border focus:border-primary/50 focus:ring-primary/20"
+                        />
+                        <Label htmlFor="alt-vehicles-yes" className="font-normal">
+                          Tak
+                        </Label>
+                      </div>
+                      <div className="flex items-center space-x-3">
+                        <RadioGroupItem
+                          value="nie"
+                          id="alt-vehicles-no"
+                          className="h-5 w-5 rounded-full border-border focus:border-primary/50 focus:ring-primary/20"
+                        />
+                        <Label htmlFor="alt-vehicles-no" className="font-normal">
+                          Nie
+                        </Label>
+                      </div>
+                    </RadioGroup>
+
+                    {formData.alternativeVehiclesAvailable && (
+                      <div className="space-y-3 mt-4">
+                        <Label htmlFor="alternativeVehiclesDescription">Opis dostępnych pojazdów</Label>
+                        <Textarea
+                          id="alternativeVehiclesDescription"
+                          value={formData.alternativeVehiclesDescription}
+                          onChange={(e) =>
+                            setFormData((prev) => ({ ...prev, alternativeVehiclesDescription: e.target.value }))
+                          }
+                          placeholder="Opisz jakie pojazdy były dostępne..."
+                          rows={3}
+                          className="resize-none h-24 rounded-xl border-border focus:border-primary/50 focus:ring-primary/20"
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
               </div>
-            </div>
 
-            {/* Status */}
-            <div>
-              <Label htmlFor="status">Status harmonogramu</Label>
-              <Select
-                value={formData.status || "draft"}
-                onValueChange={(value) => setFormData((prev) => ({ ...prev, status: value as any }))}
-              >
-                <SelectTrigger className="mt-1">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="draft">Szkic</SelectItem>
-                  <SelectItem value="submitted">Przesłany</SelectItem>
-                  <SelectItem value="approved">Zatwierdzony</SelectItem>
-                  <SelectItem value="completed">Zakończony</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                  <User className="h-5 w-5 text-primary" />
+                  Kontakty
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div className="space-y-3">
+                    <Label htmlFor="contactDispatcher" className="flex items-center gap-2 text-sm font-semibold">
+                      <Phone className="h-4 w-4 text-primary" />
+                      Kontakt - Dyspozytor
+                    </Label>
+                    <Input
+                      id="contactDispatcher"
+                      type="email"
+                      value={formData.contactDispatcher}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, contactDispatcher: e.target.value }))}
+                      className="h-12 rounded-xl border-border focus:border-primary/50 focus:ring-primary/20"
+                      placeholder="email@example.com"
+                    />
+                  </div>
 
-            {/* Form Actions */}
-            <div className="flex justify-end space-x-3 pt-4 border-t">
-              <Button variant="outline" onClick={resetForm}>
-                <X className="h-4 w-4 mr-2" />
-                Anuluj
-              </Button>
-              <Button onClick={handleSubmit} className="bg-blue-600 hover:bg-blue-700">
-                <Save className="h-4 w-4 mr-2" />
-                {editingSchedule ? "Zaktualizuj" : "Zapisz"}
-              </Button>
+                  <div className="space-y-3">
+                    <Label htmlFor="contactManager" className="flex items-center gap-2 text-sm font-semibold">
+                      <User className="h-4 w-4 text-accent" />
+                      Kontakt - Kierownik
+                    </Label>
+                    <Input
+                      id="contactManager"
+                      type="email"
+                      value={formData.contactManager}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, contactManager: e.target.value }))}
+                      className="h-12 rounded-xl border-border focus:border-primary/50 focus:ring-primary/20"
+                      placeholder="email@example.com"
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <Label htmlFor="status" className="flex items-center gap-2 text-sm font-semibold">
+                    <FileText className="h-4 w-4 text-muted-foreground" />
+                    Status harmonogramu
+                  </Label>
+                  <Select
+                    value={formData.status}
+                    onValueChange={(value) => setFormData((prev) => ({ ...prev, status: value as any }))}
+                  >
+                    <SelectTrigger className="h-12 rounded-xl border-border focus:border-primary/50 focus:ring-primary/20">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent className="rounded-xl">
+                      <SelectItem value="draft" className="rounded-lg">
+                        Szkic
+                      </SelectItem>
+                      <SelectItem value="submitted" className="rounded-lg">
+                        Przesłany
+                      </SelectItem>
+                      <SelectItem value="approved" className="rounded-lg">
+                        Zatwierdzony
+                      </SelectItem>
+                      <SelectItem value="completed" className="rounded-lg">
+                        Zakończony
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="flex justify-between items-center pt-8 border-t border-border">
+                <Button
+                  variant="outline"
+                  onClick={resetForm}
+                  className="px-8 py-3 rounded-xl border-border hover:bg-destructive/10 hover:text-destructive hover:border-destructive/20 bg-transparent"
+                >
+                  <X className="h-4 w-4 mr-2" />
+                  Anuluj
+                </Button>
+
+                <Button
+                  onClick={handleSubmit}
+                  className="bg-primary hover:bg-primary/90 text-primary-foreground px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 font-medium"
+                >
+                  <Save className="h-4 w-4 mr-2" />
+                  {editingSchedule ? "Zaktualizuj" : "Zapisz"}
+                </Button>
+              </div>
             </div>
           </CardContent>
         </Card>
       )}
 
-      {/* Schedules List */}
-      <div className="space-y-4">
+      <div className="space-y-6">
         {schedules.length === 0 ? (
-          <Card>
-            <CardContent className="text-center py-8">
-              <Calendar className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-              <p className="text-gray-500 text-lg">Brak harmonogramów</p>
-              <p className="text-gray-400 text-sm">Kliknij "Dodaj harmonogram" aby utworzyć pierwszy</p>
+          <Card className="border-2 border-dashed border-border bg-muted/20 rounded-2xl animate-fade-in">
+            <CardContent className="text-center py-16">
+              <div className="space-y-6">
+                <div className="p-6 bg-primary/10 rounded-2xl w-fit mx-auto border border-border">
+                  <Calendar className="h-16 w-16 text-primary" />
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xl font-semibold text-foreground">Brak harmonogramów</p>
+                  <p className="text-muted-foreground">
+                    Rozpocznij zarządzanie flotą - utwórz pierwszy harmonogram naprawy
+                  </p>
+                </div>
+                <Button
+                  onClick={() => setShowForm(true)}
+                  className="bg-primary hover:bg-primary/90 text-primary-foreground mt-6 px-8 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 font-medium"
+                >
+                  <Plus className="h-5 w-5 mr-2" />
+                  Dodaj pierwszy harmonogram
+                </Button>
+              </div>
             </CardContent>
           </Card>
         ) : (
-          schedules.map((schedule) => (
-            <Card key={schedule.id} className="hover:shadow-md transition-shadow">
-              <CardHeader className="pb-3">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-3">
-                    <Car className="h-5 w-5 text-blue-600" />
-                    <div>
-                      <CardTitle className="text-lg">
-                        {schedule.vehicleRegistration} (Nr tab. {schedule.vehicleFleetNumber})
-                      </CardTitle>
-                      <p className="text-sm text-gray-600">
-                        Szkoda nr {schedule.damageNumber} • {formatDate(schedule.damageDate)}
-                      </p>
+          schedules.map((schedule, index) => {
+            const statusIndicator = getStatusIndicator(schedule)
+            return (
+              <Card
+                key={schedule.id}
+                className="hover:shadow-lg transition-all duration-300 border bg-card rounded-2xl overflow-hidden animate-slide-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className={`h-2 ${statusIndicator.bgColor}`}></div>
+
+                <CardHeader className="pb-4">
+                  <div className="flex items-start justify-between">
+                    <div className="flex items-start gap-4">
+                      <div className={`p-4 ${statusIndicator.bgColor} rounded-2xl border`}>
+                        <statusIndicator.icon className={`h-7 w-7 ${statusIndicator.color}`} />
+                      </div>
+                      <div className="space-y-2">
+                        <CardTitle className="text-2xl font-bold text-foreground">
+                          {schedule.vehicleRegistration}
+                        </CardTitle>
+                        <div className="flex items-center gap-6 text-sm text-muted-foreground">
+                          <span className="flex items-center gap-2 bg-muted/50 px-3 py-1 rounded-lg">
+                            <FileText className="h-3 w-3" />
+                            Nr tab. {schedule.vehicleFleetNumber}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-3">
+                      {getStatusBadge(statusIndicator.status)}
+                      <div className="flex gap-2">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleEdit(schedule)}
+                          className="h-10 w-10 rounded-xl hover:bg-primary/10 hover:text-primary"
+                        >
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleDelete(schedule.id!)}
+                          className="h-10 w-10 rounded-xl hover:bg-destructive/10 hover:text-destructive"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-2">
-                    {getStatusBadge(schedule.status)}
-                    <Button variant="ghost" size="icon" onClick={() => handleEdit(schedule)}>
-                      <Edit className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => handleDelete(schedule.id!)}
-                      className="text-red-600 hover:text-red-700"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {/* Timeline */}
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
-                  <div>
-                    <p className="text-gray-500">Oczekiwanie na rzeczoznawcę</p>
-                    <p className="font-medium">{formatDate(schedule.expertWaitingDate)}</p>
-                  </div>
-                  <div>
-                    <p className="text-gray-500">Rozpoczęcie naprawy</p>
-                    <p className="font-medium">{formatDate(schedule.repairStartDate)}</p>
-                  </div>
-                  <div>
-                    <p className="text-gray-500">Zakończenie naprawy</p>
-                    <p className="font-medium">{formatDate(schedule.repairEndDate)}</p>
-                  </div>
-                </div>
 
-                {/* Operational Status */}
-                {schedule.whyNotOperational && (
-                  <div>
-                    <p className="text-gray-500 text-sm">Powód niezdolności do jazdy:</p>
-                    <p className="text-sm">{schedule.whyNotOperational}</p>
+                  <div className="mt-6">
+                    <RepairProgressStages schedule={schedule} />
                   </div>
-                )}
+                </CardHeader>
 
-                {/* Alternative Vehicles */}
-                <div className="flex items-center space-x-2 text-sm">
-                  <span className="text-gray-500">Pojazdy zastępcze:</span>
-                  <span className={schedule.alternativeVehiclesAvailable ? "text-green-600" : "text-red-600"}>
-                    {schedule.alternativeVehiclesAvailable ? "Dostępne" : "Niedostępne"}
-                  </span>
-                </div>
-
-                {/* Contacts */}
-                {(schedule.contactDispatcher || schedule.contactManager) && (
-                  <div className="flex items-center space-x-4 text-sm text-gray-600">
-                    {schedule.contactDispatcher && (
-                      <div className="flex items-center space-x-1">
-                        <Mail className="h-3 w-3" />
-                        <span>Dyspozytor: {schedule.contactDispatcher}</span>
-                      </div>
-                    )}
-                    {schedule.contactManager && (
-                      <div className="flex items-center space-x-1">
-                        <User className="h-3 w-3" />
-                        <span>Kierownik: {schedule.contactManager}</span>
-                      </div>
-                    )}
+                <CardContent className="space-y-6">
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div className="space-y-2">
+                      <p className="text-xs text-muted-foreground flex items-center gap-2">
+                        <Wrench className="h-3 w-3" />
+                        Rozpoczęcie naprawy
+                      </p>
+                      <p className="font-medium">{formatDate(schedule.repairStartDate)}</p>
+                    </div>
+                    <div className="space-y-2">
+                      <p className="text-xs text-muted-foreground flex items-center gap-2">
+                        <CheckCircle2 className="h-3 w-3" />
+                        Zakończenie naprawy
+                      </p>
+                      <p className="font-medium">{formatDate(schedule.repairEndDate)}</p>
+                    </div>
                   </div>
-                )}
-              </CardContent>
-            </Card>
-          ))
+
+                  {schedule.whyNotOperational && (
+                    <div className="p-5 bg-muted/50 rounded-2xl">
+                      <p className="text-xs text-muted-foreground mb-2 flex items-center gap-2">
+                        <AlertTriangle className="h-3 w-3" />
+                        Powód niezdolności do jazdy
+                      </p>
+                      <p className="text-sm">{schedule.whyNotOperational}</p>
+                    </div>
+                  )}
+
+                  <div className="flex items-center justify-between pt-6 border-t border-border">
+                    <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                      <span
+                        className={`flex items-center gap-2 ${schedule.alternativeVehiclesAvailable ? "text-green-500" : "text-accent"}`}
+                      >
+                        <Car className="h-3 w-3" />
+                        Pojazdy zastępcze: {schedule.alternativeVehiclesAvailable ? "Dostępne" : "Niedostępne"}
+                      </span>
+                    </div>
+
+                    <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                      {schedule.contactDispatcher && (
+                        <span className="flex items-center gap-2">
+                          <Mail className="h-3 w-3" />
+                          {schedule.contactDispatcher}
+                        </span>
+                      )}
+                      {schedule.contactManager && (
+                        <span className="flex items-center gap-2">
+                          <User className="h-3 w-3" />
+                          {schedule.contactManager}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            )
+          })
         )}
       </div>
     </div>
   )
 }
+

--- a/lib/api/repair-schedules.ts
+++ b/lib/api/repair-schedules.ts
@@ -1,14 +1,23 @@
 export interface RepairSchedulePayload {
   eventId: string
+  branchId?: string
+  companyName: string
   vehicleFleetNumber: string
-  vehicleRegistration: string
-  damageDate: string
-  [key: string]: any
+  expertWaitingDate?: string
+  additionalInspections?: string
+  repairStartDate?: string
+  repairEndDate?: string
+  whyNotOperational?: string
+  alternativeVehiclesAvailable?: boolean
+  alternativeVehiclesDescription?: string
+  contactDispatcher?: string
+  contactManager?: string
+  status: "draft" | "submitted" | "approved" | "completed"
 }
 
-function ensureRequired(data: { vehicleFleetNumber?: string; vehicleRegistration?: string; damageDate?: string }) {
-  if (!data.vehicleFleetNumber || !data.vehicleRegistration || !data.damageDate) {
-    throw new Error('vehicleFleetNumber, vehicleRegistration and damageDate are required')
+function ensureRequired(data: { vehicleFleetNumber?: string }) {
+  if (!data.vehicleFleetNumber) {
+    throw new Error('vehicleFleetNumber is required')
   }
 }
 
@@ -48,12 +57,6 @@ export async function createRepairSchedule(data: RepairSchedulePayload) {
 export async function updateRepairSchedule(id: string, data: Partial<RepairSchedulePayload>) {
   if ('vehicleFleetNumber' in data && !data.vehicleFleetNumber) {
     throw new Error('vehicleFleetNumber is required')
-  }
-  if ('vehicleRegistration' in data && !data.vehicleRegistration) {
-    throw new Error('vehicleRegistration is required')
-  }
-  if ('damageDate' in data && !data.damageDate) {
-    throw new Error('damageDate is required')
   }
   const response = await fetch(`${REPAIR_SCHEDULES_URL}/${id}`, {
     method: 'PUT',


### PR DESCRIPTION
## Summary
- redesign repair schedule section with status badges, progress stages, and branch-aware contact fields
- align repair schedule API payload with new fields and simplified validation
- drop obsolete damage fields on backend and add branch support
- redesign repair details section with modern card layout, employee picker, and work-hour totals

## Testing
- `dotnet test` *(fails: command not found)*
- `pnpm test components/claim-form/__tests__/repair-schedule-section.test.ts` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_689fc7ca1dac832cb3d968f87760c824