### PR TITLE
Remove expand button from repair section

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -294,7 +294,7 @@ export const ClaimMainContent = ({
   // State for expanded sections in teczka-szkodowa
   const [expandedSections, setExpandedSections] = useState({
     harmonogram: false,
-    naprawa: false,
+    naprawa: true,
   })
 
   const [autoShowRepairForm, setAutoShowRepairForm] = useState(false)
@@ -826,20 +826,11 @@ export const ClaimMainContent = ({
                       <Button
                         size="sm"
                         onClick={() => {
-                          if (!expandedSections.naprawa) toggleSection('naprawa')
                           setAutoShowRepairForm(true)
                         }}
                         className="text-xs bg-[#1a3a6c] hover:bg-[#15305a] text-white"
                       >
                         Dodaj opis naprawy
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => toggleSection('naprawa')}
-                        className="text-xs"
-                      >
-                        {expandedSections.naprawa ? 'Zwiń' : 'Rozwiń'}
                       </Button>
                     </div>
                   </div>
@@ -902,9 +893,6 @@ export const ClaimMainContent = ({
                           </div>
                         )}
 
-                      <div className="text-center pt-2">
-                        <p className="text-xs text-gray-400">Kliknij "Rozwiń" aby zobaczyć pełne szczegóły i dodać nowe pozycje naprawy</p>
-                      </div>
                     </div>
                   )}
                 </div>
@@ -2089,20 +2077,11 @@ export const ClaimMainContent = ({
                   <Button
                     size="sm"
                     onClick={() => {
-                      if (!expandedSections.naprawa) toggleSection('naprawa')
                       setAutoShowRepairForm(true)
                     }}
                     className="text-xs bg-[#1a3a6c] hover:bg-[#15305a] text-white"
                   >
                     Dodaj opis naprawy
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => toggleSection('naprawa')}
-                    className="text-xs"
-                  >
-                    {expandedSections.naprawa ? 'Zwiń' : 'Rozwiń'}
                   </Button>
                 </div>
               </div>
@@ -2202,9 +2181,6 @@ export const ClaimMainContent = ({
                         </div>
                       </div>
                     </div>
-                  </div>
-                  <div className="text-center pt-2">
-                    <p className="text-xs text-gray-400">Kliknij \"Rozwiń\" aby zobaczyć pełne szczegóły naprawy</p>
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## Summary
- remove expand/collapse button from repair details section
- default repair section to expanded state

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ccf431ec832c99383bd794147a43