### PR TITLE
feat: add Word document preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "sonner": "latest",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",
+    "docx-preview": "^0.4.1",
     "swr": "latest",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Summary
- enable Word document preview in document modal with docx-preview
- support Word MIME types when determining preview capability
- declare docx-preview dependency

## Testing
- `pnpm test` *(fails: Cannot require() ES Module in a cycle)*
- `pnpm lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c8c49f9c832c9b903f0df9d97b4f