### PR TITLE
Add claim status reference to events

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -90,9 +90,9 @@ namespace AutomotiveClaimsApi.Controllers
                     query = query.Where(e => e.ClientId == clientIdValue);
                 }
 
-                if (!string.IsNullOrEmpty(status))
+                if (!string.IsNullOrEmpty(status) && Guid.TryParse(status, out var statusGuid))
                 {
-                    query = query.Where(e => e.Status == status);
+                    query = query.Where(e => e.ClaimStatusId == statusGuid);
                 }
 
                 if (!string.IsNullOrEmpty(policyNumber))
@@ -143,6 +143,7 @@ namespace AutomotiveClaimsApi.Controllers
                         Model = e.Model,
                         Owner = e.Owner,
                         Status = e.Status,
+                        ClaimStatusId = e.ClaimStatusId,
                         DamageDate = e.DamageDate,
                         TotalClaim = e.TotalClaim,
                         Payout = e.Payout,
@@ -813,6 +814,7 @@ namespace AutomotiveClaimsApi.Controllers
             entity.InsuranceCompanyEmail = dto.InsuranceCompanyEmail;
             entity.PolicyNumber = dto.PolicyNumber;
             entity.Status = dto.Status;
+            entity.ClaimStatusId = dto.ClaimStatusId;
             entity.DamageDate = dto.DamageDate;
             entity.ReportDate = dto.ReportDate;
             entity.ReportDateToInsurer = dto.ReportDateToInsurer;
@@ -1617,6 +1619,7 @@ namespace AutomotiveClaimsApi.Controllers
             InsuranceCompanyEmail = e.InsuranceCompanyEmail,
             PolicyNumber = e.PolicyNumber,
             Status = e.Status,
+            ClaimStatusId = e.ClaimStatusId,
             DamageDate = e.DamageDate,
             ReportDate = e.ReportDate,
             ReportDateToInsurer = e.ReportDateToInsurer,

--- a/backend/DTOs/EventDto.cs
+++ b/backend/DTOs/EventDto.cs
@@ -19,6 +19,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? InsuranceCompanyEmail { get; set; }
         public string? PolicyNumber { get; set; }
         public string? Status { get; set; }
+        public Guid? ClaimStatusId { get; set; }
         public DateTime? DamageDate { get; set; }
         public DateTime? ReportDate { get; set; }
         public DateTime? ReportDateToInsurer { get; set; }

--- a/backend/DTOs/EventListItemDto.cs
+++ b/backend/DTOs/EventListItemDto.cs
@@ -10,6 +10,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Model { get; set; }
         public string? Owner { get; set; }
         public string? Status { get; set; }
+        public Guid? ClaimStatusId { get; set; }
         public DateTime? DamageDate { get; set; }
         public decimal? TotalClaim { get; set; }
         public decimal? Payout { get; set; }

--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -46,6 +46,8 @@ namespace AutomotiveClaimsApi.DTOs
         [StringLength(50)]
         public string? Status { get; set; }
 
+        public Guid? ClaimStatusId { get; set; }
+
         public DateTime? DamageDate { get; set; }
 
         public DateTime? ReportDate { get; set; }

--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -59,6 +59,11 @@ namespace AutomotiveClaimsApi.Data
                       .HasForeignKey(e => e.RegisteredById)
                       .OnDelete(DeleteBehavior.SetNull);
 
+                entity.HasOne(e => e.ClaimStatus)
+                      .WithMany()
+                      .HasForeignKey(e => e.ClaimStatusId)
+                      .OnDelete(DeleteBehavior.SetNull);
+
                 entity.HasMany(e => e.Damages).WithOne(d => d.Event).HasForeignKey(d => d.EventId).OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.Appeals).WithOne(a => a.Event).HasForeignKey(a => a.EventId).OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.ClientClaims).WithOne(c => c.Event).HasForeignKey(c => c.EventId).OnDelete(DeleteBehavior.Cascade);

--- a/backend/Migrations/20240507000014_AddClaimStatusIdToEvents.cs
+++ b/backend/Migrations/20240507000014_AddClaimStatusIdToEvents.cs
@@ -1,0 +1,50 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClaimStatusIdToEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ClaimStatusId",
+                table: "Events",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Events_ClaimStatusId",
+                table: "Events",
+                column: "ClaimStatusId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Events_ClaimStatuses_ClaimStatusId",
+                table: "Events",
+                column: "ClaimStatusId",
+                principalTable: "ClaimStatuses",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Events_ClaimStatuses_ClaimStatusId",
+                table: "Events");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Events_ClaimStatusId",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "ClaimStatusId",
+                table: "Events");
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -994,6 +994,9 @@ namespace AutomotiveClaimsApi.Migrations
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
 
+                    b.Property<Guid?>("ClaimStatusId")
+                        .HasColumnType("uuid");
+
                     b.Property<decimal?>("TotalClaim")
                         .HasColumnType("decimal(18,2)");
 
@@ -1046,11 +1049,18 @@ namespace AutomotiveClaimsApi.Migrations
                     b.Property<string>("RegisteredById")
                         .HasColumnType("text");
 
+                    b.HasIndex("ClaimStatusId");
+
                     b.HasIndex("RegisteredById");
 
                     b.HasKey("Id");
 
                     b.ToTable("Events");
+
+                    b.HasOne("AutomotiveClaimsApi.Models.Dictionary.ClaimStatus", "ClaimStatus")
+                        .WithMany()
+                        .HasForeignKey("ClaimStatusId")
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.HasOne("AutomotiveClaimsApi.Models.ApplicationUser", "RegisteredBy")
                         .WithMany()
@@ -1503,6 +1513,8 @@ namespace AutomotiveClaimsApi.Migrations
                     b.Navigation("Recourses");
 
                     b.Navigation("Settlements");
+
+                    b.Navigation("ClaimStatus");
 
                     b.Navigation("RegisteredBy");
                 });

--- a/backend/Models/Event.cs
+++ b/backend/Models/Event.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-
+using AutomotiveClaimsApi.Models.Dictionary;
 
 namespace AutomotiveClaimsApi.Models
 {
@@ -48,6 +48,10 @@ namespace AutomotiveClaimsApi.Models
 
         [MaxLength(50)]
         public string? Status { get; set; }
+
+        public Guid? ClaimStatusId { get; set; }
+
+        public ClaimStatus? ClaimStatus { get; set; }
 
         public DateTime? DamageDate { get; set; }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -34,6 +34,7 @@ export interface EventListItemDto {
   liquidator?: string
   brand?: string
   status?: string
+  claimStatusId?: string
   damageDate?: string
   totalClaim?: number
   payout?: number
@@ -126,6 +127,7 @@ export interface EventUpsertDto {
   liquidator?: string
   brand?: string
   status?: string
+  claimStatusId?: string
   riskType?: string
   damageType?: string
   objectTypeId?: number


### PR DESCRIPTION
## Summary
- add `ClaimStatusId` property and navigation to `Event`
- expose claim status in DTOs and API types
- include migration for events to reference claim statuses

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1246ffb44832c990be91358eb03ff