### PR TITLE
Add missing renderSortIcon helper

### DIFF
--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -255,6 +255,15 @@ export function ClaimsList({
 
   }
 
+  const renderSortIcon = (field: string) => {
+    if (sortConfig?.field !== field) return null
+    return sortConfig.direction === "asc" ? (
+      <ChevronUp className="inline h-3 w-3 ml-1" />
+    ) : (
+      <ChevronDown className="inline h-3 w-3 ml-1" />
+    )
+  }
+
   const handleDeleteClaim = async (claimId: string | undefined, claimNumber: string | undefined) => {
     if (!claimId) return
 


### PR DESCRIPTION
## Summary
- define renderSortIcon for ClaimsList sorting icons

## Testing
- `pnpm lint` *(fails: Next.js ESLint configuration prompt)*
- `pnpm test` *(fails: 4 tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68a11d5606ac832ca9f0aa6f52c591a2