### PR TITLE
feat(property-form): move property section and hide claim data

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -873,16 +873,29 @@ export const ClaimMainContent = ({
       return (
         <div className="space-y-4">
 
-          <DamageDataSection
-            claimFormData={claimFormData}
-            handleFormChange={handleFormChange}
-            claimObjectType={claimObjectType}
-            setClaimObjectType={setClaimObjectType}
-            riskTypes={riskTypes}
-            loadingRiskTypes={loadingRiskTypes}
-            claimStatuses={claimStatuses}
-            loadingStatuses={loadingStatuses}
-          />
+          {claimObjectType === "2" ? (
+            <PropertyDamageSection
+              claimFormData={claimFormData}
+              handleFormChange={(field, value) => handleFormChange(field as keyof Claim, value)}
+              claimObjectType={claimObjectType}
+              setClaimObjectType={setClaimObjectType}
+              riskTypes={riskTypes}
+              loadingRiskTypes={loadingRiskTypes}
+              claimStatuses={claimStatuses}
+              loadingStatuses={loadingStatuses}
+            />
+          ) : (
+            <DamageDataSection
+              claimFormData={claimFormData}
+              handleFormChange={handleFormChange}
+              claimObjectType={claimObjectType}
+              setClaimObjectType={setClaimObjectType}
+              riskTypes={riskTypes}
+              loadingRiskTypes={loadingRiskTypes}
+              claimStatuses={claimStatuses}
+              loadingStatuses={loadingStatuses}
+            />
+          )}
 
           {/* Opis zdarzenia Card */}
           <Card className="overflow-hidden shadow-sm border-gray-200 rounded-xl">
@@ -1268,18 +1281,6 @@ export const ClaimMainContent = ({
                 </div>
               </CardContent>
             </Card>
-          )}
-          {claimObjectType === "2" && (
-            <PropertyDamageSection
-              claimFormData={claimFormData}
-              handleFormChange={(field, value) => handleFormChange(field as keyof Claim, value)}
-              claimObjectType={claimObjectType}
-              setClaimObjectType={setClaimObjectType}
-              riskTypes={riskTypes}
-              loadingRiskTypes={loadingRiskTypes}
-              claimStatuses={claimStatuses}
-              loadingStatuses={loadingStatuses}
-            />
           )}
           {claimObjectType === "3" && (
             <TransportDamageSection


### PR DESCRIPTION
## Summary
- Display "Szkoda w mieniu" section at the top of property claim forms
- Hide generic claim data card when editing property claims

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm lint` *(fails: next: not found; node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a25c4d33a4832ca02950d1ab484b8f