### PR TITLE
Add PostgreSQL provider selection

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -21,9 +21,19 @@ builder.Services.AddControllersWithViews(options =>
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-// Add Entity Framework with SQL Server
+// Add Entity Framework with database provider selected from configuration
+var dbProvider = builder.Configuration.GetValue<string>("DatabaseProvider")?.ToLowerInvariant();
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+{
+    if (dbProvider == "postgres" || dbProvider == "postgresql")
+    {
+        options.UseNpgsql(builder.Configuration.GetConnectionString("PostgresConnection"));
+    }
+    else
+    {
+        options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection"));
+    }
+});
 
 // Add Identity
 builder.Services.AddIdentity<ApplicationUser, IdentityRole>(options =>

--- a/backend/appsettings.Development.json
+++ b/backend/appsettings.Development.json
@@ -6,8 +6,10 @@
       "Microsoft.EntityFrameworkCore.Database.Command": "Information"
     }
   },
+  "DatabaseProvider": "SqlServer",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=SBLAP54\\MSSQLSERVER02;Database=AutomotiveClaimsDb;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True"
+    "DefaultConnection": "Server=SBLAP54\\MSSQLSERVER02;Database=AutomotiveClaimsDb;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True",
+    "PostgresConnection": "Host=localhost;Database=AutomotiveClaimsDb;Username=postgres;Password=password"
   },
   "ClaimNotifications": {
     "Recipients": [

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -6,8 +6,10 @@
     }
   },
   "AllowedHosts": "*",
+  "DatabaseProvider": "SqlServer",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=SBLAP54\\MSSQLSERVER02;Database=AutomotiveClaimsDb2;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True"
+    "DefaultConnection": "Server=SBLAP54\\MSSQLSERVER02;Database=AutomotiveClaimsDb2;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True",
+    "PostgresConnection": "Host=localhost;Database=AutomotiveClaimsDb2;Username=postgres;Password=password"
   },
   "SmtpSettings": {
     "Host": "smtp.gmail.com",


### PR DESCRIPTION
## Summary
- allow choosing SQL Server or PostgreSQL via `DatabaseProvider` setting
- sample Postgres connection strings and provider setting in configuration files

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a47c2af2b4832c8ee00f1079115401