### PR TITLE
feat: track participant registration numbers

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -134,6 +134,8 @@ namespace AutomotiveClaimsApi.Controllers
                         ClaimNumber = e.ClaimNumber,
                         SpartaNumber = e.SpartaNumber,
                         VehicleNumber = e.VehicleNumber,
+                        VictimRegistrationNumber = e.VictimRegistrationNumber,
+                        PerpetratorRegistrationNumber = e.PerpetratorRegistrationNumber,
                         Brand = e.Brand,
                         Model = e.Model,
                         Owner = e.Owner,
@@ -830,6 +832,8 @@ namespace AutomotiveClaimsApi.Controllers
             entity.SpartaNumber = dto.SpartaNumber;
             entity.InsurerClaimNumber = dto.InsurerClaimNumber;
             entity.VehicleNumber = dto.VehicleNumber;
+            entity.VictimRegistrationNumber = dto.VictimRegistrationNumber;
+            entity.PerpetratorRegistrationNumber = dto.PerpetratorRegistrationNumber;
             entity.Brand = dto.Brand;
             entity.Model = dto.Model;
             entity.Owner = dto.Owner;
@@ -1635,6 +1639,8 @@ namespace AutomotiveClaimsApi.Controllers
             SpartaNumber = e.SpartaNumber,
             InsurerClaimNumber = e.InsurerClaimNumber,
             VehicleNumber = e.VehicleNumber,
+            VictimRegistrationNumber = e.VictimRegistrationNumber,
+            PerpetratorRegistrationNumber = e.PerpetratorRegistrationNumber,
             Brand = e.Brand,
             Model = e.Model,
             Owner = e.Owner,

--- a/backend/DTOs/EventDto.cs
+++ b/backend/DTOs/EventDto.cs
@@ -10,6 +10,8 @@ namespace AutomotiveClaimsApi.DTOs
         public string? SpartaNumber { get; set; }
         public string? InsurerClaimNumber { get; set; }
         public string? VehicleNumber { get; set; }
+        public string? VictimRegistrationNumber { get; set; }
+        public string? PerpetratorRegistrationNumber { get; set; }
         public string? Brand { get; set; }
         public string? Model { get; set; }
         public string? Owner { get; set; }

--- a/backend/DTOs/EventListItemDto.cs
+++ b/backend/DTOs/EventListItemDto.cs
@@ -6,6 +6,8 @@ namespace AutomotiveClaimsApi.DTOs
         public string? ClaimNumber { get; set; }
         public string? SpartaNumber { get; set; }
         public string? VehicleNumber { get; set; }
+        public string? VictimRegistrationNumber { get; set; }
+        public string? PerpetratorRegistrationNumber { get; set; }
         public string? Brand { get; set; }
         public string? Model { get; set; }
         public string? Owner { get; set; }

--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -20,6 +20,12 @@ namespace AutomotiveClaimsApi.DTOs
         [StringLength(50)]
         public string? VehicleNumber { get; set; }
 
+        [StringLength(50)]
+        public string? VictimRegistrationNumber { get; set; }
+
+        [StringLength(50)]
+        public string? PerpetratorRegistrationNumber { get; set; }
+
         [StringLength(100)]
         public string? Brand { get; set; }
 

--- a/backend/Migrations/20240507000015_AddRegistrationNumbersToEvents.cs
+++ b/backend/Migrations/20240507000015_AddRegistrationNumbersToEvents.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRegistrationNumbersToEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "VictimRegistrationNumber",
+                table: "Events",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PerpetratorRegistrationNumber",
+                table: "Events",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "VictimRegistrationNumber",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "PerpetratorRegistrationNumber",
+                table: "Events");
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1018,6 +1018,14 @@ namespace AutomotiveClaimsApi.Migrations
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");
 
+                    b.Property<string>("VictimRegistrationNumber")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("PerpetratorRegistrationNumber")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
                     b.Property<string>("VehicleType")
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");

--- a/backend/Models/Event.cs
+++ b/backend/Models/Event.cs
@@ -23,6 +23,12 @@ namespace AutomotiveClaimsApi.Models
         [MaxLength(100)]
         public string? VehicleNumber { get; set; }
 
+        [MaxLength(50)]
+        public string? VictimRegistrationNumber { get; set; }
+
+        [MaxLength(50)]
+        public string? PerpetratorRegistrationNumber { get; set; }
+
         [MaxLength(100)]
         public string? Brand { get; set; }
 

--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -75,7 +75,7 @@ export function ClaimsList({
   const router = useRouter()
   const [searchTerm, setSearchTerm] = useState("")
   const [filterStatus, setFilterStatus] = useState("all")
-  const [filterBrand, setFilterBrand] = useState("")
+  const [filterRegistration, setFilterRegistration] = useState("")
   const [filterHandler, setFilterHandler] = useState("")
   const [showFilters, setShowFilters] = useState(false)
   const [isRefreshing, setIsRefreshing] = useState(false)
@@ -115,7 +115,7 @@ export function ClaimsList({
             pageSize,
             search: searchTerm,
             status: filterStatus !== "all" ? filterStatus : undefined,
-            brand: filterBrand || undefined,
+            brand: filterRegistration || undefined,
             handler: filterHandler || undefined,
             claimObjectTypeId,
             sortBy,
@@ -139,7 +139,7 @@ export function ClaimsList({
     pageSize,
     searchTerm,
     filterStatus,
-    filterBrand,
+    filterRegistration,
     filterHandler,
     claimObjectTypeId,
     sortBy,
@@ -161,8 +161,9 @@ export function ClaimsList({
     () =>
       claims.filter((claim) => {
         const matchesFilter = filterStatus === "all" || claim.status === filterStatus
-        const matchesBrand =
-          !filterBrand || claim.vehicleNumber?.toLowerCase().includes(filterBrand.toLowerCase())
+        const matchesRegistration =
+          !filterRegistration ||
+          claim.victimRegistrationNumber?.toLowerCase().includes(filterRegistration.toLowerCase())
         const matchesHandler =
           !filterHandler || claim.handler?.toLowerCase().includes(filterHandler.toLowerCase())
         const matchesClaimType =
@@ -170,9 +171,9 @@ export function ClaimsList({
           !claim.riskType ||
           allowedRiskTypes.includes(claim.riskType.toLowerCase())
 
-        return matchesFilter && matchesBrand && matchesHandler && matchesClaimType
+        return matchesFilter && matchesRegistration && matchesHandler && matchesClaimType
       }),
-    [claims, filterStatus, filterBrand, filterHandler, allowedRiskTypes],
+    [claims, filterStatus, filterRegistration, filterHandler, allowedRiskTypes],
   )
 
   const sortedClaims = useMemo(() => {
@@ -294,7 +295,7 @@ export function ClaimsList({
           pageSize,
           search: searchTerm,
           status: filterStatus !== "all" ? filterStatus : undefined,
-          brand: filterBrand || undefined,
+            brand: filterRegistration || undefined,
           handler: filterHandler || undefined,
           claimObjectTypeId,
           sortBy,
@@ -442,8 +443,8 @@ export function ClaimsList({
           <div className="mt-3 flex flex-col sm:flex-row gap-3">
             <Input
               placeholder="Filtruj po numerze rejestracyjnym..."
-              value={filterBrand}
-              onChange={(e) => setFilterBrand(e.target.value)}
+              value={filterRegistration}
+              onChange={(e) => setFilterRegistration(e.target.value)}
               className="h-9 text-sm"
             />
             <Input
@@ -544,7 +545,7 @@ export function ClaimsList({
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">{claim.insurerClaimNumber || "-"}</td>
                     <td className="px-6 py-4 whitespace-nowrap">{claim.claimNumber || "-"}</td>
-                    <td className="px-6 py-4 whitespace-nowrap">{claim.vehicleNumber || "-"}</td>
+                    <td className="px-6 py-4 whitespace-nowrap">{claim.victimRegistrationNumber || "-"}</td>
                     <td className="px-6 py-4 whitespace-nowrap">{claim.handler || "-"}</td>
                     <td className="px-6 py-4 whitespace-nowrap">{claim.client || "-"}</td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -33,6 +33,8 @@ export interface EventListItemDto {
   spartaNumber?: string
   claimNumber?: string
   vehicleNumber?: string
+  victimRegistrationNumber?: string
+  perpetratorRegistrationNumber?: string
   clientId?: number
   client?: string
   liquidator?: string
@@ -126,6 +128,8 @@ export interface EventUpsertDto {
   spartaNumber?: string
   claimNumber?: string
   vehicleNumber?: string
+  victimRegistrationNumber?: string
+  perpetratorRegistrationNumber?: string
   clientId?: number
   client?: string
   liquidator?: string


### PR DESCRIPTION
## Summary
- add victim and perpetrator registration numbers to event model and DTOs
- expose victim registration in claim list UI
- create migration for new event fields

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a444fa6f90832cbbcf4a569738f9c2