### PR TITLE
Fix missing props for PropertyDamageSection

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -1273,6 +1273,12 @@ export const ClaimMainContent = ({
             <PropertyDamageSection
               claimFormData={claimFormData}
               handleFormChange={(field, value) => handleFormChange(field as keyof Claim, value)}
+              claimObjectType={claimObjectType}
+              setClaimObjectType={setClaimObjectType}
+              riskTypes={riskTypes}
+              loadingRiskTypes={loadingRiskTypes}
+              claimStatuses={claimStatuses}
+              loadingStatuses={loadingStatuses}
             />
           )}
           {claimObjectType === "3" && (


### PR DESCRIPTION
## Summary
- Pass claim type, risk and status data to `PropertyDamageSection`

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm install` *(fails: GET https://registry.npmjs.org/typescript: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a259c47820832cb52777b2d79ee1a8