### PR TITLE
fix: enable infinite scroll in claims list

### DIFF
--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -63,12 +63,10 @@ export function ClaimsList({
   } = useClaims()
   const { toast } = useToast()
 
-  const claims = initialClaims?.length ? initialClaims : fetchedClaims
-  const totalRecords = initialClaims?.length ? initialClaims.length : totalCount
+  const claims = fetchedClaims.length > 0 ? fetchedClaims : initialClaims || []
+  const totalRecords = totalCount || claims.length
 
   useEffect(() => {
-    if (initialClaims?.length) return
-
     const loadClaims = async () => {
       try {
         await fetchClaims(
@@ -102,8 +100,6 @@ export function ClaimsList({
     filterBrand,
     filterHandler,
     claimObjectTypeId,
-    initialClaims,
-
   ])
 
   // TODO: consider moving this filtering to use-claims or the API to reduce client workload
@@ -157,10 +153,8 @@ export function ClaimsList({
   )
 
   useEffect(() => {
-
-    if (initialClaims?.length) return
-
     const node = loaderRef.current
+    if (!node) return
     const observer = new IntersectionObserver(
       (entries) => {
         if (
@@ -173,16 +167,11 @@ export function ClaimsList({
       },
       { root: containerRef.current || undefined },
     )
-    if (node) {
-      observer.observe(node)
-    }
+    observer.observe(node)
     return () => {
-      if (node) {
-        observer.unobserve(node)
-      }
+      observer.unobserve(node)
     }
-
-  }, [loading, claims.length, totalRecords, initialClaims])
+  }, [loading, claims.length, totalRecords])
 
 
   const getStatusColor = (status: string) => {
@@ -312,9 +301,9 @@ export function ClaimsList({
           >
             <RefreshCw className={`h-3 w-3 ${isRefreshing ? "animate-spin" : ""}`} />
           </Button>
-          {totalCount > 0 && (
+          {totalRecords > 0 && (
             <Badge variant="secondary" className="text-xs">
-              {totalCount} szkód
+              {totalRecords} szkód
             </Badge>
           )}
         </div>
@@ -550,7 +539,7 @@ export function ClaimsList({
         <div className="px-6 pb-6 flex-shrink-0">
           <div className="flex justify-between items-center text-sm text-gray-500 bg-gray-50 px-4 py-2 rounded-lg">
             <span>
-              Wyświetlono {filteredClaims.length} z {totalCount} szkód
+              Wyświetlono {filteredClaims.length} z {totalRecords} szkód
               {error && " (sprawdź połączenie z API)"}
             </span>
             <span>


### PR DESCRIPTION
## Summary
- always fetch claims data and track total records to enable incremental loading
- observe scroll sentinel without early exit to trigger page increments

## Testing
- `pnpm lint` *(fails: Next.js ESLint plugin missing)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_689fd11dce3c832c8e4bc514c1b6735e