### PR TITLE
fix: keep claim form menu fixed on left

### DIFF
--- a/components/claim-form/claim-form-sidebar.tsx
+++ b/components/claim-form/claim-form-sidebar.tsx
@@ -133,7 +133,7 @@ function ClaimFormSidebar({ activeClaimSection, setActiveClaimSection, claimObje
     return { ...section, items }
   })
   return (
-    <div className="w-64 bg-white border-r border-gray-200 h-full overflow-y-auto">
+    <div className="sticky top-0 h-screen w-64 bg-white border-r border-gray-200 overflow-y-auto flex-shrink-0">
       <div className="p-3">
         <div className="space-y-6">
           {sections.map((section, sectionIndex) => (


### PR DESCRIPTION
## Summary
- make claim form sidebar sticky and full-height so menu stays fixed on the left

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*


------
https://chatgpt.com/codex/tasks/task_e_68a4894c42bc832c9d74e4c779d9147b