### PR TITLE
Connect client claims section to backend controller

### DIFF
--- a/app/api/clientclaims/[id]/download/route.ts
+++ b/app/api/clientclaims/[id]/download/route.ts
@@ -6,7 +6,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const { id } = params
 
-    const response = await fetch(`${API_BASE_URL}/client-claims/${id}/download`)
+    const response = await fetch(`${API_BASE_URL}/clientclaims/${id}/download`)
 
     if (!response.ok) {
       const errorText = await response.text()

--- a/app/api/clientclaims/[id]/preview/route.ts
+++ b/app/api/clientclaims/[id]/preview/route.ts
@@ -6,7 +6,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const { id } = params
 
-    const response = await fetch(`${API_BASE_URL}/client-claims/${id}/preview`)
+    const response = await fetch(`${API_BASE_URL}/clientclaims/${id}/preview`)
 
     if (!response.ok) {
       const errorText = await response.text()

--- a/app/api/clientclaims/[id]/route.ts
+++ b/app/api/clientclaims/[id]/route.ts
@@ -6,7 +6,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const { id } = params
 
-    const response = await fetch(`${API_BASE_URL}/client-claims/${id}`)
+    const response = await fetch(`${API_BASE_URL}/clientclaims/${id}`)
 
     if (!response.ok) {
       const errorText = await response.text()
@@ -54,7 +54,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
     if (documentDescription) backendFormData.append("DocumentDescription", documentDescription)
     if (document) backendFormData.append("Document", document)
 
-    const response = await fetch(`${API_BASE_URL}/client-claims/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/clientclaims/${id}`, {
       method: "PUT",
       body: backendFormData,
     })
@@ -80,7 +80,7 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
   try {
     const { id } = params
 
-    const response = await fetch(`${API_BASE_URL}/client-claims/${id}`, {
+    const response = await fetch(`${API_BASE_URL}/clientclaims/${id}`, {
       method: "DELETE",
     })
 

--- a/app/api/clientclaims/route.ts
+++ b/app/api/clientclaims/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Event ID is required" }, { status: 400 })
     }
 
-    const response = await fetch(`${API_BASE_URL}/client-claims/event/${eventId}`, {
+    const response = await fetch(`${API_BASE_URL}/clientclaims/event/${eventId}`, {
       headers: {
         "Content-Type": "application/json",
       },
@@ -64,7 +64,7 @@ export async function POST(request: NextRequest) {
     if (documentDescription) backendFormData.append("DocumentDescription", documentDescription)
     if (document) backendFormData.append("Document", document)
 
-    const response = await fetch(`${API_BASE_URL}/client-claims`, {
+    const response = await fetch(`${API_BASE_URL}/clientclaims`, {
       method: "POST",
       body: backendFormData,
     })

--- a/lib/api/clientclaims.ts
+++ b/lib/api/clientclaims.ts
@@ -1,0 +1,124 @@
+import { API_BASE_URL, ClientClaimDto } from "../api"
+import type { ClientClaim, ClaimStatus } from "@/types"
+
+export interface ClientClaimUpsert {
+  eventId?: string
+  claimNumber?: string
+  claimDate: string
+  claimType: string
+  claimAmount: number
+  currency: string
+  status: ClaimStatus
+  description?: string
+  claimNotes?: string
+  documentDescription?: string
+}
+
+const CLIENT_CLAIMS_URL = `${API_BASE_URL}/clientclaims`
+
+function mapDtoToClientClaim(dto: ClientClaimDto): ClientClaim {
+  return {
+    id: dto.id,
+    eventId: dto.eventId,
+    claimNumber: dto.claimNumber || undefined,
+    claimDate: dto.claimDate?.split("T")[0] || "",
+    claimType: dto.claimType || "",
+    claimAmount: dto.claimAmount,
+    currency: dto.currency,
+    status: dto.status as ClaimStatus,
+    description: dto.description || undefined,
+    documentPath: dto.documentPath || undefined,
+    documentName: dto.documentName || undefined,
+    documentDescription: dto.documentDescription || undefined,
+    claimNotes: dto.claimNotes || undefined,
+    createdAt: dto.createdAt,
+    updatedAt: dto.updatedAt,
+  }
+}
+
+function buildFormData(data: ClientClaimUpsert, document?: File) {
+  const formData = new FormData()
+  if (data.eventId) formData.append("EventId", data.eventId)
+  formData.append("ClaimDate", data.claimDate)
+  formData.append("ClaimType", data.claimType)
+  formData.append("ClaimAmount", data.claimAmount.toString())
+  formData.append("Currency", data.currency)
+  formData.append("Status", data.status)
+  if (data.description) formData.append("Description", data.description)
+  if (data.claimNotes) formData.append("ClaimNotes", data.claimNotes)
+  if (data.claimNumber) formData.append("ClaimNumber", data.claimNumber)
+  if (data.documentDescription)
+    formData.append("DocumentDescription", data.documentDescription)
+  if (document) formData.append("Document", document)
+  return formData
+}
+
+export async function createClientClaim(
+  data: ClientClaimUpsert,
+  document?: File,
+): Promise<ClientClaim> {
+  const body = buildFormData(data, document)
+  const response = await fetch(CLIENT_CLAIMS_URL, {
+    method: "POST",
+    credentials: "include",
+    body,
+  })
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(text || "Failed to create client claim")
+  }
+  const dto = (await response.json()) as ClientClaimDto
+  return mapDtoToClientClaim(dto)
+}
+
+export async function updateClientClaim(
+  id: string,
+  data: ClientClaimUpsert,
+  document?: File,
+): Promise<ClientClaim> {
+  const body = buildFormData(data, document)
+  const response = await fetch(`${CLIENT_CLAIMS_URL}/${id}`, {
+    method: "PUT",
+    credentials: "include",
+    body,
+  })
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(text || "Failed to update client claim")
+  }
+  const dto = (await response.json()) as ClientClaimDto
+  return mapDtoToClientClaim(dto)
+}
+
+export async function deleteClientClaim(id: string): Promise<void> {
+  const response = await fetch(`${CLIENT_CLAIMS_URL}/${id}`, {
+    method: "DELETE",
+    credentials: "include",
+  })
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(text || "Failed to delete client claim")
+  }
+}
+
+export async function downloadClientClaimDocument(id: string): Promise<Blob> {
+  const response = await fetch(`${CLIENT_CLAIMS_URL}/${id}/download`, {
+    method: "GET",
+    credentials: "include",
+  })
+  if (!response.ok) {
+    throw new Error("Failed to download document")
+  }
+  return response.blob()
+}
+
+export async function previewClientClaimDocument(id: string): Promise<Blob> {
+  const response = await fetch(`${CLIENT_CLAIMS_URL}/${id}/preview`, {
+    method: "GET",
+    credentials: "include",
+  })
+  if (!response.ok) {
+    throw new Error("Failed to preview document")
+  }
+  return response.blob()
+}


### PR DESCRIPTION
## Summary
- add API client for client claim endpoints
- wire client claims section to create, update, delete and preview via API
- rename client claim endpoints to `clientclaims` to match backend controller

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/input-otp: Forbidden - 403)*
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*

------
https://chatgpt.com/codex/tasks/task_e_68a251f1eaac832c98cd40e55a8b7bb3