### PR TITLE
Add global document search and selected download support

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -10,7 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
-import { AlertTriangle, User, FileSignature, Wrench, Car, X, MessageSquare, Clock, FileCheck, Search, Mail, Plus, CheckCircle, Trash2, Save, Calendar, Phone, Paperclip, DollarSign, Gavel, ArrowUpDown, HandHeart, Users, CreditCard, Shield, UserCheck } from 'lucide-react'
+import { AlertTriangle, User, FileSignature, Wrench, Car, X, MessageSquare, Clock, FileCheck, Search, Mail, Plus, CheckCircle, Trash2, Save, Calendar, Phone, Paperclip, DollarSign, Gavel, ArrowUpDown, HandHeart, Users, CreditCard, Shield, UserCheck, Download } from 'lucide-react'
 import { DamageDiagram } from "@/components/damage-diagram"
 import { ParticipantForm } from "./participant-form"
 import { DocumentsSection } from "../documents-section"
@@ -202,6 +202,8 @@ export const ClaimMainContent = ({
   const eventId = claimFormData.id && isGuid(claimFormData.id) ? claimFormData.id : undefined
 
   const documentsSectionRef = useRef<DocumentsSectionRef>(null)
+
+  const [documentSearch, setDocumentSearch] = useState("")
 
   const [repairDetails, setRepairDetails] = useState<RepairDetail[]>([])
 
@@ -1386,6 +1388,27 @@ export const ClaimMainContent = ({
                   <Paperclip className="h-4 w-4" />
                 </div>
                 <CardTitle className="text-lg font-semibold">Dokumenty</CardTitle>
+              </div>
+              <div className="flex items-center space-x-2">
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                  <Input
+                    placeholder="Wyszukaj..."
+                    className="pl-8 bg-white text-black"
+                    value={documentSearch}
+                    onChange={(e) => {
+                      setDocumentSearch(e.target.value)
+                      documentsSectionRef.current?.search(e.target.value)
+                    }}
+                  />
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => documentsSectionRef.current?.downloadSelected()}
+                >
+                  <Download className="mr-2 h-4 w-4" /> Pobierz zaznaczone
+                </Button>
               </div>
             </CardHeader>
             <CardContent className="p-0 bg-white">

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -728,10 +728,6 @@ export const DocumentsSection = React.forwardRef<DocumentsSectionRef, DocumentsS
     handlePreview(allDocuments[0], allDocuments)
   }
 
-  useImperativeHandle(ref, () => ({
-    downloadAll: handleDownloadAll,
-  }))
-
   const handleDownloadSelected = async (category?: string) => {
     const documentsForCategory = allDocuments.filter((d) =>
       category ? d.documentType === category && selectedDocumentIds.includes(d.id) : selectedDocumentIds.includes(d.id),
@@ -785,6 +781,12 @@ export const DocumentsSection = React.forwardRef<DocumentsSectionRef, DocumentsS
       })
     }
   }
+
+  useImperativeHandle(ref, () => ({
+    downloadAll: handleDownloadAll,
+    downloadSelected: handleDownloadSelected,
+    search: (query: string) => setSearchQuery(query),
+  }))
 
   const handleDrag = (e: React.DragEvent) => {
     e.preventDefault()

--- a/types/index.ts
+++ b/types/index.ts
@@ -304,4 +304,10 @@ export interface DocumentsSectionProps {
 
 export interface DocumentsSectionRef {
   downloadAll: (category?: string) => Promise<void>
+  downloadSelected: (category?: string) => Promise<void>
+  /**
+   * Set search query for documents in this section.
+   * Used for global document search across sections.
+   */
+  search: (query: string) => void
 }


### PR DESCRIPTION
## Summary
- expose downloadSelected and search controls in DocumentsSection
- add global document search bar and download selected button
- expand DocumentsSectionRef for external control

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm install` *(fails: Forbidden 403 from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ffd6d50c832ca61c839f4030c216