### PR TITLE
feat: unify claim summaries

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -10,7 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
-import { AlertTriangle, User, FileSignature, Wrench, Car, X, MessageSquare, Clock, FileCheck, Search, Mail, Plus, CheckCircle, Trash2, Save, Calendar, Phone, MapPin, Paperclip, DollarSign, Gavel, ArrowUpDown, HandHeart, Users, CreditCard, Shield, UserCheck } from 'lucide-react'
+import { AlertTriangle, User, FileSignature, Wrench, Car, X, MessageSquare, Clock, FileCheck, Search, Mail, Plus, CheckCircle, Trash2, Save, Calendar, Phone, Paperclip, DollarSign, Gavel, ArrowUpDown, HandHeart, Users, CreditCard, Shield, UserCheck } from 'lucide-react'
 import { DamageDiagram } from "@/components/damage-diagram"
 import { ParticipantForm } from "./participant-form"
 import { DocumentsSection } from "../documents-section"
@@ -689,61 +689,6 @@ export const ClaimMainContent = ({
     }))
   }
 
-  // Helper function to render participant details
-  const renderParticipantDetails = (
-    participant: ParticipantInfo | undefined,
-    title: string,
-    icon: React.ReactNode,
-    bgColor: string,
-  ) => {
-    if (!participant) {
-      return (
-        <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-          <div className={`px-4 py-3 ${bgColor} border-b border-gray-200`}>
-            <div className="flex items-center space-x-2">
-              {icon}
-              <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
-            </div>
-          </div>
-          <div className="p-4">
-            <div className="text-center py-8 text-gray-500">
-              <p>Brak danych {title.toLowerCase()}</p>
-            </div>
-          </div>
-        </div>
-      )
-    }
-
-    return (
-      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-        <div className={`px-4 py-3 ${bgColor} border-b border-gray-200`}>
-          <div className="flex items-center space-x-2">
-            {icon}
-            <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
-          </div>
-        </div>
-        <div className="p-4 space-y-3">
-          <InfoCard label="Imię i nazwisko" value={participant.name} />
-          <InfoCard label="Adres" value={participant.address} />
-          <InfoCard label="Miasto" value={participant.city} />
-          <InfoCard label="Kod pocztowy" value={participant.postalCode} />
-          <InfoCard label="Kraj" value={participant.country} />
-          <InfoCard label="Telefon" value={participant.phone} />
-          <InfoCard label="E-mail" value={participant.email} />
-          <InfoCard label="Rejestracja" value={participant.vehicleRegistration} />
-          <InfoCard label="VIN" value={participant.vehicleVin} />
-          <InfoCard label="Typ pojazdu" value={participant.vehicleType} />
-          <InfoCard label="Marka" value={participant.vehicleBrand} />
-          <InfoCard label="Model" value={participant.vehicleModel} />
-          {participant.vehicleYear && (
-            <InfoCard label="Rok" value={participant.vehicleYear.toString()} />
-          )}
-          <InfoCard label="Ubezpieczyciel" value={participant.insuranceCompany} />
-          <InfoCard label="Nr polisy" value={participant.policyNumber} />
-        </div>
-      </div>
-    )
-  }
 
   switch (activeClaimSection) {
     case "harmonogram":
@@ -2029,107 +1974,10 @@ export const ClaimMainContent = ({
             claimStatuses={claimStatuses}
             riskTypes={riskTypes}
           />
-        )
-      default: {
-        const visibleNotes = notes.filter((note) => !note.type || note.type === "note")
-        return (
-      <div className="space-y-4">
-        <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
-          {/* Left Column - DANE SZKODY I ZDARZENIA */}
-          <div className="space-y-4">
-            <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-              <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
-                <div className="flex items-center space-x-2">
-                  <FileText className="h-4 w-4 text-blue-600" />
-                  <h3 className="text-sm font-semibold text-gray-900">Dane szkody i zdarzenia</h3>
-                </div>
-              </div>
-              <div className="p-4 space-y-3">
-                <div className="grid grid-cols-2 gap-3">
-                  <InfoCard label="Nr szkody Sparta" value={claimFormData.spartaNumber} />
-                  <InfoCard label="Nr szkody TU" value={claimFormData.insurerClaimNumber} />
-                </div>
-
-                <div className="grid grid-cols-2 gap-3">
-                  <InfoCard label="Status" value={getStatusLabel(claimFormData.status)} />
-                  <InfoCard label="Szkodę zarejestrował" value={claimFormData.handler} />
-                </div>
-
-                <InfoCard label="Rodzaj szkody" value={claimFormData.damageType} />
-                <InfoCard label="Ryzyko szkody" value={getRiskTypeLabel(claimFormData.riskType)} />
-
-                <div className="grid grid-cols-2 gap-3">
-                  <InfoCard label="Data zdarzenia" value={claimFormData.damageDate} />
-                  <InfoCard label="Godzina zdarzenia" value={claimFormData.eventTime} />
-                </div>
-
-                <div className="grid grid-cols-2 gap-3">
-                  <InfoCard label="Data zgłoszenia" value={claimFormData.reportDate} />
-                  <InfoCard label="Data zgłoszenia do TU" value={claimFormData.reportDateToInsurer} />
-                </div>
-
-                <InfoCard
-                  icon={<MapPin className="h-4 w-4" />}
-                  label="Miejsce zdarzenia"
-                  value={claimFormData.eventLocation}
-                />
-
-                {claimFormData.eventDescription && (
-                  <div className="bg-gray-50 rounded-lg p-3">
-                    <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
-                      Opis zdarzenia
-                    </span>
-                    <p className="text-sm text-gray-900 leading-relaxed">{claimFormData.eventDescription}</p>
-                  </div>
-                )}
-
-                <div className="grid grid-cols-2 gap-3">
-                  <InfoCard label="Klient" value={claimFormData.client} />
-                  <InfoCard label="TU" value={claimFormData.insuranceCompany} />
-                </div>
-
-                {claimFormData.leasingCompany && (
-                  <InfoCard label="Firma leasingowa" value={claimFormData.leasingCompany} />
-                )}
-
-                <div className="grid grid-cols-2 gap-3">
-                  <InfoCard label="Obszar" value={claimFormData.area} />
-                  <InfoCard label="Kanał zgłoszenia" value={claimFormData.reportingChannel} />
-                </div>
-
-                {claimFormData.comments && (
-                  <div className="bg-gray-50 rounded-lg p-3">
-                    <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
-                      Uwagi
-                    </span>
-                    <p className="text-sm text-gray-900 leading-relaxed">{claimFormData.comments}</p>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* POSZKODOWANY Section */}
-            {renderParticipantDetails(
-              claimFormData.injuredParty,
-              "Poszkodowany",
-              <User className="h-4 w-4 text-blue-600" />,
-              "bg-gradient-to-r from-blue-50 to-blue-100"
-            )}
-          </div>
-
-          {/* Right Column - SPRAWCA */}
-          <div className="space-y-4">
-            {renderParticipantDetails(
-              claimFormData.perpetrator,
-              "Sprawca",
-              <AlertTriangle className="h-4 w-4 text-red-600" />,
-              "bg-gradient-to-r from-red-50 to-red-100"
-            )}
-          </div>
-        </div>
-
-        {/* Full Width Sections */}
-
+          )
+        default:
+          return (
+        
         <div className="space-y-4">
           <CommunicationClaimSummary
             claimFormData={claimFormData}
@@ -2370,7 +2218,6 @@ export const ClaimMainContent = ({
       </div>
     )
       }
-    }
     }
 
 

--- a/components/claim-form/property-claim-summary.tsx
+++ b/components/claim-form/property-claim-summary.tsx
@@ -2,19 +2,11 @@
 
 import { FileText, MessageSquare } from "lucide-react"
 import { DocumentsSection } from "../documents-section"
-import { PropertyDamageSection } from "./property-damage-section"
-import { PropertyParticipantsSection } from "./property-participants-section"
-import type { Claim, Note, UploadedFile } from "@/types"
+import type { Claim, Note, UploadedFile, ClaimStatus } from "@/types"
 
 interface RiskType {
   value: string
   label: string
-}
-
-interface ClaimStatus {
-  id: number
-  name: string
-  description: string
 }
 
 interface PropertyClaimSummaryProps {
@@ -27,26 +19,120 @@ interface PropertyClaimSummaryProps {
   riskTypes: RiskType[]
 }
 
+const InfoCard = ({ icon, label, value }: { icon?: React.ReactNode; label: string; value?: string }) => (
+  <div className="bg-white border border-gray-200 rounded-lg p-3">
+    <div className="flex items-center space-x-2 mb-1">
+      {icon && <div className="text-gray-400">{icon}</div>}
+      <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">{label}</span>
+    </div>
+    <p className="text-sm font-medium text-gray-900">{value || "Nie określono"}</p>
+  </div>
+)
+
 export function PropertyClaimSummary({
   claimFormData,
   notes,
   uploadedFiles,
   setUploadedFiles,
   eventId,
+  claimStatuses,
+  riskTypes,
 }: PropertyClaimSummaryProps) {
   const visibleNotes = notes.filter((note) => !note.type || note.type === "note")
 
+  const getStatusLabel = (statusId?: string) => {
+    const status = claimStatuses.find((s) => s.id.toString() === statusId)
+    return status ? status.name : statusId || "Nie wybrano"
+  }
+
+  const getRiskTypeLabel = (riskTypeCode?: string) => {
+    const riskType = riskTypes.find((r) => r.value === riskTypeCode)
+    return riskType ? riskType.label : riskTypeCode || "Nie wybrano"
+  }
+
   return (
     <div className="space-y-4">
-      <PropertyParticipantsSection
-        claimFormData={claimFormData}
-        handleFormChange={() => {}}
-      />
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
+          <div className="flex items-center space-x-2">
+            <FileText className="h-4 w-4 text-blue-600" />
+            <h3 className="text-sm font-semibold text-gray-900">Dane szkody i zdarzenia</h3>
+          </div>
+        </div>
+        <div className="p-4 space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Nr szkody Sparta" value={claimFormData.spartaNumber} />
+            <InfoCard label="Nr szkody TU" value={claimFormData.insurerClaimNumber} />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Status" value={getStatusLabel(claimFormData.status)} />
+            <InfoCard label="Szkodę zarejestrował" value={claimFormData.handler} />
+          </div>
+          <InfoCard label="Rodzaj szkody" value={claimFormData.damageType} />
+          <InfoCard label="Ryzyko szkody" value={getRiskTypeLabel(claimFormData.riskType)} />
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Data zdarzenia" value={claimFormData.damageDate} />
+            <InfoCard label="Data zgłoszenia" value={claimFormData.reportDate} />
+          </div>
+          {claimFormData.eventLocation && (
+            <InfoCard label="Miejsce zdarzenia" value={claimFormData.eventLocation} />
+          )}
+        </div>
+      </div>
 
-      <PropertyDamageSection
-        claimFormData={claimFormData}
-        handleFormChange={() => {}}
-      />
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
+          <div className="flex items-center space-x-2">
+            <FileText className="h-4 w-4 text-blue-600" />
+            <h3 className="text-sm font-semibold text-gray-900">Uczestnicy</h3>
+          </div>
+        </div>
+        <div className="p-4 space-y-4">
+          <div>
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
+              Dane poszkodowanego
+            </span>
+            <p className="text-sm text-gray-900 whitespace-pre-line">
+              {claimFormData.injuredData || "Brak danych"}
+            </p>
+          </div>
+          <div>
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
+              Dane sprawcy
+            </span>
+            <p className="text-sm text-gray-900 whitespace-pre-line">
+              {claimFormData.perpetratorData || "Brak danych"}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
+          <div className="flex items-center space-x-2">
+            <FileText className="h-4 w-4 text-blue-600" />
+            <h3 className="text-sm font-semibold text-gray-900">Szkoda w mieniu</h3>
+          </div>
+        </div>
+        <div className="p-4 space-y-4">
+          <div>
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
+              Przedmiot szkody
+            </span>
+            <p className="text-sm text-gray-900 whitespace-pre-line">
+              {claimFormData.propertyDamageSubject || "Brak danych"}
+            </p>
+          </div>
+          <div>
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
+              Wykaz uszkodzeń / strat
+            </span>
+            <p className="text-sm text-gray-900 whitespace-pre-line">
+              {claimFormData.damageListing || "Brak danych"}
+            </p>
+          </div>
+        </div>
+      </div>
 
       <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
         <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">

--- a/components/claim-form/transport-claim-summary.tsx
+++ b/components/claim-form/transport-claim-summary.tsx
@@ -2,19 +2,11 @@
 
 import { FileText, MessageSquare } from "lucide-react"
 import { DocumentsSection } from "../documents-section"
-import { TransportDamageSection } from "./transport-damage-section"
-import { TransportParticipantsSection } from "./transport-participants-section"
-import type { Claim, Note, UploadedFile } from "@/types"
+import type { Claim, Note, UploadedFile, ClaimStatus } from "@/types"
 
 interface RiskType {
   value: string
   label: string
-}
-
-interface ClaimStatus {
-  id: number
-  name: string
-  description: string
 }
 
 interface TransportClaimSummaryProps {
@@ -27,27 +19,131 @@ interface TransportClaimSummaryProps {
   riskTypes: RiskType[]
 }
 
+const InfoCard = ({ icon, label, value }: { icon?: React.ReactNode; label: string; value?: string }) => (
+  <div className="bg-white border border-gray-200 rounded-lg p-3">
+    <div className="flex items-center space-x-2 mb-1">
+      {icon && <div className="text-gray-400">{icon}</div>}
+      <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">{label}</span>
+    </div>
+    <p className="text-sm font-medium text-gray-900">{value || "Nie określono"}</p>
+  </div>
+)
+
 export function TransportClaimSummary({
   claimFormData,
   notes,
   uploadedFiles,
   setUploadedFiles,
   eventId,
+  claimStatuses,
+  riskTypes,
 }: TransportClaimSummaryProps) {
   const visibleNotes = notes.filter((note) => !note.type || note.type === "note")
 
+  const getStatusLabel = (statusId?: string) => {
+    const status = claimStatuses.find((s) => s.id.toString() === statusId)
+    return status ? status.name : statusId || "Nie wybrano"
+  }
+
+  const getRiskTypeLabel = (riskTypeCode?: string) => {
+    const riskType = riskTypes.find((r) => r.value === riskTypeCode)
+    return riskType ? riskType.label : riskTypeCode || "Nie wybrano"
+  }
+
+  const transportDamage = (claimFormData.transportDamage || {}) as any
+
   return (
     <div className="space-y-4">
-      <TransportParticipantsSection
-        claimFormData={claimFormData}
-        handleFormChange={() => {}}
-      />
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
+          <div className="flex items-center space-x-2">
+            <FileText className="h-4 w-4 text-blue-600" />
+            <h3 className="text-sm font-semibold text-gray-900">Dane szkody i zdarzenia</h3>
+          </div>
+        </div>
+        <div className="p-4 space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Nr szkody Sparta" value={claimFormData.spartaNumber} />
+            <InfoCard label="Nr szkody TU" value={claimFormData.insurerClaimNumber} />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Status" value={getStatusLabel(claimFormData.status)} />
+            <InfoCard label="Szkodę zarejestrował" value={claimFormData.handler} />
+          </div>
+          <InfoCard label="Rodzaj szkody" value={claimFormData.damageType} />
+          <InfoCard label="Ryzyko szkody" value={getRiskTypeLabel(claimFormData.riskType)} />
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Data zdarzenia" value={claimFormData.damageDate} />
+            <InfoCard label="Data zgłoszenia" value={claimFormData.reportDate} />
+          </div>
+          {claimFormData.eventLocation && <InfoCard label="Miejsce zdarzenia" value={claimFormData.eventLocation} />}
+        </div>
+      </div>
 
-      <TransportDamageSection
-        claimFormData={claimFormData}
-        handleFormChange={() => {}}
-        disabled
-      />
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
+          <div className="flex items-center space-x-2">
+            <FileText className="h-4 w-4 text-blue-600" />
+            <h3 className="text-sm font-semibold text-gray-900">Uczestnicy</h3>
+          </div>
+        </div>
+        <div className="p-4 space-y-4">
+          <div>
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">Dane poszkodowanego</span>
+            <p className="text-sm text-gray-900 whitespace-pre-line">
+              {claimFormData.injuredData || "Brak danych"}
+            </p>
+          </div>
+          <div>
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">Dane sprawcy</span>
+            <p className="text-sm text-gray-900 whitespace-pre-line">
+              {claimFormData.perpetratorData || "Brak danych"}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
+          <div className="flex items-center space-x-2">
+            <FileText className="h-4 w-4 text-blue-600" />
+            <h3 className="text-sm font-semibold text-gray-900">Szkoda w transporcie</h3>
+          </div>
+        </div>
+        <div className="p-4 space-y-4">
+          <div>
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
+              Opis ładunku / lista strat
+            </span>
+            <p className="text-sm text-gray-900 whitespace-pre-line">
+              {transportDamage.cargoDescription || "Brak danych"}
+            </p>
+          </div>
+          {Array.isArray(transportDamage.losses) && transportDamage.losses.length > 0 && (
+            <div>
+              <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
+                Lista strat
+              </span>
+              <ul className="list-disc pl-5 text-sm text-gray-900 space-y-1">
+                {transportDamage.losses.map((loss: string, idx: number) => (
+                  <li key={idx}>{loss}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Przewoźnik" value={transportDamage.carrier} />
+            <InfoCard label="Nr polisy" value={transportDamage.policyNumber} />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Osoba do oględzin" value={transportDamage.inspectionContactName} />
+            <InfoCard label="Telefon" value={transportDamage.inspectionContactPhone} />
+          </div>
+          {transportDamage.inspectionContactEmail && (
+            <InfoCard label="Email" value={transportDamage.inspectionContactEmail} />
+          )}
+        </div>
+      </div>
 
       <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
         <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">


### PR DESCRIPTION
## Summary
- Restore communication claim folder by delegating to `CommunicationClaimSummary`
- Add read-only summary views for property and transport claims
- Include claim info, participants, and damage details in new summary components

## Testing
- `pnpm test` (fails: test failed)


------
https://chatgpt.com/codex/tasks/task_e_68a1308c05b0832cbe3bc77bd5d668b6