### PR TITLE
Integrate property damage details into single section

### DIFF
--- a/components/claim-form/property-claim-form.tsx
+++ b/components/claim-form/property-claim-form.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import DamageDataSection from "./damage-data-section"
 import PropertyDamageSection from "./property-damage-section"
 import PropertyParticipantsSection from "./property-participants-section"
 import type { Dispatch, SetStateAction } from "react"
@@ -71,7 +70,7 @@ export function PropertyClaimForm({
 }: PropertyClaimFormProps) {
   return (
     <div className="space-y-6">
-      <DamageDataSection
+      <PropertyDamageSection
         claimFormData={claimFormData}
         handleFormChange={handleFormChange}
         claimObjectType={claimObjectType}
@@ -80,10 +79,6 @@ export function PropertyClaimForm({
         loadingRiskTypes={loadingRiskTypes}
         claimStatuses={claimStatuses}
         loadingStatuses={loadingStatuses}
-      />
-      <PropertyDamageSection
-        claimFormData={claimFormData}
-        handleFormChange={handleFormChange}
       />
       <PropertyParticipantsSection
         claimFormData={claimFormData}

--- a/components/claim-form/property-claim-summary.tsx
+++ b/components/claim-form/property-claim-summary.tsx
@@ -56,7 +56,7 @@ export function PropertyClaimSummary({
         <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
           <div className="flex items-center space-x-2">
             <FileText className="h-4 w-4 text-blue-600" />
-            <h3 className="text-sm font-semibold text-gray-900">Dane szkody i zdarzenia</h3>
+            <h3 className="text-sm font-semibold text-gray-900">Szkoda w mieniu</h3>
           </div>
         </div>
         <div className="p-4 space-y-3">
@@ -76,6 +76,36 @@ export function PropertyClaimSummary({
           </div>
           {claimFormData.eventLocation && (
             <InfoCard label="Miejsce zdarzenia" value={claimFormData.eventLocation} />
+          )}
+          <div>
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
+              Przedmiot szkody
+            </span>
+            <p className="text-sm text-gray-900 whitespace-pre-line">
+              {claimFormData.propertyDamageSubject || "Brak danych"}
+            </p>
+          </div>
+          <div>
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
+              Wykaz uszkodzeń / strat
+            </span>
+            <p className="text-sm text-gray-900 whitespace-pre-line">
+              {claimFormData.damageListing || "Brak danych"}
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Nr polisy" value={claimFormData.policyNumber} />
+            <InfoCard label="Ubezpieczyciel" value={claimFormData.insurer} />
+          </div>
+          {claimFormData.inspectionContact && (
+            <div>
+              <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
+                Dane i kontakt do oględzin
+              </span>
+              <p className="text-sm text-gray-900 whitespace-pre-line">
+                {claimFormData.inspectionContact}
+              </p>
+            </div>
           )}
         </div>
       </div>
@@ -102,33 +132,6 @@ export function PropertyClaimSummary({
             </span>
             <p className="text-sm text-gray-900 whitespace-pre-line">
               {claimFormData.perpetratorData || "Brak danych"}
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-        <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
-          <div className="flex items-center space-x-2">
-            <FileText className="h-4 w-4 text-blue-600" />
-            <h3 className="text-sm font-semibold text-gray-900">Szkoda w mieniu</h3>
-          </div>
-        </div>
-        <div className="p-4 space-y-4">
-          <div>
-            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
-              Przedmiot szkody
-            </span>
-            <p className="text-sm text-gray-900 whitespace-pre-line">
-              {claimFormData.propertyDamageSubject || "Brak danych"}
-            </p>
-          </div>
-          <div>
-            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
-              Wykaz uszkodzeń / strat
-            </span>
-            <p className="text-sm text-gray-900 whitespace-pre-line">
-              {claimFormData.damageListing || "Brak danych"}
             </p>
           </div>
         </div>

--- a/components/claim-form/property-damage-section.tsx
+++ b/components/claim-form/property-damage-section.tsx
@@ -1,17 +1,73 @@
 "use client"
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { DependentSelect } from "@/components/ui/dependent-select"
+import ClientDropdown from "@/components/client-dropdown"
+import HandlerDropdown from "@/components/handler-dropdown"
+import InsuranceDropdown from "@/components/insurance-dropdown"
+import LeasingDropdown from "@/components/leasing-dropdown"
 import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
+import { FileText } from "lucide-react"
+import type { Claim } from "@/types"
+import type { ClientSelectionEvent } from "@/types/client"
+import type { HandlerSelectionEvent } from "@/types/handler"
+import type { CompanySelectionEvent } from "@/types/insurance"
+import type { LeasingCompanySelectionEvent } from "@/types/leasing"
 
-interface PropertyDamageSectionProps {
-  claimFormData: Record<string, any>
-  handleFormChange: (field: string, value: any) => void
+interface RiskType {
+  value: string
+  label: string
 }
 
-export function PropertyDamageSection({ claimFormData, handleFormChange }: PropertyDamageSectionProps) {
+interface ClaimStatus {
+  id: number
+  name: string
+  description: string
+}
+
+interface PropertyDamageSectionProps {
+  claimFormData: Partial<Claim>
+  handleFormChange: (field: keyof Claim, value: any) => void
+  claimObjectType: string
+  setClaimObjectType: (value: string) => void
+  riskTypes: RiskType[]
+  loadingRiskTypes: boolean
+  claimStatuses: ClaimStatus[]
+  loadingStatuses: boolean
+}
+
+const formatDateForInput = (dateString: string | undefined): string => {
+  if (!dateString) return ""
+  if (dateString.match(/^\d{4}-\d{2}-\d{2}/)) {
+    return dateString.split("T")[0]
+  }
+  const parts = dateString.split(".")
+  if (parts.length === 3) {
+    const [day, month, year] = parts
+    return `${year}-${month}-${day}`
+  }
+  const date = new Date(dateString)
+  if (!isNaN(date.getTime())) {
+    return date.toISOString().split("T")[0]
+  }
+  return ""
+}
+
+export function PropertyDamageSection({
+  claimFormData,
+  handleFormChange,
+  claimObjectType,
+  setClaimObjectType,
+  riskTypes,
+  loadingRiskTypes,
+  claimStatuses,
+  loadingStatuses,
+}: PropertyDamageSectionProps) {
   const handleServiceChange = (service: string, checked: boolean) => {
     const currentServices = claimFormData.servicesCalled || []
     const newServices = checked
@@ -21,136 +77,366 @@ export function PropertyDamageSection({ claimFormData, handleFormChange }: Prope
   }
 
   return (
-    <Card className="border border-gray-200 bg-white shadow-sm">
-      <CardHeader className="bg-gray-50 border-b">
-        <CardTitle className="text-lg font-semibold text-gray-700">
-          Szkoda w mieniu
-        </CardTitle>
+    <Card className="overflow-hidden shadow-sm border-gray-200 rounded-xl">
+      <CardHeader className="flex flex-row items-center space-x-4 bg-gradient-to-r from-blue-600 to-blue-700 text-white p-4">
+        <div className="w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center">
+          <FileText className="h-4 w-4" />
+        </div>
+        <CardTitle className="text-lg font-semibold">Szkoda w mieniu</CardTitle>
       </CardHeader>
-      <CardContent className="p-6 space-y-6">
-        <div className="space-y-2">
-          <Label htmlFor="propertyDamageSubject">Przedmiot szkody</Label>
-          <Textarea
-            id="propertyDamageSubject"
-            value={claimFormData.propertyDamageSubject || ""}
-            onChange={(e) => handleFormChange("propertyDamageSubject", e.target.value)}
-            placeholder="Opis przedmiotu szkody"
-          />
+      <CardContent className="p-6 bg-white">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
+          <div className="space-y-6">
+            <div>
+              <Label htmlFor="claimObjectType" className="text-sm font-medium text-gray-700">
+                Typ szkody
+              </Label>
+              <Select
+                value={claimObjectType}
+                onValueChange={(value) => {
+                  setClaimObjectType(value)
+                  handleFormChange("riskType", "")
+                  handleFormChange("damageType", "")
+                }}
+              >
+                <SelectTrigger className="mt-1">
+                  <SelectValue placeholder="Wybierz typ szkody..." />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="1">Szkody komunikacyjne</SelectItem>
+                  <SelectItem value="2">Szkody mienia</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor="riskType" className="text-sm font-medium text-gray-700">
+                Ryzyko szkody
+              </Label>
+              <Select
+                value={claimFormData.riskType || ""}
+                onValueChange={(value) => {
+                  handleFormChange("riskType", value)
+                  handleFormChange("damageType", "")
+                }}
+                disabled={loadingRiskTypes}
+              >
+                <SelectTrigger className="mt-1">
+                  <SelectValue
+                    placeholder={loadingRiskTypes ? "Ładowanie..." : "Wybierz ryzyko szkody..."}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {riskTypes.map((riskType) => (
+                    <SelectItem key={riskType.value} value={riskType.value}>
+                      {riskType.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor="status" className="text-sm font-medium text-gray-700">
+                Status szkody
+              </Label>
+              <Select
+                value={claimFormData.status?.toString() || ""}
+                onValueChange={(value) => handleFormChange("status", value)}
+                disabled={loadingStatuses}
+              >
+                <SelectTrigger className="mt-1">
+                  <SelectValue
+                    placeholder={loadingStatuses ? "Ładowanie..." : "Wybierz status szkody..."}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {claimStatuses.map((status) => (
+                    <SelectItem key={status.id} value={status.id.toString()}>
+                      {status.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor="reportDateToInsurer" className="text-sm font-medium text-gray-700">
+                Data zgłoszenia do TU
+              </Label>
+              <Input
+                id="reportDateToInsurer"
+                type="date"
+                value={formatDateForInput(claimFormData.reportDateToInsurer)}
+                onChange={(e) => handleFormChange("reportDateToInsurer", e.target.value)}
+                className="mt-1"
+              />
+            </div>
+            <div className="relative z-10">
+              <Label htmlFor="client" className="text-sm font-medium text-gray-700 mb-2 block">
+                Klient
+              </Label>
+              <ClientDropdown
+                selectedClientId={claimFormData.clientId ? parseInt(claimFormData.clientId) : undefined}
+                onClientSelected={(event: ClientSelectionEvent) => {
+                  handleFormChange("client", event.clientName)
+                  handleFormChange("clientId", event.clientId.toString())
+                }}
+                className="relative z-20"
+              />
+            </div>
+            <div>
+              <Label className="text-sm font-medium text-gray-700 mb-3 block">
+                Kanał zgłoszenia
+              </Label>
+              <RadioGroup
+                value={claimFormData.reportingChannel || ""}
+                onValueChange={(value) => handleFormChange("reportingChannel", value)}
+                className="flex space-x-4"
+              >
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="infolinia" id="channel-infolinia" />
+                  <Label htmlFor="channel-infolinia" className="font-normal text-sm">
+                    Infolinia
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="email" id="channel-email" />
+                  <Label htmlFor="channel-email" className="font-normal text-sm">
+                    Email
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value="bezpośrednio" id="channel-direct" />
+                  <Label htmlFor="channel-direct" className="font-normal text-sm">
+                    Bezpośrednio
+                  </Label>
+                </div>
+              </RadioGroup>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div>
+              <Label htmlFor="damageType" className="text-sm font-medium text-gray-700">
+                Rodzaj szkody
+              </Label>
+              <DependentSelect
+                value={claimFormData.damageType || ""}
+                onValueChange={(value) => handleFormChange("damageType", value)}
+                placeholder="Wybierz rodzaj szkody..."
+                apiUrl="/api/damage-types"
+                riskTypeId={claimFormData.riskType}
+                disabled={!claimFormData.riskType}
+              />
+            </div>
+            <div>
+              <Label htmlFor="insurerClaimNumber" className="text-sm font-medium text-gray-700">
+                Nr szkody TU
+              </Label>
+              <Input
+                id="insurerClaimNumber"
+                value={claimFormData.insurerClaimNumber || ""}
+                onChange={(e) => handleFormChange("insurerClaimNumber", e.target.value)}
+                className="mt-1"
+              />
+            </div>
+            <div>
+              <Label className="text-sm font-medium text-gray-700">Nr szkody Sparta</Label>
+              <Input
+                id="spartaNumber"
+                value={claimFormData.spartaNumber || ""}
+                readOnly
+                className="bg-gray-50 mt-1 border-gray-200"
+              />
+            </div>
+            <div>
+              <Label htmlFor="handler" className="text-sm font-medium text-gray-700">
+                Szkodę zarejestrował
+              </Label>
+              <HandlerDropdown
+                selectedHandlerId={claimFormData.handlerId || undefined}
+                onHandlerSelected={(event: HandlerSelectionEvent) => {
+                  handleFormChange("handlerId", event.handlerId.toString())
+                  handleFormChange("handler", event.handlerName)
+                  handleFormChange("handlerEmail", event.handlerEmail || "")
+                  handleFormChange("handlerPhone", event.handlerPhone || "")
+                }}
+                className="mt-1"
+              />
+            </div>
+          </div>
         </div>
 
-        <div className="space-y-2">
-          <Label htmlFor="damageListing">Wykaz uszkodzeń / strat</Label>
-          <Textarea
-            id="damageListing"
-            value={claimFormData.damageListing || ""}
-            onChange={(e) => handleFormChange("damageListing", e.target.value)}
-            placeholder="Opis uszkodzeń lub strat"
-          />
-        </div>
+        <div className="border-t border-gray-200 my-8" />
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label htmlFor="policyNumber">Nr polisy</Label>
-            <Input
-              id="policyNumber"
-              value={claimFormData.policyNumber || ""}
-              onChange={(e) => handleFormChange("policyNumber", e.target.value)}
-              placeholder="Wprowadź numer polisy"
+        <div className="space-y-6">
+          <div className="relative z-10">
+            <Label
+              htmlFor="insuranceCompany"
+              className="text-sm font-medium text-gray-700 mb-2 block"
+            >
+              Towarzystwo ubezpieczeniowe
+            </Label>
+            <InsuranceDropdown
+              selectedCompanyId={
+                claimFormData.insuranceCompanyId
+                  ? parseInt(claimFormData.insuranceCompanyId)
+                  : undefined
+              }
+              onCompanySelected={(event: CompanySelectionEvent) => {
+                handleFormChange("insuranceCompany", event.companyName)
+                handleFormChange("insuranceCompanyId", event.companyId.toString())
+              }}
+              className="relative z-20"
             />
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="insurer">Ubezpieczyciel</Label>
-            <Input
-              id="insurer"
-              value={claimFormData.insurer || ""}
-              onChange={(e) => handleFormChange("insurer", e.target.value)}
-              placeholder="Wprowadź nazwę ubezpieczyciela"
+          <div className="relative z-10">
+            <Label
+              htmlFor="leasingCompany"
+              className="text-sm font-medium text-gray-700 mb-2 block"
+            >
+              Firma leasingowa
+            </Label>
+            <LeasingDropdown
+              selectedCompanyId={
+                claimFormData.leasingCompanyId
+                  ? parseInt(claimFormData.leasingCompanyId)
+                  : undefined
+              }
+              onCompanySelected={(event: LeasingCompanySelectionEvent) => {
+                handleFormChange("leasingCompany", event.companyName)
+                handleFormChange("leasingCompanyId", event.companyId.toString())
+              }}
+              className="relative z-10"
             />
-          </div>
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="inspectionContact">Dane i kontakt do oględzin</Label>
-          <Textarea
-            id="inspectionContact"
-            value={claimFormData.inspectionContact || ""}
-            onChange={(e) => handleFormChange("inspectionContact", e.target.value)}
-            placeholder="Osoba kontaktowa i informacje do oględzin"
-          />
-        </div>
-
-        <div className="space-y-2">
-          <Label>Wezwane służby</Label>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {['policja', 'pogotowie', 'straz', 'holownik'].map((service) => (
-              <div key={service} className="flex items-center space-x-2">
-                <Checkbox
-                  id={service}
-                  checked={claimFormData.servicesCalled?.includes(service) || false}
-                  onCheckedChange={(checked) => handleServiceChange(service, checked as boolean)}
-                />
-                <Label htmlFor={service} className="capitalize">
-                  {service === 'straz' ? 'Straż pożarna' : service}
-                </Label>
-              </div>
-            ))}
           </div>
         </div>
 
-        {claimFormData.servicesCalled?.includes("policja") && (
-          <div className="space-y-2">
-            <Label htmlFor="policeDescription">Policja - opis</Label>
-            <Input
-              id="policeDescription"
-              value={claimFormData.policeDescription || ""}
-              onChange={(e) => handleFormChange("policeDescription", e.target.value)}
-              placeholder="Wprowadź opis interwencji policji"
-            />
-            <Label htmlFor="policeUnitDetails">Policja - dane jednostki</Label>
-            <Input
-              id="policeUnitDetails"
-              value={claimFormData.policeUnitDetails || ""}
-              onChange={(e) => handleFormChange("policeUnitDetails", e.target.value)}
-              placeholder="Wprowadź dane jednostki policji"
-            />
-          </div>
-        )}
+        <div className="border-t border-gray-200 my-8" />
 
-        {claimFormData.servicesCalled?.includes("pogotowie") && (
+        <div className="space-y-6">
           <div className="space-y-2">
-            <Label htmlFor="ambulanceDescription">Pogotowie - opis</Label>
-            <Input
-              id="ambulanceDescription"
-              value={claimFormData.ambulanceDescription || ""}
-              onChange={(e) => handleFormChange("ambulanceDescription", e.target.value)}
-              placeholder="Wprowadź opis interwencji pogotowia"
+            <Label htmlFor="propertyDamageSubject">Przedmiot szkody</Label>
+            <Textarea
+              id="propertyDamageSubject"
+              value={claimFormData.propertyDamageSubject || ""}
+              onChange={(e) => handleFormChange("propertyDamageSubject", e.target.value)}
+              placeholder="Opis przedmiotu szkody"
             />
           </div>
-        )}
 
-        {claimFormData.servicesCalled?.includes("straz") && (
           <div className="space-y-2">
-            <Label htmlFor="fireDescription">Straż pożarna - opis</Label>
-            <Input
-              id="fireDescription"
-              value={claimFormData.fireDescription || ""}
-              onChange={(e) => handleFormChange("fireDescription", e.target.value)}
-              placeholder="Wprowadź opis interwencji straży pożarnej"
+            <Label htmlFor="damageListing">Wykaz uszkodzeń / strat</Label>
+            <Textarea
+              id="damageListing"
+              value={claimFormData.damageListing || ""}
+              onChange={(e) => handleFormChange("damageListing", e.target.value)}
+              placeholder="Opis uszkodzeń lub strat"
             />
           </div>
-        )}
 
-        {claimFormData.servicesCalled?.includes("holownik") && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="policyNumber">Nr polisy</Label>
+              <Input
+                id="policyNumber"
+                value={claimFormData.policyNumber || ""}
+                onChange={(e) => handleFormChange("policyNumber", e.target.value)}
+                placeholder="Wprowadź numer polisy"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="insurer">Ubezpieczyciel</Label>
+              <Input
+                id="insurer"
+                value={claimFormData.insurer || ""}
+                onChange={(e) => handleFormChange("insurer", e.target.value)}
+                placeholder="Wprowadź nazwę ubezpieczyciela"
+              />
+            </div>
+          </div>
+
           <div className="space-y-2">
-            <Label htmlFor="towDescription">Holownik - opis</Label>
-            <Input
-              id="towDescription"
-              value={claimFormData.towDescription || ""}
-              onChange={(e) => handleFormChange("towDescription", e.target.value)}
-              placeholder="Wprowadź opis usługi holowania"
+            <Label htmlFor="inspectionContact">Dane i kontakt do oględzin</Label>
+            <Textarea
+              id="inspectionContact"
+              value={claimFormData.inspectionContact || ""}
+              onChange={(e) => handleFormChange("inspectionContact", e.target.value)}
+              placeholder="Osoba kontaktowa i informacje do oględzin"
             />
           </div>
-        )}
+
+          <div className="space-y-2">
+            <Label>Wezwane służby</Label>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              {['policja', 'pogotowie', 'straz', 'holownik'].map((service) => (
+                <div key={service} className="flex items-center space-x-2">
+                  <Checkbox
+                    id={service}
+                    checked={claimFormData.servicesCalled?.includes(service) || false}
+                    onCheckedChange={(checked) => handleServiceChange(service, checked as boolean)}
+                  />
+                  <Label htmlFor={service} className="capitalize">
+                    {service === 'straz' ? 'Straż pożarna' : service}
+                  </Label>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {claimFormData.servicesCalled?.includes("policja") && (
+            <div className="space-y-2">
+              <Label htmlFor="policeDescription">Policja - opis</Label>
+              <Input
+                id="policeDescription"
+                value={claimFormData.policeDescription || ""}
+                onChange={(e) => handleFormChange("policeDescription", e.target.value)}
+                placeholder="Wprowadź opis interwencji policji"
+              />
+              <Label htmlFor="policeUnitDetails">Policja - dane jednostki</Label>
+              <Input
+                id="policeUnitDetails"
+                value={claimFormData.policeUnitDetails || ""}
+                onChange={(e) => handleFormChange("policeUnitDetails", e.target.value)}
+                placeholder="Wprowadź dane jednostki policji"
+              />
+            </div>
+          )}
+
+          {claimFormData.servicesCalled?.includes("pogotowie") && (
+            <div className="space-y-2">
+              <Label htmlFor="ambulanceDescription">Pogotowie - opis</Label>
+              <Input
+                id="ambulanceDescription"
+                value={claimFormData.ambulanceDescription || ""}
+                onChange={(e) => handleFormChange("ambulanceDescription", e.target.value)}
+                placeholder="Wprowadź opis interwencji pogotowia"
+              />
+            </div>
+          )}
+
+          {claimFormData.servicesCalled?.includes("straz") && (
+            <div className="space-y-2">
+              <Label htmlFor="fireDescription">Straż pożarna - opis</Label>
+              <Input
+                id="fireDescription"
+                value={claimFormData.fireDescription || ""}
+                onChange={(e) => handleFormChange("fireDescription", e.target.value)}
+                placeholder="Wprowadź opis interwencji straży pożarnej"
+              />
+            </div>
+          )}
+
+          {claimFormData.servicesCalled?.includes("holownik") && (
+            <div className="space-y-2">
+              <Label htmlFor="towDescription">Holownik - opis</Label>
+              <Input
+                id="towDescription"
+                value={claimFormData.towDescription || ""}
+                onChange={(e) => handleFormChange("towDescription", e.target.value)}
+                placeholder="Wprowadź opis usługi holowania"
+              />
+            </div>
+          )}
+        </div>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## Summary
- Merge general claim details with property-specific inputs into one `Szkoda w mieniu` section
- Simplify property claim form to use only the combined section
- Update summary view to display new property damage fields

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm install` *(fails: GET https://registry.npmjs.org/...: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a2544e677c832c87a50d8c64ff73f6