### PR TITLE
Fix document preview when Google Cloud Storage is disabled

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -21,6 +21,7 @@ interface Document {
   contentType: string
   fileSize: number
   filePath: string
+  cloudUrl?: string
   description?: string
   status: string
   uploadedBy: string
@@ -194,10 +195,13 @@ export const DocumentsSection = ({
       } else if (response.ok) {
         const data: Document[] = await response.json()
         console.log("Loaded documents:", data)
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL || ""
         const mappedDocs: Document[] = data.map((d: any) => ({
           ...d,
           documentType: mapCategoryCodeToName(d.documentType || d.category),
           categoryCode: d.documentType || d.category,
+          previewUrl: d.cloudUrl || `${apiUrl}/documents/${d.id}/preview`,
+          downloadUrl: `${apiUrl}/documents/${d.id}/download`,
         }))
         setDocuments(mappedDocs)
       } else {


### PR DESCRIPTION
## Summary
- ensure documents always use internal preview and download routes when no cloud URL exists
- expose optional `cloudUrl` in document interface for better mapping
- prefix internal document routes with API base URL to support deployments without Google Storage

## Testing
- `pnpm lint` (fails: How would you like to configure ESLint? ... exit code 1)
- `pnpm test` (fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)


------
https://chatgpt.com/codex/tasks/task_e_68a1088e2f1c832c80c8a45a1a6c8aed