### PR TITLE
fix: make claim top header sticky

### DIFF
--- a/components/claim-form/claim-top-header.tsx
+++ b/components/claim-form/claim-top-header.tsx
@@ -40,7 +40,7 @@ const getStatusColor = (status: string) => {
 
 export function ClaimTopHeader({ claimFormData, onClose }: ClaimTopHeaderProps) {
   return (
-    <div className="bg-white border-b border-gray-200 p-4 mb-0 mx-0 w-full">
+    <div className="bg-white border-b border-gray-200 p-4 mb-0 mx-0 w-full sticky top-0 z-10">
       {/* Info grid */}
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
         <div className="bg-gray-50 rounded-lg p-3 border border-gray-200 hover:shadow-md transition-shadow">


### PR DESCRIPTION
## Summary
- keep claim info header fixed at top during scroll

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*


------
https://chatgpt.com/codex/tasks/task_e_68a485f696e4832cb8c4cdca67fc03e2