### PR TITLE
fix: retain document category when editing description

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -583,12 +583,17 @@ export const DocumentsSection = React.forwardRef<DocumentsSectionRef, DocumentsS
   }
 
   const handleDescriptionChange = async (documentId: string | number, description: string) => {
-
     const pendingIndex = pendingFiles.findIndex((f) => f.id === documentId)
+
     if (pendingIndex !== -1) {
       setPendingFiles?.((prev) => prev.map((f) => (f.id === documentId ? { ...f, description } : f)))
+      setPreviewDocument((prev) => (prev?.id === documentId ? { ...prev, description } : prev))
       return
     }
+
+    // Optimistic update to keep document within its category and update preview
+    setDocuments((prev) => prev.map((doc) => (doc.id === documentId ? { ...doc, description } : doc)))
+    setPreviewDocument((prev) => (prev?.id === documentId ? { ...prev, description } : prev))
 
     try {
       const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents/${documentId}`, {
@@ -602,7 +607,12 @@ export const DocumentsSection = React.forwardRef<DocumentsSectionRef, DocumentsS
 
       if (response.ok) {
         const updatedDocument = await response.json()
-        setDocuments((prev) => prev.map((doc) => (doc.id === documentId ? updatedDocument : doc)))
+        setDocuments((prev) =>
+          prev.map((doc) => (doc.id === documentId ? { ...doc, ...updatedDocument } : doc)),
+        )
+        setPreviewDocument((prev) =>
+          prev?.id === documentId ? { ...prev, ...updatedDocument } : prev,
+        )
       }
     } catch (error) {
       console.error("Error updating document description:", error)


### PR DESCRIPTION
## Summary
- keep document in its category when editing description
- update preview when description changes

## Testing
- `pnpm lint` *(fails: next: not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*


------
https://chatgpt.com/codex/tasks/task_e_68a2536fc4d8832ca5e0dcb3f1824f64