### PR TITLE
feat: persist client claim document paths

### DIFF
--- a/backend/Migrations/20240211000000_AddClientClaimDocumentFields.cs
+++ b/backend/Migrations/20240211000000_AddClientClaimDocumentFields.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    public partial class AddClientClaimDocumentFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DocumentPath",
+                table: "ClientClaims",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DocumentName",
+                table: "ClientClaims",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DocumentDescription",
+                table: "ClientClaims",
+                type: "text",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DocumentPath",
+                table: "ClientClaims");
+
+            migrationBuilder.DropColumn(
+                name: "DocumentName",
+                table: "ClientClaims");
+
+            migrationBuilder.DropColumn(
+                name: "DocumentDescription",
+                table: "ClientClaims");
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -310,6 +310,15 @@ namespace AutomotiveClaimsApi.Migrations
                         .HasColumnType("text")
                         .HasColumnName("ClaimNotes");
 
+                    b.Property<string>("DocumentPath")
+                        .HasColumnType("text");
+
+                    b.Property<string>("DocumentName")
+                        .HasColumnType("text");
+
+                    b.Property<string>("DocumentDescription")
+                        .HasColumnType("text");
+
                     b.Property<string>("ClaimNumber")
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");


### PR DESCRIPTION
## Summary
- add migration adding document fields to client claims
- update EF snapshot to include new document columns

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a20c3a3664832c8fc87ab5eeb592a4