### PR TITLE
Fix default summary rendering

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -720,14 +720,13 @@ export const ClaimMainContent = ({
                         {expandedSections.harmonogram ? 'Zwiń' : 'Rozwiń'}
                       </Button>
                     </div>
+              </div>
+              <div className="p-4">
+                {expandedSections.harmonogram && eventId ? (
+                  <div className="border rounded-lg overflow-hidden">
+                    <RepairScheduleSection eventId={eventId} />
                   </div>
-                </div>
-                <div className="p-4">
-                  {expandedSections.harmonogram && eventId ? (
-                    <div className="border rounded-lg overflow-hidden">
-                      <RepairScheduleSection eventId={eventId} />
-                    </div>
-                  ) : (
+                ) : (
                     <div className="space-y-4">
                       {/* Preview of repair schedules */}
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -1974,46 +1973,44 @@ export const ClaimMainContent = ({
             claimStatuses={claimStatuses}
             riskTypes={riskTypes}
           />
-          )
-        default:
-          return (
-        
-        <div className="space-y-4">
-          <CommunicationClaimSummary
-            claimFormData={claimFormData}
-            notes={notes}
-            uploadedFiles={uploadedFiles}
-            setUploadedFiles={setUploadedFiles}
-            eventId={eventId}
-            claimStatuses={claimStatuses}
-            riskTypes={riskTypes}
-          />
-          {/* Harmonogram naprawy - expandable section */}
-          <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-            <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-2">
-                  <Calendar className="h-4 w-4 text-blue-600" />
-                  <h3 className="text-sm font-semibold text-gray-900">Harmonogram naprawy</h3>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => toggleSection('harmonogram')}
-                    className="text-xs"
-                  >
-                    {expandedSections.harmonogram ? 'Zwiń' : 'Rozwiń'}
+        )
+      default:
+        return (
+          <div className="space-y-4">
+            <CommunicationClaimSummary
+              claimFormData={claimFormData}
+              notes={notes}
+              uploadedFiles={uploadedFiles}
+              setUploadedFiles={setUploadedFiles}
+              eventId={eventId}
+              claimStatuses={claimStatuses}
+              riskTypes={riskTypes}
+            />
+            {/* Harmonogram naprawy - expandable section */}
+            <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+              <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-2">
+                    <Calendar className="h-4 w-4 text-blue-600" />
+                    <h3 className="text-sm font-semibold text-gray-900">Harmonogram naprawy</h3>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => toggleSection('harmonogram')}
+                      className="text-xs"
+                    >
+                      {expandedSections.harmonogram ? 'Zwiń' : 'Rozwiń'}
                   </Button>
                 </div>
               </div>
-            </div>
-            <div className="p-4">
-              {expandedSections.harmonogram && eventId ? (
-                <div className="border rounded-lg overflow-hidden">
-                  <RepairScheduleSection eventId={eventId} />
-                </div>
-              ) : (
+              <div className="p-4">
+                {expandedSections.harmonogram && eventId ? (
+                  <div className="border rounded-lg overflow-hidden">
+                    <RepairScheduleSection eventId={eventId} />
+                  </div>
+                ) : (
                 <div className="space-y-4">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <InfoCard
@@ -2078,10 +2075,10 @@ export const ClaimMainContent = ({
                   </div>
                 </div>
               )}
+              </div>
             </div>
-          </div>
-          {/* Szczegóły naprawy - expandable section */}
-          <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+            {/* Szczegóły naprawy - expandable section */}
+            <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
             <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
               <div className="flex items-center justify-between">
                 <div className="flex items-center space-x-2">
@@ -2213,11 +2210,9 @@ export const ClaimMainContent = ({
               )}
             </div>
           </div>
-        </div>
-
-      </div>
-    )
-      }
+          </div>
+      )
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- resolve syntax error in claim main content default case
- properly wrap schedule section and close JSX tags in default block

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*
- `pnpm test` *(fails: Cannot require() ES Module /app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68a1387c0790832cb5b435cba718a137