### PR TITLE
Fix handlerId type for claim API

### DIFF
--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -18,7 +18,7 @@ test('includes dropdown selections in payload', () => {
   assert.equal(payload.damageType, 'DT')
   assert.equal(payload.insuranceCompanyId, 5)
   assert.equal(payload.clientId, 7)
-  assert.equal(payload.handlerId, '9')
+  assert.equal(payload.handlerId, 9)
 })
 
 test('maps damageType object to its code value', () => {

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -227,7 +227,7 @@ export const transformFrontendClaimToApiPayload = (
     insuranceCompanyId: insuranceCompanyId ? parseInt(insuranceCompanyId, 10) : undefined,
     leasingCompanyId: leasingCompanyId ? parseInt(leasingCompanyId, 10) : undefined,
     clientId: clientId ? parseInt(clientId, 10) : undefined,
-    handlerId,
+    handlerId: handlerId ? parseInt(handlerId, 10) : undefined,
     riskType,
     ...(damageTypeValue ? { damageType: damageTypeValue } : {}),
     damageDate: toIso(rest.damageDate, "damageDate"),

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -42,7 +42,7 @@ export interface EventListItemDto {
   insuranceCompany?: string
   leasingCompanyId?: number
   leasingCompany?: string
-  handlerId?: string
+  handlerId?: number
   handler?: string
   objectTypeId?: number
   registeredById?: string
@@ -64,7 +64,7 @@ export interface EventDto extends EventListItemDto {
   servicesCalled?: string
 
   insuranceCompanyId?: number
-  handlerId?: string
+  handlerId?: number
   riskType?: string
   damageType?: string
   subcontractorName?: string
@@ -131,7 +131,7 @@ export interface EventUpsertDto {
   insuranceCompany?: string
   leasingCompanyId?: number
   leasingCompany?: string
-  handlerId?: string
+  handlerId?: number
   handler?: string
   damageDate?: string
   reportDate?: string


### PR DESCRIPTION
## Summary
- ensure handlerId is sent as a number in claim API payloads
- adjust API DTO typings and tests for numeric handlerId

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68a1147319ec832cb01547739ff882d4