### PR TITLE
Reset scroll position when switching claim sections

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -52,6 +52,7 @@ export default function ClaimPage() {
   const [isLoading, setIsLoading] = useState(!isNew)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [claim, setClaim] = useState<Claim | null>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
 
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([
     {
@@ -87,6 +88,10 @@ export default function ClaimPage() {
       setActiveClaimSection(privileged ? "dane-zdarzenia" : "teczka-szkodowa")
     }
   }, [user])
+
+  useEffect(() => {
+    contentRef.current?.scrollTo({ top: 0, behavior: "smooth" })
+  }, [activeClaimSection])
 
   const {
     claimFormData,
@@ -314,7 +319,7 @@ export default function ClaimPage() {
             setActiveClaimSection={setActiveClaimSection}
             claimObjectType={claim?.objectTypeId?.toString()}
           />
-          <div className="flex-1 overflow-y-auto bg-gray-50">
+          <div ref={contentRef} className="flex-1 overflow-y-auto bg-gray-50">
             <div className="p-6 min-h-full">
               <ClaimMainContent
                 activeClaimSection={activeClaimSection}

--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { useToast } from "@/hooks/use-toast"
@@ -26,6 +26,11 @@ export default function EditClaimPage() {
   const [loadError, setLoadError] = useState<string | null>(null)
 
   const id = params.id as string
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    contentRef.current?.scrollTo({ top: 0, behavior: "smooth" })
+  }, [activeClaimSection])
 
   useEffect(() => {
     if (user?.roles) {
@@ -245,7 +250,7 @@ export default function EditClaimPage() {
           setActiveClaimSection={setActiveClaimSection}
           claimObjectType={claimFormData.objectTypeId?.toString()}
         />
-        <div className="flex-1 overflow-y-auto bg-gray-50">
+        <div ref={contentRef} className="flex-1 overflow-y-auto bg-gray-50">
           <div className="p-6 min-h-full">
             <ClaimMainContent
               activeClaimSection={activeClaimSection}

--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -61,6 +61,7 @@ export default function NewClaimPage() {
   const [claimId, setClaimId] = useState<string>("")
   const [activeClaimSection, setActiveClaimSection] = useState("teczka-szkodowa")
   const [isSaving, setIsSaving] = useState(false)
+  const contentRef = useRef<HTMLDivElement>(null)
   
   // Repair schedules and details state
   const [repairSchedules, setRepairSchedules] = useState<RepairSchedule[]>([])
@@ -132,6 +133,10 @@ export default function NewClaimPage() {
       setActiveClaimSection(privileged ? "dane-zdarzenia" : "teczka-szkodowa")
     }
   }, [user])
+
+  useEffect(() => {
+    contentRef.current?.scrollTo({ top: 0, behavior: "smooth" })
+  }, [activeClaimSection])
 
   useEffect(() => {
     const clientId = searchParams.get("clientId")
@@ -424,7 +429,7 @@ export default function NewClaimPage() {
           claimObjectType={claimObjectType}
         />
 
-        <div className="flex-1 overflow-y-auto bg-gray-50">
+        <div ref={contentRef} className="flex-1 overflow-y-auto bg-gray-50">
           <div className="p-6 min-h-full">
             <ClaimMainContent
               activeClaimSection={activeClaimSection}


### PR DESCRIPTION
## Summary
- ensure claim edit, creation, and generic claim pages scroll to top when changing sections

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm install` *(fails: GET https://registry.npmjs.org/typescript: Forbidden - 403)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*

------
https://chatgpt.com/codex/tasks/task_e_68a4860f74a4832cb0bec9f399dcadc1