### PR TITLE
Add dynamic reporting module with Excel export

### DIFF
--- a/app/reports/layout.tsx
+++ b/app/reports/layout.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+import { Header } from '@/components/header'
+import { Sidebar } from '@/components/sidebar'
+
+export default function ReportsLayout({ children }: { children: ReactNode }) {
+  const [activeTab, setActiveTab] = useState('reports')
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+      <div className="ml-16 flex flex-col min-h-screen">
+        <Header onMenuClick={() => {}} />
+        <main className="flex-1">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  getReportMetadata,
+  exportReport,
+  getFilterValues,
+  ReportRequest,
+  ReportMetadata,
+} from "@/lib/api/reports";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { saveAs } from "file-saver";
+
+export default function ReportsPage() {
+  const [metadata, setMetadata] = useState<ReportMetadata>({});
+  const [entity, setEntity] = useState("");
+  const [fields, setFields] = useState<string[]>([]);
+  const [filters, setFilters] = useState<Record<string, string>>({});
+  const [filterField, setFilterField] = useState("");
+  const [filterOptions, setFilterOptions] = useState<string[]>([]);
+  const [fromDate, setFromDate] = useState("");
+  const [toDate, setToDate] = useState("");
+
+  useEffect(() => {
+    getReportMetadata().then(setMetadata).catch(console.error);
+  }, []);
+
+  const toggleField = (field: string) => {
+    setFields((prev) =>
+      prev.includes(field) ? prev.filter((f) => f !== field) : [...prev, field],
+    );
+  };
+
+  useEffect(() => {
+    if (entity && filterField) {
+      getFilterValues(entity, filterField)
+        .then(setFilterOptions)
+        .catch(console.error);
+    }
+  }, [entity, filterField]);
+
+  const handleExport = async () => {
+    const request: ReportRequest = {
+      entity,
+      fields,
+      filters: Object.keys(filters).length ? filters : undefined,
+      fromDate: fromDate || undefined,
+      toDate: toDate || undefined,
+    };
+    const blob = await exportReport(request);
+    saveAs(blob, "report.xlsx");
+  };
+
+  const entityFields = metadata[entity] || [];
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Raporty</h1>
+      <div className="w-full md:w-1/3">
+        <Select value={entity} onValueChange={setEntity}>
+          <SelectTrigger>
+            <SelectValue placeholder="Wybierz encję" />
+          </SelectTrigger>
+          <SelectContent>
+            {Object.keys(metadata).map((name) => (
+              <SelectItem key={name} value={name}>
+                {name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {entity && (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <p className="font-medium">Pola</p>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+              {entityFields.map((f) => (
+                <label key={f} className="flex items-center space-x-2">
+                  <Checkbox
+                    checked={fields.includes(f)}
+                    onCheckedChange={() => toggleField(f)}
+                  />
+                  <span>{f}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <p className="font-medium">Filtry</p>
+            <div className="flex space-x-2">
+              <Select value={filterField} onValueChange={setFilterField}>
+                <SelectTrigger className="w-48">
+                  <SelectValue placeholder="Pole" />
+                </SelectTrigger>
+                <SelectContent>
+                  {entityFields.map((f) => (
+                    <SelectItem key={f} value={f}>
+                      {f}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {filterField && (
+                <Select
+                  onValueChange={(value) => {
+                    setFilters((prev) => ({ ...prev, [filterField]: value }));
+                    setFilterField("");
+                    setFilterOptions([]);
+                  }}
+                >
+                  <SelectTrigger className="w-48">
+                    <SelectValue placeholder="Wartość" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {filterOptions.map((v) => (
+                      <SelectItem key={v} value={v}>
+                        {v}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+            {Object.keys(filters).length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {Object.entries(filters).map(([key, value]) => (
+                  <span
+                    key={key}
+                    className="px-2 py-1 bg-secondary rounded text-sm"
+                  >
+                    {key}: {value}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <Input
+              type="date"
+              value={fromDate}
+              onChange={(e) => setFromDate(e.target.value)}
+            />
+            <Input
+              type="date"
+              value={toDate}
+              onChange={(e) => setToDate(e.target.value)}
+            />
+          </div>
+        </div>
+      )}
+      <Button onClick={handleExport} disabled={!entity || fields.length === 0}>
+        Eksport do Excel
+      </Button>
+    </div>
+  );
+}

--- a/backend/AutomotiveClaimsApi.csproj
+++ b/backend/AutomotiveClaimsApi.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.0" />
+    <PackageReference Include="ClosedXML" Version="0.102.4" />
   </ItemGroup>
 
 </Project>

--- a/backend/Controllers/ReportController.cs
+++ b/backend/Controllers/ReportController.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ClosedXML.Excel;
+using AutomotiveClaimsApi.Data;
+
+namespace AutomotiveClaimsApi.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class ReportController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+
+        public ReportController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet("metadata")]
+        public IActionResult GetMetadata()
+        {
+            var dbSets = typeof(ApplicationDbContext).GetProperties()
+                .Where(p => p.PropertyType.IsGenericType && p.PropertyType.GetGenericTypeDefinition() == typeof(DbSet<>));
+
+            var result = new Dictionary<string, IEnumerable<string>>();
+
+            foreach (var dbSet in dbSets)
+            {
+                var entityType = dbSet.PropertyType.GetGenericArguments()[0];
+                var fields = entityType.GetProperties()
+                    .Where(pi => pi.PropertyType.IsPrimitive || pi.PropertyType == typeof(string) || pi.PropertyType == typeof(DateTime) || pi.PropertyType == typeof(DateTime?))
+                    .Select(pi => pi.Name)
+                    .ToList();
+                result[entityType.Name] = fields;
+            }
+
+            return Ok(result);
+        }
+
+        [HttpGet("values")]
+        public IActionResult GetFieldValues([FromQuery] string entity, [FromQuery] string field)
+        {
+            if (string.IsNullOrEmpty(entity) || string.IsNullOrEmpty(field))
+                return BadRequest();
+
+            var dbSetProperty = typeof(ApplicationDbContext).GetProperties()
+                .FirstOrDefault(p => p.PropertyType.IsGenericType && p.PropertyType.GetGenericArguments()[0].Name == entity);
+            if (dbSetProperty == null)
+                return NotFound();
+
+            var entityType = dbSetProperty.PropertyType.GetGenericArguments()[0];
+            var prop = entityType.GetProperty(field);
+            if (prop == null)
+                return NotFound();
+
+            var setMethod = typeof(ApplicationDbContext).GetMethods()
+                .First(m => m.Name == "Set" && m.IsGenericMethod && m.GetParameters().Length == 0);
+            var queryable = (IQueryable)setMethod.MakeGenericMethod(entityType).Invoke(_context, null)!;
+            var values = queryable.Cast<object>()
+                .Select(e => prop.GetValue(e)?.ToString())
+                .Where(v => !string.IsNullOrEmpty(v))
+                .Distinct()
+                .ToList();
+
+            return Ok(values);
+        }
+
+        [HttpPost("export")]
+        public IActionResult Export([FromBody] ReportRequest request)
+        {
+            if (string.IsNullOrEmpty(request.Entity))
+                return BadRequest("Entity is required");
+
+            var dbSetProperty = typeof(ApplicationDbContext).GetProperties()
+                .FirstOrDefault(p => p.PropertyType.IsGenericType && p.PropertyType.GetGenericArguments()[0].Name == request.Entity);
+            if (dbSetProperty == null)
+                return NotFound();
+
+            var entityType = dbSetProperty.PropertyType.GetGenericArguments()[0];
+            var setMethod = typeof(ApplicationDbContext).GetMethods()
+                .First(m => m.Name == "Set" && m.IsGenericMethod && m.GetParameters().Length == 0);
+            var queryable = (IQueryable)setMethod.MakeGenericMethod(entityType).Invoke(_context, null)!;
+            var data = queryable.Cast<object>().ToList();
+
+            if (request.Filters != null)
+            {
+                foreach (var filter in request.Filters)
+                {
+                    var prop = entityType.GetProperty(filter.Key);
+                    if (prop != null)
+                    {
+                        data = data.Where(d => (prop.GetValue(d)?.ToString() ?? "") == filter.Value).ToList();
+                    }
+                }
+            }
+            if (request.FromDate != null)
+            {
+                var dateProp = entityType.GetProperty("DamageDate") ?? entityType.GetProperty("CreatedAt");
+                if (dateProp != null)
+                {
+                    data = data.Where(d =>
+                    {
+                        var val = dateProp.GetValue(d) as DateTime?;
+                        return val != null && val >= request.FromDate;
+                    }).ToList();
+                }
+            }
+            if (request.ToDate != null)
+            {
+                var dateProp = entityType.GetProperty("DamageDate") ?? entityType.GetProperty("CreatedAt");
+                if (dateProp != null)
+                {
+                    data = data.Where(d =>
+                    {
+                        var val = dateProp.GetValue(d) as DateTime?;
+                        return val != null && val <= request.ToDate;
+                    }).ToList();
+                }
+            }
+
+            using var workbook = new XLWorkbook();
+            var worksheet = workbook.Worksheets.Add("Report");
+            for (int i = 0; i < request.Fields.Count; i++)
+            {
+                worksheet.Cell(1, i + 1).Value = request.Fields[i];
+            }
+            for (int row = 0; row < data.Count; row++)
+            {
+                for (int col = 0; col < request.Fields.Count; col++)
+                {
+                    var prop = entityType.GetProperty(request.Fields[col]);
+                    if (prop != null)
+                    {
+                        var value = prop.GetValue(data[row]);
+                        worksheet.Cell(row + 2, col + 1).Value = value?.ToString();
+                    }
+                }
+            }
+
+            using var stream = new MemoryStream();
+            workbook.SaveAs(stream);
+            stream.Position = 0;
+            return File(stream.ToArray(), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "report.xlsx");
+        }
+    }
+
+    public class ReportRequest
+    {
+        public string Entity { get; set; } = string.Empty;
+        public List<string> Fields { get; set; } = new();
+        public Dictionary<string, string>? Filters { get; set; }
+        public DateTime? FromDate { get; set; }
+        public DateTime? ToDate { get; set; }
+    }
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -3,7 +3,14 @@ import Link from "next/link"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 
-import { LayoutDashboard, FileText, Car, Settings, Inbox } from "lucide-react"
+import {
+  LayoutDashboard,
+  FileText,
+  Car,
+  Settings,
+  Inbox,
+  BarChart3,
+} from "lucide-react"
 
 import { useAuth } from "@/hooks/use-auth"
 
@@ -32,6 +39,12 @@ const menuItems = [
     icon: Inbox,
 
     href: "/emails/unassigned",
+  },
+  {
+    id: "reports",
+    label: "Raporty",
+    icon: BarChart3,
+    href: "/reports",
   },
   {
     id: "settings",

--- a/lib/api/reports.ts
+++ b/lib/api/reports.ts
@@ -1,0 +1,52 @@
+import { API_BASE_URL } from "../api";
+
+export interface ReportMetadata {
+  [entity: string]: string[];
+}
+
+export interface ReportRequest {
+  entity: string;
+  fields: string[];
+  filters?: Record<string, string>;
+  fromDate?: string;
+  toDate?: string;
+}
+
+export async function getReportMetadata(): Promise<ReportMetadata> {
+  const res = await fetch(`${API_BASE_URL}/report/metadata`, {
+    credentials: "include",
+  });
+  if (!res.ok) {
+    throw new Error("Failed to fetch report metadata");
+  }
+  return res.json();
+}
+
+export async function exportReport(request: ReportRequest): Promise<Blob> {
+  const res = await fetch(`${API_BASE_URL}/report/export`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+  if (!res.ok) {
+    throw new Error("Failed to export report");
+  }
+  return res.blob();
+}
+
+export async function getFilterValues(
+  entity: string,
+  field: string,
+): Promise<string[]> {
+  const res = await fetch(
+    `${API_BASE_URL}/report/values?entity=${encodeURIComponent(
+      entity,
+    )}&field=${encodeURIComponent(field)}`,
+    { credentials: "include" },
+  );
+  if (!res.ok) {
+    throw new Error("Failed to fetch filter values");
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- implement backend report controller that enumerates entities, filters results, and exports selected fields to Excel
- add ClosedXML dependency for spreadsheet generation
- build front-end reports page for field selection, filtering, and one-click Excel download
- wire up Reports page into sidebar navigation and add dedicated layout
- support dynamic filters with API-provided distinct field values

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm install` *(fails: GET https://registry.npmjs.org/typescript: Forbidden - 403)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a2079fe430832c801a8e8dfc89ddd2