### PR TITLE
feat: add client dashboard

### DIFF
--- a/app/api/dashboard/client/route.ts
+++ b/app/api/dashboard/client/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api";
+
+export async function GET(request: NextRequest) {
+  try {
+    const token = request.cookies.get("token")?.value;
+    const url = `${API_BASE_URL}/dashboard/client`;
+
+    const response = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      credentials: "include",
+      cache: "no-store",
+    });
+
+    if (response.status === 401) {
+      return NextResponse.redirect(new URL("/login", request.url));
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error(`Backend API error: ${response.status} - ${errorText}`);
+      return NextResponse.json(
+        { error: `Backend API error: ${errorText}` },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Dashboard API error:", error);
+    return NextResponse.json({ error: "Failed to fetch dashboard data" }, { status: 500 });
+  }
+}

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api";
+
+export async function GET(request: NextRequest) {
+  try {
+    const token = request.cookies.get("token")?.value;
+    const url = `${API_BASE_URL}/dashboard/user`;
+
+    const response = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      credentials: "include",
+      cache: "no-store",
+    });
+
+    if (response.status === 401) {
+      return NextResponse.redirect(new URL("/login", request.url));
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error(`Backend API error: ${response.status} - ${errorText}`);
+      return NextResponse.json(
+        { error: `Backend API error: ${errorText}` },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Dashboard API error:", error);
+    return NextResponse.json({ error: "Failed to fetch dashboard data" }, { status: 500 });
+  }
+}

--- a/backend/Controllers/DashboardController.cs
+++ b/backend/Controllers/DashboardController.cs
@@ -1,0 +1,100 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity;
+using AutomotiveClaimsApi.Data;
+using AutomotiveClaimsApi.DTOs;
+using AutomotiveClaimsApi.Models;
+
+namespace AutomotiveClaimsApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize(Roles = "Admin,User")]
+    public class DashboardController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly ILogger<DashboardController> _logger;
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public DashboardController(ApplicationDbContext context, ILogger<DashboardController> logger, UserManager<ApplicationUser> userManager)
+        {
+            _context = context;
+            _logger = logger;
+            _userManager = userManager;
+        }
+
+        [HttpGet("user")]
+        public async Task<ActionResult<UserDashboardDto>> GetUserDashboard()
+        {
+            try
+            {
+                var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (string.IsNullOrEmpty(userId))
+                {
+                    return Unauthorized(new { error = "User not authenticated" });
+                }
+
+                var query = _context.Events.Where(e => e.RegisteredById == userId);
+
+                var total = await query.CountAsync();
+                var closed = await query.CountAsync(e => e.Status == "Closed");
+                var active = await query.CountAsync(e => e.Status != "Closed");
+
+                var result = new UserDashboardDto
+                {
+                    TotalClaims = total,
+                    ActiveClaims = active,
+                    ClosedClaims = closed
+                };
+
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve user dashboard stats");
+                return StatusCode(500, new { error = "Failed to retrieve dashboard stats" });
+            }
+        }
+
+        [HttpGet("client")]
+        public async Task<ActionResult<ClientDashboardDto>> GetClientDashboard()
+        {
+            try
+            {
+                var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+                if (string.IsNullOrEmpty(userId))
+                {
+                    return Unauthorized(new { error = "User not authenticated" });
+                }
+
+                var user = await _userManager.Users.FirstOrDefaultAsync(u => u.Id == userId);
+                if (user == null || user.ClientId == null)
+                {
+                    return NotFound(new { error = "User not assigned to a client" });
+                }
+
+                var query = _context.Events.Where(e => e.ClientId == user.ClientId);
+
+                var total = await query.CountAsync();
+                var closed = await query.CountAsync(e => e.Status == "Closed");
+                var active = await query.CountAsync(e => e.Status != "Closed");
+
+                var result = new ClientDashboardDto
+                {
+                    TotalClaims = total,
+                    ActiveClaims = active,
+                    ClosedClaims = closed
+                };
+
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve client dashboard stats");
+                return StatusCode(500, new { error = "Failed to retrieve dashboard stats" });
+            }
+        }
+    }
+}

--- a/backend/DTOs/ClientDashboardDto.cs
+++ b/backend/DTOs/ClientDashboardDto.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class ClientDashboardDto
+    {
+        public int TotalClaims { get; set; }
+        public int ActiveClaims { get; set; }
+        public int ClosedClaims { get; set; }
+    }
+}

--- a/backend/DTOs/UserDashboardDto.cs
+++ b/backend/DTOs/UserDashboardDto.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class UserDashboardDto
+    {
+        public int TotalClaims { get; set; }
+        public int ActiveClaims { get; set; }
+        public int ClosedClaims { get; set; }
+    }
+}

--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -47,6 +47,14 @@ namespace AutomotiveClaimsApi.Data
         {
             base.OnModelCreating(modelBuilder);
 
+            modelBuilder.Entity<ApplicationUser>(entity =>
+            {
+                entity.HasOne(u => u.Client)
+                      .WithMany()
+                      .HasForeignKey(u => u.ClientId)
+                      .OnDelete(DeleteBehavior.SetNull);
+            });
+
             // Event is the central aggregate root
             modelBuilder.Entity<Event>(entity =>
             {

--- a/backend/Models/ApplicationUser.cs
+++ b/backend/Models/ApplicationUser.cs
@@ -9,5 +9,8 @@ namespace AutomotiveClaimsApi.Models
 
         public DateTime CreatedAt { get; set; }
         public DateTime? LastLogin { get; set; }
+
+        public int? ClientId { get; set; }
+        public Client? Client { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- allow users to be associated with a client
- add API route returning claim counts for the user's client
- surface client claim statistics on the dashboard

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm install` *(fails: GET https://registry.npmjs.org/tsconfig-paths: Forbidden - 403)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a20cdefd04832cbfb8be4dc77f531f