### PR TITLE
feat: save email drafts

### DIFF
--- a/lib/email-service.ts
+++ b/lib/email-service.ts
@@ -46,6 +46,7 @@ export interface AssignEmailToClaimDto {
 
 class EmailService {
   private apiUrl = `${API_BASE_URL}/emails`
+  private defaultFrom = "noreply@automotiveclaims.com"
 
   async getAllEmails(): Promise<EmailDto[]> {
     try {
@@ -188,17 +189,45 @@ class EmailService {
         credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          from: this.defaultFrom,
           to: sendRequest.to,
           cc: sendRequest.cc,
           bcc: sendRequest.bcc,
           subject: sendRequest.subject,
           body: sendRequest.body,
+          isHtml: false,
+          direction: "Outbound",
           claimId: sendRequest.claimId,
         }),
       })
       return response.ok
     } catch (error) {
       console.error("sendEmail failed:", error)
+      return false
+    }
+  }
+
+  async saveDraft(sendRequest: SendEmailRequestDto): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.apiUrl}/draft`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          from: this.defaultFrom,
+          to: sendRequest.to,
+          cc: sendRequest.cc,
+          bcc: sendRequest.bcc,
+          subject: sendRequest.subject,
+          body: sendRequest.body,
+          isHtml: false,
+          direction: "Outbound",
+          claimIds: sendRequest.claimId ? [sendRequest.claimId] : undefined,
+        }),
+      })
+      return response.ok
+    } catch (error) {
+      console.error("saveDraft failed:", error)
       return false
     }
   }


### PR DESCRIPTION
## Summary
- allow email drafts to be stored in backend with default From address
- add draft-saving support to inbox compose view
- send emails with default From address and outbound metadata

## Testing
- `pnpm lint` *(fails: next: not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register`)*

------
https://chatgpt.com/codex/tasks/task_e_68a45c3ebd48832ca86b9f5a414630dc