### PR TITLE
Map transport damage fields to database

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -844,6 +844,13 @@ namespace AutomotiveClaimsApi.Controllers
             entity.ServicesCalled = dto.ServicesCalled;
             entity.PoliceUnitDetails = dto.PoliceUnitDetails;
             entity.VehicleType = dto.VehicleType;
+            entity.CargoDescription = dto.CargoDescription;
+            entity.Losses = dto.Losses;
+            entity.Carrier = dto.Carrier;
+            entity.CarrierPolicyNumber = dto.CarrierPolicyNumber;
+            entity.InspectionContactName = dto.InspectionContactName;
+            entity.InspectionContactPhone = dto.InspectionContactPhone;
+            entity.InspectionContactEmail = dto.InspectionContactEmail;
             entity.SubcontractorName = dto.SubcontractorName;
             entity.SubcontractorPolicyNumber = dto.SubcontractorPolicyNumber;
             entity.SubcontractorInsurer = dto.SubcontractorInsurer;
@@ -1644,6 +1651,13 @@ namespace AutomotiveClaimsApi.Controllers
             ServicesCalled = e.ServicesCalled?.Split(',', StringSplitOptions.RemoveEmptyEntries),
             PoliceUnitDetails = e.PoliceUnitDetails,
             VehicleType = e.VehicleType,
+            CargoDescription = e.CargoDescription,
+            Losses = e.Losses?.Split(',', StringSplitOptions.RemoveEmptyEntries),
+            Carrier = e.Carrier,
+            CarrierPolicyNumber = e.CarrierPolicyNumber,
+            InspectionContactName = e.InspectionContactName,
+            InspectionContactPhone = e.InspectionContactPhone,
+            InspectionContactEmail = e.InspectionContactEmail,
             SubcontractorName = e.SubcontractorName,
             SubcontractorPolicyNumber = e.SubcontractorPolicyNumber,
             SubcontractorInsurer = e.SubcontractorInsurer,

--- a/backend/DTOs/EventDto.cs
+++ b/backend/DTOs/EventDto.cs
@@ -52,6 +52,13 @@ namespace AutomotiveClaimsApi.DTOs
         public string[]? ServicesCalled { get; set; }
         public string? PoliceUnitDetails { get; set; }
         public string? VehicleType { get; set; }
+        public string? CargoDescription { get; set; }
+        public string[]? Losses { get; set; }
+        public string? Carrier { get; set; }
+        public string? CarrierPolicyNumber { get; set; }
+        public string? InspectionContactName { get; set; }
+        public string? InspectionContactPhone { get; set; }
+        public string? InspectionContactEmail { get; set; }
         public string? SubcontractorName { get; set; }
         public string? SubcontractorPolicyNumber { get; set; }
         public string? SubcontractorInsurer { get; set; }

--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -131,6 +131,27 @@ namespace AutomotiveClaimsApi.DTOs
         [StringLength(100)]
         public string? VehicleType { get; set; }
 
+        [StringLength(2000)]
+        public string? CargoDescription { get; set; }
+
+        [StringLength(2000)]
+        public string? Losses { get; set; }
+
+        [StringLength(200)]
+        public string? Carrier { get; set; }
+
+        [StringLength(100)]
+        public string? CarrierPolicyNumber { get; set; }
+
+        [StringLength(200)]
+        public string? InspectionContactName { get; set; }
+
+        [StringLength(50)]
+        public string? InspectionContactPhone { get; set; }
+
+        [StringLength(200)]
+        public string? InspectionContactEmail { get; set; }
+
         [StringLength(200)]
         public string? SubcontractorName { get; set; }
 

--- a/backend/Migrations/20240507000015_AddTransportDamageFields.cs
+++ b/backend/Migrations/20240507000015_AddTransportDamageFields.cs
@@ -1,0 +1,95 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTransportDamageFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CargoDescription",
+                table: "Events",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Losses",
+                table: "Events",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Carrier",
+                table: "Events",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CarrierPolicyNumber",
+                table: "Events",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InspectionContactName",
+                table: "Events",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InspectionContactPhone",
+                table: "Events",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InspectionContactEmail",
+                table: "Events",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CargoDescription",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "Losses",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "Carrier",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "CarrierPolicyNumber",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "InspectionContactName",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "InspectionContactPhone",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "InspectionContactEmail",
+                table: "Events");
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1013,6 +1013,34 @@ namespace AutomotiveClaimsApi.Migrations
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
 
+                    b.Property<string>("CargoDescription")
+                        .HasMaxLength(2000)
+                        .HasColumnType("character varying(2000)");
+
+                    b.Property<string>("Losses")
+                        .HasMaxLength(2000)
+                        .HasColumnType("character varying(2000)");
+
+                    b.Property<string>("Carrier")
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("CarrierPolicyNumber")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("InspectionContactName")
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("InspectionContactPhone")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("InspectionContactEmail")
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
                     b.Property<string>("SubcontractorName")
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");

--- a/backend/Models/Event.cs
+++ b/backend/Models/Event.cs
@@ -136,6 +136,27 @@ namespace AutomotiveClaimsApi.Models
         [MaxLength(100)]
         public string? VehicleType { get; set; }
 
+        [MaxLength(2000)]
+        public string? CargoDescription { get; set; }
+
+        [MaxLength(2000)]
+        public string? Losses { get; set; }
+
+        [MaxLength(200)]
+        public string? Carrier { get; set; }
+
+        [MaxLength(100)]
+        public string? CarrierPolicyNumber { get; set; }
+
+        [MaxLength(200)]
+        public string? InspectionContactName { get; set; }
+
+        [MaxLength(50)]
+        public string? InspectionContactPhone { get; set; }
+
+        [MaxLength(200)]
+        public string? InspectionContactEmail { get; set; }
+
         [MaxLength(200)]
         public string? SubcontractorName { get; set; }
 

--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -105,3 +105,25 @@ test('omits appeals when undefined', () => {
   assert.ok(!('appeals' in payload))
 
 })
+
+test('maps transportDamage fields to flat payload', () => {
+  const payload = transformFrontendClaimToApiPayload({
+    transportDamage: {
+      cargoDescription: 'desc',
+      losses: ['l1', 'l2'],
+      carrier: 'carrier',
+      policyNumber: 'P123',
+      inspectionContactName: 'John',
+      inspectionContactPhone: '555',
+      inspectionContactEmail: 'john@example.com',
+    },
+  } as any)
+
+  assert.equal(payload.cargoDescription, 'desc')
+  assert.equal(payload.losses, 'l1,l2')
+  assert.equal(payload.carrier, 'carrier')
+  assert.equal(payload.carrierPolicyNumber, 'P123')
+  assert.equal(payload.inspectionContactName, 'John')
+  assert.equal(payload.inspectionContactPhone, '555')
+  assert.equal(payload.inspectionContactEmail, 'john@example.com')
+})

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -67,6 +67,14 @@ export interface EventDto extends EventListItemDto {
    */
   servicesCalled?: string
 
+  cargoDescription?: string
+  losses?: string[]
+  carrier?: string
+  carrierPolicyNumber?: string
+  inspectionContactName?: string
+  inspectionContactPhone?: string
+  inspectionContactEmail?: string
+
   insuranceCompanyId?: number
   handlerId?: number
   riskType?: string
@@ -150,6 +158,14 @@ export interface EventUpsertDto {
    * e.g. "policja,pogotowie,straz".
    */
   servicesCalled?: string
+
+  cargoDescription?: string
+  losses?: string
+  carrier?: string
+  carrierPolicyNumber?: string
+  inspectionContactName?: string
+  inspectionContactPhone?: string
+  inspectionContactEmail?: string
 
   totalClaim?: number
   payout?: number

--- a/types/index.ts
+++ b/types/index.ts
@@ -71,6 +71,13 @@ export interface Claim
     | "claimFromSubcontractorPolicyDate"
     | "complaintResponse"
     | "complaintResponseDate"
+    | "cargoDescription"
+    | "losses"
+    | "carrier"
+    | "carrierPolicyNumber"
+    | "inspectionContactName"
+    | "inspectionContactPhone"
+    | "inspectionContactEmail"
   > {
   id?: string
   clientId?: string


### PR DESCRIPTION
## Summary
- add transport-related fields (cargo details, carrier, inspection contacts) to Event model and DTOs
- serialize transport damage data in claim API mappings and frontend transformations
- include migration and tests for new transport fields

## Testing
- `pnpm test` *(fails: Cannot require() ES Module in a cycle)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cda63958832c9b0c6295ed199e76