### PR TITLE
Propagate object type ID in claim and event hooks

### DIFF
--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -44,6 +44,7 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
     ...apiClaim,
     id: apiClaim.id,
     rowVersion: apiClaim.rowVersion,
+    objectTypeId: apiClaim.objectTypeId,
     insuranceCompanyId: apiClaim.insuranceCompanyId?.toString(),
     leasingCompanyId: apiClaim.leasingCompanyId?.toString(),
     handlerId: apiClaim.handlerId?.toString(),
@@ -222,6 +223,11 @@ export const transformFrontendClaimToApiPayload = (
     id,
     rowVersion,
     ...rest,
+    objectTypeId: rest.objectTypeId
+      ? typeof rest.objectTypeId === "string"
+        ? parseInt(rest.objectTypeId, 10)
+        : rest.objectTypeId
+      : undefined,
 
     // Convert string identifiers to numbers for API payload
     insuranceCompanyId: insuranceCompanyId ? parseInt(insuranceCompanyId, 10) : undefined,

--- a/hooks/use-events.ts
+++ b/hooks/use-events.ts
@@ -9,6 +9,7 @@ export interface Event {
   eventDate: string
   eventTime: string
   location: string
+  objectTypeId?: number
   city?: string
   postalCode?: string
   country?: string
@@ -33,6 +34,7 @@ const transformApiEvent = (apiEvent: EventDto): Event => ({
   eventDate: apiEvent.damageDate ? new Date(apiEvent.damageDate).toLocaleDateString("pl-PL") : "",
   eventTime: apiEvent.eventTime?.split("T")[1]?.slice(0, 5) || "",
   location: apiEvent.location || "",
+  objectTypeId: apiEvent.objectTypeId,
   city: apiEvent.location || "",
   postalCode: "",
   country: "PL",
@@ -61,6 +63,7 @@ const transformToApiEvent = (event: Partial<Event>): Partial<EventDto> => ({
   location: event.location || "",
   description: event.eventDescription,
   servicesCalled: event.policeInvolved ? ["policja"] : [],
+  objectTypeId: event.objectTypeId,
   notes: event.notes,
 })
 


### PR DESCRIPTION
## Summary
- include `objectTypeId` in event hooks and API transforms
- carry `objectTypeId` through claim transform and payload

## Testing
- `pnpm lint` *(fails: Next.js ESLint plugin prompt)*
- `pnpm test` *(fails: Cannot require() ES Module due to cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68a117ffc444832c83add4ff425d20f3