### PR TITLE
Add CaseHandlers CRUD with settings

### DIFF
--- a/app/settings/case-handlers/page.tsx
+++ b/app/settings/case-handlers/page.tsx
@@ -1,0 +1,328 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table"
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationLink,
+} from "@/components/ui/pagination"
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
+import { ArrowUpDown } from "lucide-react"
+import {
+  apiService,
+  type CaseHandlerDto,
+  type CreateCaseHandlerDto,
+} from "@/lib/api"
+
+export default function CaseHandlersPage() {
+  const [handlers, setHandlers] = useState<CaseHandlerDto[]>([])
+  const [search, setSearch] = useState("")
+  const [activeFilter, setActiveFilter] = useState<string>("all")
+  const [sortBy, setSortBy] = useState<keyof CaseHandlerDto>("name")
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc")
+  const [page, setPage] = useState(1)
+  const pageSize = 10
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [error, setError] = useState("")
+  const [formData, setFormData] = useState<CreateCaseHandlerDto>({
+    name: "",
+    code: "",
+    email: "",
+    phone: "",
+    department: "",
+    isActive: true,
+  })
+
+  const loadHandlers = async () => {
+    const data = await apiService.getCaseHandlers()
+    setHandlers(data)
+  }
+
+  useEffect(() => {
+    loadHandlers()
+  }, [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError("")
+    if (!formData.name.trim()) {
+      setError("Nazwa jest wymagana")
+      return
+    }
+    try {
+      if (editingId !== null) {
+        await apiService.updateCaseHandler(editingId, formData)
+      } else {
+        await apiService.createCaseHandler(formData)
+      }
+      setFormData({
+        name: "",
+        code: "",
+        email: "",
+        phone: "",
+        department: "",
+        isActive: true,
+      })
+      setEditingId(null)
+      loadHandlers()
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }
+
+  const startEdit = (handler: CaseHandlerDto) => {
+    setFormData({
+      name: handler.name,
+      code: handler.code ?? "",
+      email: handler.email ?? "",
+      phone: handler.phone ?? "",
+      department: handler.department ?? "",
+      isActive: handler.isActive,
+    })
+    setEditingId(handler.id)
+  }
+
+  const handleDelete = async (id: number) => {
+    setError("")
+    try {
+      await apiService.deleteCaseHandler(id)
+      loadHandlers()
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }
+
+  const toggleSort = (column: keyof CaseHandlerDto) => {
+    if (sortBy === column) {
+      setSortOrder(sortOrder === "asc" ? "desc" : "asc")
+    } else {
+      setSortBy(column)
+      setSortOrder("asc")
+    }
+  }
+
+  const filtered = handlers.filter((h) => {
+    const term = search.toLowerCase()
+    const matchesSearch =
+      h.name.toLowerCase().includes(term) ||
+      (h.code && h.code.toLowerCase().includes(term)) ||
+      (h.email && h.email.toLowerCase().includes(term)) ||
+      (h.phone && h.phone.toLowerCase().includes(term)) ||
+      (h.department && h.department.toLowerCase().includes(term))
+    const matchesActive =
+      activeFilter === "all"
+        ? true
+        : activeFilter === "active"
+        ? h.isActive
+        : !h.isActive
+    return matchesSearch && matchesActive
+  })
+
+  const sorted = [...filtered].sort((a, b) => {
+    const aVal = (a[sortBy] ?? "") as string
+    const bVal = (b[sortBy] ?? "") as string
+    if (aVal < bVal) return sortOrder === "asc" ? -1 : 1
+    if (aVal > bVal) return sortOrder === "asc" ? 1 : -1
+    return 0
+  })
+
+  const total = sorted.length
+  const totalPages = Math.ceil(total / pageSize)
+  const paginated = sorted.slice((page - 1) * pageSize, page * pageSize)
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-semibold">Likwidatorzy</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        {error && <p className="text-red-500">{error}</p>}
+        <div>
+          <Label htmlFor="name">Nazwa</Label>
+          <Input
+            id="name"
+            value={formData.name}
+            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+          />
+        </div>
+        <div>
+          <Label htmlFor="code">Kod</Label>
+          <Input
+            id="code"
+            value={formData.code ?? ""}
+            onChange={(e) => setFormData({ ...formData, code: e.target.value })}
+          />
+        </div>
+        <div>
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            value={formData.email ?? ""}
+            onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+          />
+        </div>
+        <div>
+          <Label htmlFor="phone">Telefon</Label>
+          <Input
+            id="phone"
+            value={formData.phone ?? ""}
+            onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
+          />
+        </div>
+        <div>
+          <Label htmlFor="department">Dział</Label>
+          <Input
+            id="department"
+            value={formData.department ?? ""}
+            onChange={(e) => setFormData({ ...formData, department: e.target.value })}
+          />
+        </div>
+        <div className="flex items-center space-x-2">
+          <Checkbox
+            id="isActive"
+            checked={formData.isActive}
+            onCheckedChange={(checked) =>
+              setFormData({ ...formData, isActive: !!checked })
+            }
+          />
+          <Label htmlFor="isActive">Aktywny</Label>
+        </div>
+        <div className="flex space-x-2">
+          <Button type="submit">{editingId !== null ? "Aktualizuj" : "Dodaj"}</Button>
+          {editingId !== null && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setEditingId(null)
+                setFormData({
+                  name: "",
+                  code: "",
+                  email: "",
+                  phone: "",
+                  department: "",
+                  isActive: true,
+                })
+              }}
+            >
+              Anuluj
+            </Button>
+          )}
+        </div>
+      </form>
+
+      <div className="flex items-center gap-4">
+        <Input
+          placeholder="Szukaj"
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value)
+            setPage(1)
+          }}
+          className="max-w-xs"
+        />
+        <Select
+          value={activeFilter}
+          onValueChange={(v) => {
+            setActiveFilter(v)
+            setPage(1)
+          }}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Filtr" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Wszyscy</SelectItem>
+            <SelectItem value="active">Aktywni</SelectItem>
+            <SelectItem value="inactive">Nieaktywni</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead onClick={() => toggleSort("name")} className="cursor-pointer">
+              Nazwa <ArrowUpDown className="inline h-4 w-4" />
+            </TableHead>
+            <TableHead onClick={() => toggleSort("code")} className="cursor-pointer">
+              Kod <ArrowUpDown className="inline h-4 w-4" />
+            </TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Telefon</TableHead>
+            <TableHead>Dział</TableHead>
+            <TableHead>Aktywny</TableHead>
+            <TableHead>Akcje</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {paginated.map((h) => (
+            <TableRow key={h.id}>
+              <TableCell>{h.name}</TableCell>
+              <TableCell>{h.code}</TableCell>
+              <TableCell>{h.email}</TableCell>
+              <TableCell>{h.phone}</TableCell>
+              <TableCell>{h.department}</TableCell>
+              <TableCell>{h.isActive ? "Tak" : "Nie"}</TableCell>
+              <TableCell className="space-x-2">
+                <Button variant="outline" size="sm" onClick={() => startEdit(h)}>
+                  Edytuj
+                </Button>
+                <Button variant="outline" size="sm" onClick={() => handleDelete(h.id)}>
+                  Usuń
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {totalPages > 1 && (
+        <Pagination className="mt-4">
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+              />
+            </PaginationItem>
+            {Array.from({ length: totalPages }, (_, i) => (
+              <PaginationItem key={i}>
+                <PaginationLink
+                  onClick={() => setPage(i + 1)}
+                  isActive={page === i + 1}
+                >
+                  {i + 1}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+            <PaginationItem>
+              <PaginationNext
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      )}
+    </div>
+  )
+}
+

--- a/app/settings/layout.tsx
+++ b/app/settings/layout.tsx
@@ -16,6 +16,7 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
   const settingsItems = [
     { href: '/settings/clients', label: 'Klienci' },
     { href: '/settings/users', label: 'Użytkownicy' },
+    { href: '/settings/case-handlers', label: 'Likwidatorzy' },
     { href: '/settings/risk-types', label: 'Typy ryzyka' },
     { href: '/settings/damage-types', label: 'Typy szkód' },
     { href: '/settings/notifications', label: 'Powiadomienia' },

--- a/backend/Controllers/CaseHandlersController.cs
+++ b/backend/Controllers/CaseHandlersController.cs
@@ -1,0 +1,78 @@
+using AutomotiveClaimsApi.DTOs;
+using AutomotiveClaimsApi.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AutomotiveClaimsApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CaseHandlersController : ControllerBase
+    {
+        private readonly ICaseHandlerService _service;
+
+        public CaseHandlersController(ICaseHandlerService service)
+        {
+            _service = service;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetCaseHandlers()
+        {
+            var result = await _service.GetCaseHandlersAsync();
+            if (!result.Success)
+            {
+                return StatusCode(result.StatusCode, new { error = result.Error });
+            }
+
+            return Ok(result.Data);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetCaseHandler(int id)
+        {
+            var result = await _service.GetCaseHandlerAsync(id);
+            if (!result.Success)
+            {
+                return StatusCode(result.StatusCode, new { error = result.Error });
+            }
+
+            return Ok(result.Data);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateCaseHandler(CaseHandlerDto dto)
+        {
+            var result = await _service.CreateCaseHandlerAsync(dto);
+            if (!result.Success)
+            {
+                return StatusCode(result.StatusCode, new { error = result.Error });
+            }
+
+            return CreatedAtAction(nameof(GetCaseHandler), new { id = result.Data!.Id }, result.Data);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateCaseHandler(int id, CaseHandlerDto dto)
+        {
+            var result = await _service.UpdateCaseHandlerAsync(id, dto);
+            if (!result.Success)
+            {
+                return StatusCode(result.StatusCode, new { error = result.Error });
+            }
+
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteCaseHandler(int id)
+        {
+            var result = await _service.DeleteCaseHandlerAsync(id);
+            if (!result.Success)
+            {
+                return StatusCode(result.StatusCode, new { error = result.Error });
+            }
+
+            return NoContent();
+        }
+    }
+}

--- a/backend/DTOs/CaseHandlerDto.cs
+++ b/backend/DTOs/CaseHandlerDto.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class CaseHandlerDto
+    {
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(200)]
+        public string Name { get; set; } = string.Empty;
+
+        [MaxLength(20)]
+        public string? Code { get; set; }
+
+        [MaxLength(200)]
+        public string? Email { get; set; }
+
+        [MaxLength(50)]
+        public string? Phone { get; set; }
+
+        [MaxLength(100)]
+        public string? Department { get; set; }
+
+        public bool IsActive { get; set; } = true;
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -75,6 +75,7 @@ builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<IDocumentService, DocumentService>();
 builder.Services.AddScoped<IRiskTypeService, RiskTypeService>();
 builder.Services.AddScoped<IDamageTypeService, DamageTypeService>();
+builder.Services.AddScoped<ICaseHandlerService, CaseHandlerService>();
 
 // Add background services
 builder.Services.AddHostedService<EmailBackgroundService>();

--- a/backend/Services/CaseHandlerService.cs
+++ b/backend/Services/CaseHandlerService.cs
@@ -1,0 +1,159 @@
+using AutomotiveClaimsApi.Data;
+using AutomotiveClaimsApi.DTOs;
+using AutomotiveClaimsApi.Models.Dictionary;
+using Microsoft.EntityFrameworkCore;
+
+namespace AutomotiveClaimsApi.Services
+{
+    public class CaseHandlerService : ICaseHandlerService
+    {
+        private readonly ApplicationDbContext _context;
+
+        public CaseHandlerService(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<ServiceResult<IEnumerable<CaseHandlerDto>>> GetCaseHandlersAsync()
+        {
+            try
+            {
+                var handlers = await _context.CaseHandlers
+                    .OrderBy(h => h.Name)
+                    .Select(h => new CaseHandlerDto
+                    {
+                        Id = h.Id,
+                        Name = h.Name,
+                        Code = h.Code,
+                        Email = h.Email,
+                        Phone = h.Phone,
+                        Department = h.Department,
+                        IsActive = h.IsActive
+                    })
+                    .ToListAsync();
+
+                return ServiceResult<IEnumerable<CaseHandlerDto>>.Ok(handlers);
+            }
+            catch
+            {
+                return ServiceResult<IEnumerable<CaseHandlerDto>>.Fail("Failed to fetch case handlers", 500);
+            }
+        }
+
+        public async Task<ServiceResult<CaseHandlerDto>> GetCaseHandlerAsync(int id)
+        {
+            try
+            {
+                var handler = await _context.CaseHandlers.FindAsync(id);
+                if (handler == null)
+                {
+                    return ServiceResult<CaseHandlerDto>.Fail("Case handler not found", 404);
+                }
+
+                var dto = new CaseHandlerDto
+                {
+                    Id = handler.Id,
+                    Name = handler.Name,
+                    Code = handler.Code,
+                    Email = handler.Email,
+                    Phone = handler.Phone,
+                    Department = handler.Department,
+                    IsActive = handler.IsActive
+                };
+
+                return ServiceResult<CaseHandlerDto>.Ok(dto);
+            }
+            catch
+            {
+                return ServiceResult<CaseHandlerDto>.Fail("Failed to fetch case handler", 500);
+            }
+        }
+
+        public async Task<ServiceResult<CaseHandlerDto>> CreateCaseHandlerAsync(CaseHandlerDto dto)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(dto.Code) && await _context.CaseHandlers.AnyAsync(h => h.Code == dto.Code))
+                {
+                    return ServiceResult<CaseHandlerDto>.Fail("Case handler code already exists", 409);
+                }
+
+                var handler = new CaseHandler
+                {
+                    Name = dto.Name,
+                    Code = dto.Code,
+                    Email = dto.Email,
+                    Phone = dto.Phone,
+                    Department = dto.Department,
+                    IsActive = dto.IsActive
+                };
+
+                _context.CaseHandlers.Add(handler);
+                await _context.SaveChangesAsync();
+
+                dto.Id = handler.Id;
+                return ServiceResult<CaseHandlerDto>.Created(dto);
+            }
+            catch
+            {
+                return ServiceResult<CaseHandlerDto>.Fail("Failed to create case handler", 500);
+            }
+        }
+
+        public async Task<ServiceResult> UpdateCaseHandlerAsync(int id, CaseHandlerDto dto)
+        {
+            try
+            {
+                if (id != dto.Id)
+                {
+                    return ServiceResult.Fail("ID mismatch", 400);
+                }
+
+                var handler = await _context.CaseHandlers.FindAsync(id);
+                if (handler == null)
+                {
+                    return ServiceResult.Fail("Case handler not found", 404);
+                }
+
+                if (!string.IsNullOrEmpty(dto.Code) && await _context.CaseHandlers.AnyAsync(h => h.Code == dto.Code && h.Id != id))
+                {
+                    return ServiceResult.Fail("Case handler code already exists", 409);
+                }
+
+                handler.Name = dto.Name;
+                handler.Code = dto.Code;
+                handler.Email = dto.Email;
+                handler.Phone = dto.Phone;
+                handler.Department = dto.Department;
+                handler.IsActive = dto.IsActive;
+
+                await _context.SaveChangesAsync();
+                return ServiceResult.Ok();
+            }
+            catch
+            {
+                return ServiceResult.Fail("Failed to update case handler", 500);
+            }
+        }
+
+        public async Task<ServiceResult> DeleteCaseHandlerAsync(int id)
+        {
+            try
+            {
+                var handler = await _context.CaseHandlers.FindAsync(id);
+                if (handler == null || !handler.IsActive)
+                {
+                    return ServiceResult.Fail("Case handler not found", 404);
+                }
+
+                handler.IsActive = false;
+                await _context.SaveChangesAsync();
+                return ServiceResult.Ok();
+            }
+            catch
+            {
+                return ServiceResult.Fail("Failed to delete case handler", 500);
+            }
+        }
+    }
+}

--- a/backend/Services/ICaseHandlerService.cs
+++ b/backend/Services/ICaseHandlerService.cs
@@ -1,0 +1,13 @@
+using AutomotiveClaimsApi.DTOs;
+
+namespace AutomotiveClaimsApi.Services
+{
+    public interface ICaseHandlerService
+    {
+        Task<ServiceResult<IEnumerable<CaseHandlerDto>>> GetCaseHandlersAsync();
+        Task<ServiceResult<CaseHandlerDto>> GetCaseHandlerAsync(int id);
+        Task<ServiceResult<CaseHandlerDto>> CreateCaseHandlerAsync(CaseHandlerDto dto);
+        Task<ServiceResult> UpdateCaseHandlerAsync(int id, CaseHandlerDto dto);
+        Task<ServiceResult> DeleteCaseHandlerAsync(int id);
+    }
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -259,6 +259,34 @@ export interface DamageTypeDto {
   updatedAt?: string
 }
 
+export interface CaseHandlerDto {
+  id: number
+  name: string
+  code?: string
+  email?: string
+  phone?: string
+  department?: string
+  isActive: boolean
+}
+
+export interface CreateCaseHandlerDto {
+  name: string
+  code?: string
+  email?: string
+  phone?: string
+  department?: string
+  isActive?: boolean
+}
+
+export interface UpdateCaseHandlerDto {
+  name?: string
+  code?: string
+  email?: string
+  phone?: string
+  department?: string
+  isActive?: boolean
+}
+
 export interface CreateRiskTypeDto {
   code: string
   name: string
@@ -1071,6 +1099,31 @@ class ApiService {
 
   async deleteDamageType(id: string): Promise<void> {
     await this.request<void>(`/damage-types/${id}`, {
+      method: 'DELETE',
+    })
+  }
+
+  // Case Handlers API
+  async getCaseHandlers(): Promise<CaseHandlerDto[]> {
+    return this.request<CaseHandlerDto[]>('/case-handlers')
+  }
+
+  async createCaseHandler(data: CreateCaseHandlerDto): Promise<CaseHandlerDto> {
+    return this.request<CaseHandlerDto>('/case-handlers', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    })
+  }
+
+  async updateCaseHandler(id: number, data: UpdateCaseHandlerDto): Promise<void> {
+    await this.request<void>(`/case-handlers/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    })
+  }
+
+  async deleteCaseHandler(id: number): Promise<void> {
+    await this.request<void>(`/case-handlers/${id}`, {
       method: 'DELETE',
     })
   }


### PR DESCRIPTION
## Summary
- implement CaseHandler DTO, service, controller, and register service for backend CRUD operations
- expose case handler API calls and interfaces for front-end
- add settings page for managing case handlers and update navigation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `pnpm test` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68a138ccd304832ca7a210fe3f1331ce