### PR TITLE
Reduce spacing between claim form controls

### DIFF
--- a/components/claim-form/appeals-section.tsx
+++ b/components/claim-form/appeals-section.tsx
@@ -488,7 +488,7 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {/* Header Section */}
       <div className="flex items-center gap-3 bg-gray-100 p-3 rounded-md mb-4 border border-[#d1d9e6]">
         <div className="text-[#1a3a6c]">
@@ -519,7 +519,7 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
             </h3>
           </div>
           <div className="p-6">
-            <form onSubmit={handleSubmit} className="space-y-6">
+            <form onSubmit={handleSubmit} className="space-y-4">
               {/* Date Fields */}
               <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <div className="space-y-2">
@@ -616,7 +616,7 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
                             setFormData((prev) => ({ ...prev, documentDescription: e.target.value }))
                           }
                           rows={2}
-                          className="mt-1"
+                          className="mt-0.5"
                         />
                       </div>
                     )}
@@ -961,7 +961,7 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
           <DialogHeader>
             <DialogTitle>Podgląd: {previewFileName}</DialogTitle>
             {previewDoc?.description && (
-              <p className="text-sm text-gray-600 mt-1">{previewDoc.description}</p>
+              <p className="text-sm text-gray-600 mt-0.5">{previewDoc.description}</p>
             )}
           </DialogHeader>
           <div className="flex-1 overflow-auto flex items-center justify-center bg-gray-100 rounded p-4 min-h-[400px]">

--- a/components/claim-form/claim-form-sidebar.tsx
+++ b/components/claim-form/claim-form-sidebar.tsx
@@ -135,7 +135,7 @@ function ClaimFormSidebar({ activeClaimSection, setActiveClaimSection, claimObje
   return (
     <div className="w-64 bg-white border-r border-gray-200 h-full overflow-y-auto">
       <div className="p-3">
-        <div className="space-y-6">
+        <div className="space-y-4">
           {sections.map((section, sectionIndex) => (
             <div key={section.id} className="space-y-3">
               {/* Section Header */}

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -904,7 +904,7 @@ export const ClaimMainContent = ({
               </div>
               <CardTitle className="text-lg font-semibold">Opis zdarzenia</CardTitle>
             </CardHeader>
-            <CardContent className="p-6 bg-white space-y-6">
+            <CardContent className="p-6 bg-white space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <div>
                   <Label htmlFor="damageDate" className="text-sm font-medium text-gray-700">
@@ -915,7 +915,7 @@ export const ClaimMainContent = ({
                     type="date"
                     value={formatDateForInput(claimFormData.damageDate)}
                     onChange={(e) => handleFormChange("damageDate", e.target.value)}
-                    className="mt-1"
+                    className="mt-0.5"
                   />
                 </div>
                 <div>
@@ -927,7 +927,7 @@ export const ClaimMainContent = ({
                     type="time"
                     value={claimFormData.eventTime || ""}
                     onChange={(e) => handleFormChange("eventTime", e.target.value)}
-                    className="mt-1"
+                    className="mt-0.5"
                   />
                 </div>
                 <div>
@@ -939,7 +939,7 @@ export const ClaimMainContent = ({
                     type="date"
                     value={formatDateForInput(claimFormData.reportDate)}
                     onChange={(e) => handleFormChange("reportDate", e.target.value)}
-                    className="mt-1"
+                    className="mt-0.5"
                   />
                 </div>
               </div>
@@ -952,7 +952,7 @@ export const ClaimMainContent = ({
                   placeholder="np. Warszawa, ul. Marszałkowska 1"
                   value={claimFormData.eventLocation || ""}
                   onChange={(e) => handleFormChange("eventLocation", e.target.value)}
-                  className="mt-1"
+                  className="mt-0.5"
                 />
               </div>
               <div>
@@ -965,7 +965,7 @@ export const ClaimMainContent = ({
                   rows={4}
                   value={claimFormData.eventDescription || ""}
                   onChange={(e) => handleFormChange("eventDescription", e.target.value)}
-                  className="mt-1"
+                  className="mt-0.5"
                 />
               </div>
               <div>
@@ -978,7 +978,7 @@ export const ClaimMainContent = ({
                   rows={2}
                   value={claimFormData.comments || ""}
                   onChange={(e) => handleFormChange("comments", e.target.value)}
-                  className="mt-1"
+                  className="mt-0.5"
                 />
               </div>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -1082,7 +1082,7 @@ export const ClaimMainContent = ({
               </div>
               <CardTitle className="text-lg font-semibold">Służby</CardTitle>
             </CardHeader>
-            <CardContent className="p-6 bg-white space-y-6">
+            <CardContent className="p-6 bg-white space-y-4">
               <div>
                 <div className="flex items-center space-x-6">
                   <div className="flex items-center space-x-2">
@@ -1138,7 +1138,7 @@ export const ClaimMainContent = ({
                       placeholder="Wprowadź opis interwencji policji"
                       value={claimFormData.policeDescription || ""}
                       onChange={(e) => handleFormChange("policeDescription", e.target.value)}
-                      className="mt-1"
+                      className="mt-0.5"
                     />
                   </div>
                 )}
@@ -1152,7 +1152,7 @@ export const ClaimMainContent = ({
                       placeholder="Wprowadź opis interwencji pogotowia"
                       value={claimFormData.ambulanceDescription || ""}
                       onChange={(e) => handleFormChange("ambulanceDescription", e.target.value)}
-                      className="mt-1"
+                      className="mt-0.5"
                     />
                   </div>
                 )}
@@ -1166,7 +1166,7 @@ export const ClaimMainContent = ({
                       placeholder="Wprowadź opis interwencji straży pożarnej"
                       value={claimFormData.fireDescription || ""}
                       onChange={(e) => handleFormChange("fireDescription", e.target.value)}
-                      className="mt-1"
+                      className="mt-0.5"
                     />
                   </div>
                 )}
@@ -1180,7 +1180,7 @@ export const ClaimMainContent = ({
                       placeholder="Wprowadź opis usługi holowania"
                       value={claimFormData.towDescription || ""}
                       onChange={(e) => handleFormChange("towDescription", e.target.value)}
-                      className="mt-1"
+                      className="mt-0.5"
                     />
                   </div>
                 )}
@@ -1195,7 +1195,7 @@ export const ClaimMainContent = ({
                     placeholder="Wprowadź dane jednostki policji"
                     value={claimFormData.policeUnitDetails || ""}
                     onChange={(e) => handleFormChange("policeUnitDetails", e.target.value)}
-                    className="mt-1"
+                    className="mt-0.5"
                   />
                 </div>
               )}
@@ -1211,7 +1211,7 @@ export const ClaimMainContent = ({
                 <CardTitle className="text-lg font-semibold">Uszkodzenia samochodu</CardTitle>
               </CardHeader>
               <CardContent className="p-6 bg-white grid grid-cols-1 lg:grid-cols-2 gap-8">
-                <div className="space-y-6">
+                <div className="space-y-4">
                   <div>
                     <div className="relative z-10">
                       <Label htmlFor="vehicleType" className="text-sm font-medium text-gray-700 mb-2 block">
@@ -1240,7 +1240,7 @@ export const ClaimMainContent = ({
                       rows={3}
                       value={claimFormData.damageDescription || ""}
                       onChange={(e) => handleFormChange("damageDescription", e.target.value)}
-                      className="mt-1"
+                      className="mt-0.5"
                     />
                   </div>
                   <div>
@@ -1557,7 +1557,7 @@ export const ClaimMainContent = ({
                         value={noteForm.title}
                         onChange={(e) => setNoteForm((prev) => ({ ...prev, title: e.target.value }))}
                         placeholder="Wprowadź tytuł..."
-                        className="mt-1"
+                        className="mt-0.5"
                       />
                     </div>
                     <div>
@@ -1570,7 +1570,7 @@ export const ClaimMainContent = ({
                         onChange={(e) => setNoteForm((prev) => ({ ...prev, description: e.target.value }))}
                         placeholder="Wprowadź opis..."
                         rows={4}
-                        className="mt-1"
+                        className="mt-0.5"
                       />
                     </div>
                     {showNoteForm === "task" && (
@@ -1585,7 +1585,7 @@ export const ClaimMainContent = ({
                               setNoteForm((prev) => ({ ...prev, priority: value }))
                             }
                           >
-                            <SelectTrigger className="mt-1">
+                            <SelectTrigger className="mt-0.5">
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
@@ -1604,7 +1604,7 @@ export const ClaimMainContent = ({
                             type="date"
                             value={noteForm.dueDate}
                             onChange={(e) => setNoteForm((prev) => ({ ...prev, dueDate: e.target.value }))}
-                            className="mt-1"
+                            className="mt-0.5"
                           />
                         </div>
                       </div>

--- a/components/claim-form/client-claims-section.tsx
+++ b/components/claim-form/client-claims-section.tsx
@@ -526,7 +526,7 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <div className="flex items-center gap-3 bg-gray-100 p-3 rounded-md mb-4 border border-[#d1d9e6]">
         <div className="text-[#1a3a6c]">
           <User className="h-5 w-5" />
@@ -556,7 +556,7 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
             </h3>
           </div>
           <div className="p-6">
-            <form onSubmit={handleSubmit} className="space-y-6">
+            <form onSubmit={handleSubmit} className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 <div className="space-y-2">
                   <Label htmlFor="claimNumber" className="text-sm font-medium text-gray-700">
@@ -744,7 +744,7 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
                               documentDescription: e.target.value,
                             }))
                           }
-                          className="mt-1"
+                          className="mt-0.5"
                         />
                       </div>
                     </div>
@@ -821,7 +821,7 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
                         onChange={(e) =>
                           setFormData((prev) => ({ ...prev, documentDescription: e.target.value }))
                         }
-                        className="mt-1"
+                        className="mt-0.5"
                       />
                     </div>
                   </div>

--- a/components/claim-form/communication-claim-summary.tsx
+++ b/components/claim-form/communication-claim-summary.tsx
@@ -492,7 +492,7 @@ const CommunicationClaimSummary = ({
                           {note.type === "task" && note.status && getStatusIcon(note.status)}
                         </div>
                         <h4 className="font-medium text-gray-900 text-sm">{note.title}</h4>
-                        <p className="text-sm text-gray-600 mt-1">{note.description}</p>
+                        <p className="text-sm text-gray-600 mt-0.5">{note.description}</p>
                         <div className="flex items-center space-x-4 text-xs text-gray-500 mt-2">
                           <span>{note.user}</span>
                           <span>{new Date(note.createdAt).toLocaleDateString("pl-PL")}</span>

--- a/components/claim-form/damage-basic-info-section.tsx
+++ b/components/claim-form/damage-basic-info-section.tsx
@@ -43,7 +43,7 @@ export function DamageBasicInfoSection({
           }}
           disabled
         >
-          <SelectTrigger className="mt-1">
+          <SelectTrigger className="mt-0.5">
             <SelectValue placeholder="Wybierz typ szkody..." />
           </SelectTrigger>
           <SelectContent>
@@ -65,7 +65,7 @@ export function DamageBasicInfoSection({
           }}
           disabled={loadingRiskTypes}
         >
-          <SelectTrigger className="mt-1">
+          <SelectTrigger className="mt-0.5">
             <SelectValue placeholder={loadingRiskTypes ? "Ładowanie..." : "Wybierz ryzyko szkody..."} />
           </SelectTrigger>
           <SelectContent>

--- a/components/claim-form/damage-data-section.tsx
+++ b/components/claim-form/damage-data-section.tsx
@@ -75,8 +75,8 @@ export function DamageDataSection({
         <CardTitle className="text-lg font-semibold">Dane szkody</CardTitle>
       </CardHeader>
       <CardContent className="p-6 bg-white">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
-          <div className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
+          <div className="space-y-4">
             <div>
               <Label htmlFor="claimObjectType" className="text-sm font-medium text-gray-700">
                 Typ szkody
@@ -89,7 +89,7 @@ export function DamageDataSection({
                   handleFormChange("damageType", "")
                 }}
               >
-                <SelectTrigger className="mt-1">
+                <SelectTrigger className="mt-0.5">
                   <SelectValue placeholder="Wybierz typ szkody..." />
                 </SelectTrigger>
                 <SelectContent>
@@ -110,7 +110,7 @@ export function DamageDataSection({
                 }}
                 disabled={loadingRiskTypes}
               >
-                <SelectTrigger className="mt-1">
+                <SelectTrigger className="mt-0.5">
                   <SelectValue placeholder={loadingRiskTypes ? "Ładowanie..." : "Wybierz ryzyko szkody..."} />
                 </SelectTrigger>
                 <SelectContent>
@@ -131,7 +131,7 @@ export function DamageDataSection({
                 onValueChange={(value) => handleFormChange("status", value)}
                 disabled={loadingStatuses}
               >
-                <SelectTrigger className="mt-1">
+                <SelectTrigger className="mt-0.5">
                   <SelectValue placeholder={loadingStatuses ? "Ładowanie..." : "Wybierz status szkody..."} />
                 </SelectTrigger>
                 <SelectContent>
@@ -152,7 +152,7 @@ export function DamageDataSection({
                 type="date"
                 value={formatDateForInput(claimFormData.reportDateToInsurer)}
                 onChange={(e) => handleFormChange("reportDateToInsurer", e.target.value)}
-                className="mt-1"
+                className="mt-0.5"
               />
             </div>
             <div className="relative z-10">
@@ -197,7 +197,7 @@ export function DamageDataSection({
             </div>
           </div>
 
-          <div className="space-y-6">
+          <div className="space-y-4">
             <div>
               <Label htmlFor="damageType" className="text-sm font-medium text-gray-700">
                 Rodzaj szkody
@@ -219,7 +219,7 @@ export function DamageDataSection({
                 id="insurerClaimNumber"
                 value={claimFormData.insurerClaimNumber || ""}
                 onChange={(e) => handleFormChange("insurerClaimNumber", e.target.value)}
-                className="mt-1"
+                className="mt-0.5"
               />
             </div>
             <div>
@@ -228,7 +228,7 @@ export function DamageDataSection({
                 id="spartaNumber"
                 value={claimFormData.spartaNumber || ""}
                 readOnly
-                className="bg-gray-50 mt-1 border-gray-200"
+                className="bg-gray-50 mt-0.5 border-gray-200"
               />
             </div>
             <div>
@@ -243,7 +243,7 @@ export function DamageDataSection({
                   handleFormChange("handlerEmail", event.handlerEmail || "")
                   handleFormChange("handlerPhone", event.handlerPhone || "")
                 }}
-                className="mt-1"
+                className="mt-0.5"
               />
             </div>
           </div>
@@ -251,7 +251,7 @@ export function DamageDataSection({
 
         <div className="border-t border-gray-200 my-8" />
 
-        <div className="space-y-6">
+        <div className="space-y-4">
           <div className="relative z-10">
             <Label htmlFor="insuranceCompany" className="text-sm font-medium text-gray-700 mb-2 block">
               Towarzystwo ubezpieczeniowe

--- a/components/claim-form/damage-inspection-section.tsx
+++ b/components/claim-form/damage-inspection-section.tsx
@@ -15,7 +15,7 @@ export function DamageInspectionSection({
   handleFormChange,
 }: DamageInspectionSectionProps) {
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <Label htmlFor="inspectionDate" className="text-sm font-medium text-gray-700">
@@ -26,7 +26,7 @@ export function DamageInspectionSection({
             type="date"
             value={(claimFormData as any).inspectionDate || ""}
             onChange={(e) => handleFormChange("inspectionDate", e.target.value)}
-            className="mt-1"
+            className="mt-0.5"
           />
         </div>
         <div>
@@ -37,7 +37,7 @@ export function DamageInspectionSection({
             id="inspectionExpert"
             value={(claimFormData as any).inspectionExpert || ""}
             onChange={(e) => handleFormChange("inspectionExpert", e.target.value)}
-            className="mt-1"
+            className="mt-0.5"
           />
         </div>
       </div>
@@ -49,7 +49,7 @@ export function DamageInspectionSection({
           id="inspectionNotes"
           value={(claimFormData as any).inspectionNotes || ""}
           onChange={(e) => handleFormChange("inspectionNotes", e.target.value)}
-          className="mt-1"
+          className="mt-0.5"
         />
       </div>
     </div>

--- a/components/claim-form/damage-vehicle-details-section.tsx
+++ b/components/claim-form/damage-vehicle-details-section.tsx
@@ -23,7 +23,7 @@ export function DamageVehicleDetailsSection({
           id="vehicleNumber"
           value={claimFormData.vehicleNumber || ""}
           onChange={(e) => handleFormChange("vehicleNumber", e.target.value)}
-          className="mt-1"
+          className="mt-0.5"
         />
       </div>
       <div>
@@ -34,7 +34,7 @@ export function DamageVehicleDetailsSection({
           id="vehicleRegistration"
           value={(claimFormData as any).vehicleRegistration || ""}
           onChange={(e) => handleFormChange("vehicleRegistration", e.target.value)}
-          className="mt-1"
+          className="mt-0.5"
         />
       </div>
       <div>
@@ -45,7 +45,7 @@ export function DamageVehicleDetailsSection({
           id="vehicleVin"
           value={(claimFormData as any).vehicleVin || ""}
           onChange={(e) => handleFormChange("vehicleVin", e.target.value)}
-          className="mt-1"
+          className="mt-0.5"
         />
       </div>
       <div>
@@ -56,7 +56,7 @@ export function DamageVehicleDetailsSection({
           id="brand"
           value={claimFormData.brand || ""}
           onChange={(e) => handleFormChange("brand", e.target.value)}
-          className="mt-1"
+          className="mt-0.5"
         />
       </div>
       <div>
@@ -67,7 +67,7 @@ export function DamageVehicleDetailsSection({
           id="vehicleType"
           value={claimFormData.vehicleType || ""}
           onChange={(e) => handleFormChange("vehicleType", e.target.value)}
-          className="mt-1"
+          className="mt-0.5"
         />
       </div>
       <div>
@@ -78,7 +78,7 @@ export function DamageVehicleDetailsSection({
           id="vehicleModel"
           value={(claimFormData as any).vehicleModel || ""}
           onChange={(e) => handleFormChange("vehicleModel", e.target.value)}
-          className="mt-1"
+          className="mt-0.5"
         />
       </div>
     </div>

--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -515,7 +515,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {/* Add/Edit Decision Form Toggle Button */}
       <div className="mb-4 flex justify-end">
         <Button
@@ -536,7 +536,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
             </h3>
           </div>
           <div className="p-6">
-            <form onSubmit={handleSubmit} className="space-y-6">
+            <form onSubmit={handleSubmit} className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 <div className="space-y-2">
                   <Label htmlFor="decisionDate" className="text-sm font-medium text-gray-700">
@@ -672,7 +672,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
                           value={formData.documentDescription}
                           onChange={(e) => handleInputChange("documentDescription", e.target.value)}
                           rows={2}
-                          className="mt-1"
+                          className="mt-0.5"
                         />
                       </div>
                     )}
@@ -704,7 +704,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
                       <span className="font-semibold">Kliknij, aby wybrać pliki</span> lub przeciągnij i upuść
                     </p>
                     <p className="text-xs text-muted-foreground">Obsługiwane formaty: PDF, DOC, DOCX, JPG, PNG</p>
-                    <p className="text-xs text-muted-foreground mt-1">Możesz wybrać wiele plików jednocześnie</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">Możesz wybrać wiele plików jednocześnie</p>
                     <input
                       ref={fileInputRef}
                       type="file"
@@ -762,9 +762,9 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
                           value={formData.documentDescription}
                           onChange={(e) => handleInputChange("documentDescription", e.target.value)}
                           rows={2}
-                          className="mt-1"
+                          className="mt-0.5"
                         />
-                        <p className="text-xs text-muted-foreground mt-1">
+                        <p className="text-xs text-muted-foreground mt-0.5">
                           Opis pomoże w łatwiejszej identyfikacji dokumentu w przyszłości.
                         </p>
                       </div>
@@ -784,7 +784,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
                   {Object.keys(totalPaymentsByCurrency).length > 0 ? (
                     <div>
                       Suma wypłat:
-                      <ul className="list-none ml-2 mt-1">
+                      <ul className="list-none ml-2 mt-0.5">
                         {Object.entries(totalPaymentsByCurrency).map(([currency, amount]) => (
                           <li key={currency} className="font-bold">
                             {formatCurrency(amount, currency)}

--- a/components/claim-form/driver-form.tsx
+++ b/components/claim-form/driver-form.tsx
@@ -38,7 +38,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
           )}
         </div>
 
-        <div className="space-y-6">
+        <div className="space-y-4">
           {/* Dane podstawowe */}
           <div className="space-y-4">
             <h4 className="text-base font-semibold text-gray-900 border-b pb-2">Dane podstawowe</h4>
@@ -53,7 +53,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                   value={driverData.firstName || ""}
                   onChange={(e) => onDriverChange("firstName", e.target.value)}
                   placeholder="Wprowadź imię"
-                  className="mt-1"
+                  className="mt-0.5"
                 />
               </div>
               <div>
@@ -65,7 +65,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                   value={driverData.lastName || ""}
                   onChange={(e) => onDriverChange("lastName", e.target.value)}
                   placeholder="Wprowadź nazwisko"
-                  className="mt-1"
+                  className="mt-0.5"
                 />
               </div>
             </div>
@@ -80,7 +80,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                   value={driverData.identityNumber || ""}
                   onChange={(e) => onDriverChange("identityNumber", e.target.value)}
                   placeholder="PESEL lub numer paszportu"
-                  className="mt-1"
+                  className="mt-0.5"
                 />
               </div>
               <div>
@@ -92,7 +92,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                   value={driverData.licenseNumber || ""}
                   onChange={(e) => onDriverChange("licenseNumber", e.target.value)}
                   placeholder="Numer prawa jazdy"
-                  className="mt-1"
+                  className="mt-0.5"
                 />
               </div>
             </div>
@@ -106,7 +106,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                   value={driverData.role || "driver"}
                   onValueChange={(value) => onDriverChange("role", value)}
                 >
-                  <SelectTrigger className="mt-1">
+                  <SelectTrigger className="mt-0.5">
                     <SelectValue placeholder="Wybierz rolę" />
                   </SelectTrigger>
                   <SelectContent>
@@ -125,7 +125,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                   value={driverData.owner || ""}
                   onChange={(e) => onDriverChange("owner", e.target.value)}
                   placeholder="Imię i nazwisko właściciela"
-                  className="mt-1"
+                  className="mt-0.5"
                 />
               </div>
               <div>
@@ -137,7 +137,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                   value={driverData.coOwner || ""}
                   onChange={(e) => onDriverChange("coOwner", e.target.value)}
                   placeholder="Imię i nazwisko współwłaściciela"
-                  className="mt-1"
+                  className="mt-0.5"
                 />
               </div>
             </div>
@@ -150,7 +150,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                 value={driverData.citizenship || "PL"}
                 onValueChange={(value) => onDriverChange("citizenship", value)}
               >
-                <SelectTrigger className="mt-1">
+                <SelectTrigger className="mt-0.5">
                   <SelectValue placeholder="Wybierz obywatelstwo" />
                 </SelectTrigger>
                 <SelectContent>
@@ -179,7 +179,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                   value={driverData.address || ""}
                   onChange={(e) => onDriverChange("address", e.target.value)}
                   placeholder="Ulica i numer"
-                  className="mt-1"
+                  className="mt-0.5"
                 />
               </div>
               <div>
@@ -191,7 +191,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                   value={driverData.city || ""}
                   onChange={(e) => onDriverChange("city", e.target.value)}
                   placeholder="Nazwa miasta"
-                  className="mt-1"
+                  className="mt-0.5"
                 />
               </div>
             </div>
@@ -205,7 +205,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                 value={driverData.postalCode || ""}
                 onChange={(e) => onDriverChange("postalCode", e.target.value)}
                 placeholder="00-000"
-                className="mt-1"
+                className="mt-0.5"
               />
             </div>
 
@@ -218,7 +218,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                 value={driverData.street || ""}
                 onChange={(e) => onDriverChange("street", e.target.value)}
                 placeholder="Nazwa ulicy"
-                className="mt-1"
+                className="mt-0.5"
               />
             </div>
 
@@ -232,7 +232,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                   value={driverData.houseNumber || ""}
                   onChange={(e) => onDriverChange("houseNumber", e.target.value)}
                   placeholder="Nr domu"
-                  className="mt-1"
+                  className="mt-0.5"
                 />
               </div>
               <div>
@@ -244,7 +244,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                   value={driverData.flatNumber || ""}
                   onChange={(e) => onDriverChange("flatNumber", e.target.value)}
                   placeholder="Nr mieszkania"
-                  className="mt-1"
+                  className="mt-0.5"
                 />
               </div>
             </div>
@@ -257,7 +257,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                 value={driverData.country || "PL"}
                 onValueChange={(value) => onDriverChange("country", value)}
               >
-                <SelectTrigger className="mt-1">
+                <SelectTrigger className="mt-0.5">
                   <SelectValue placeholder="Wybierz kraj" />
                 </SelectTrigger>
                 <SelectContent>
@@ -285,7 +285,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                 value={driverData.phone || ""}
                 onChange={(e) => onDriverChange("phone", e.target.value)}
                 placeholder="+48 123 456 789"
-                className="mt-1"
+                className="mt-0.5"
                 type="tel"
               />
             </div>
@@ -300,7 +300,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                 value={driverData.email || ""}
                 onChange={(e) => onDriverChange("email", e.target.value)}
                 placeholder="email@example.com"
-                className="mt-1"
+                className="mt-0.5"
               />
             </div>
 
@@ -330,7 +330,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
                 value={driverData.additionalInfo || ""}
                 onChange={(e) => onDriverChange("additionalInfo", e.target.value)}
                 placeholder="Dodatkowe informacje o uczestniku..."
-                className="mt-1"
+                className="mt-0.5"
                 rows={4}
               />
             </div>

--- a/components/claim-form/participant-form.tsx
+++ b/components/claim-form/participant-form.tsx
@@ -406,7 +406,7 @@ export const ParticipantForm: React.FC<ParticipantFormProps> = ({
           </div>
 
           <div className="p-4">
-            <div className="space-y-6">
+            <div className="space-y-4">
               {participantData.drivers && participantData.drivers.map((driver, index) => (
                 <div key={driver.id} className="border border-gray-200 rounded-lg p-4 bg-gray-50">
                   <div className="flex items-center justify-between mb-4">

--- a/components/claim-form/participants-section.tsx
+++ b/components/claim-form/participants-section.tsx
@@ -166,7 +166,7 @@ export function ParticipantsSection({
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {/* Add participant buttons */}
       <div className="flex gap-3 mb-6">
         {!injuredParty && (

--- a/components/claim-form/property-claim-form.tsx
+++ b/components/claim-form/property-claim-form.tsx
@@ -69,7 +69,7 @@ export function PropertyClaimForm({
   loadingStatuses,
 }: PropertyClaimFormProps) {
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <PropertyDamageSection
         claimFormData={claimFormData}
         handleFormChange={handleFormChange}

--- a/components/claim-form/property-claim-summary.tsx
+++ b/components/claim-form/property-claim-summary.tsx
@@ -175,7 +175,7 @@ export function PropertyClaimSummary({
                   className="border-l-4 border-blue-500 pl-4 py-2 bg-gray-50 rounded-r-lg"
                 >
                   <h4 className="font-medium text-gray-900 text-sm">{note.title}</h4>
-                  <p className="text-sm text-gray-600 mt-1">{note.description}</p>
+                  <p className="text-sm text-gray-600 mt-0.5">{note.description}</p>
                   <div className="flex items-center space-x-4 text-xs text-gray-500 mt-2">
                     {note.user && <span>{note.user}</span>}
                     {note.createdAt && (

--- a/components/claim-form/property-damage-section.tsx
+++ b/components/claim-form/property-damage-section.tsx
@@ -85,8 +85,8 @@ export function PropertyDamageSection({
         <CardTitle className="text-lg font-semibold">Szkoda w mieniu</CardTitle>
       </CardHeader>
       <CardContent className="p-6 bg-white">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
-          <div className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
+          <div className="space-y-4">
             <div>
               <Label htmlFor="claimObjectType" className="text-sm font-medium text-gray-700">
                 Typ szkody
@@ -99,7 +99,7 @@ export function PropertyDamageSection({
                   handleFormChange("damageType", "")
                 }}
               >
-                <SelectTrigger className="mt-1">
+                <SelectTrigger className="mt-0.5">
                   <SelectValue placeholder="Wybierz typ szkody..." />
                 </SelectTrigger>
                 <SelectContent>
@@ -120,7 +120,7 @@ export function PropertyDamageSection({
                 }}
                 disabled={loadingRiskTypes}
               >
-                <SelectTrigger className="mt-1">
+                <SelectTrigger className="mt-0.5">
                   <SelectValue
                     placeholder={loadingRiskTypes ? "Ładowanie..." : "Wybierz ryzyko szkody..."}
                   />
@@ -143,7 +143,7 @@ export function PropertyDamageSection({
                 onValueChange={(value) => handleFormChange("status", value)}
                 disabled={loadingStatuses}
               >
-                <SelectTrigger className="mt-1">
+                <SelectTrigger className="mt-0.5">
                   <SelectValue
                     placeholder={loadingStatuses ? "Ładowanie..." : "Wybierz status szkody..."}
                   />
@@ -166,7 +166,7 @@ export function PropertyDamageSection({
                 type="date"
                 value={formatDateForInput(claimFormData.reportDateToInsurer)}
                 onChange={(e) => handleFormChange("reportDateToInsurer", e.target.value)}
-                className="mt-1"
+                className="mt-0.5"
               />
             </div>
             <div className="relative z-10">
@@ -213,7 +213,7 @@ export function PropertyDamageSection({
             </div>
           </div>
 
-          <div className="space-y-6">
+          <div className="space-y-4">
             <div>
               <Label htmlFor="damageType" className="text-sm font-medium text-gray-700">
                 Rodzaj szkody
@@ -235,7 +235,7 @@ export function PropertyDamageSection({
                 id="insurerClaimNumber"
                 value={claimFormData.insurerClaimNumber || ""}
                 onChange={(e) => handleFormChange("insurerClaimNumber", e.target.value)}
-                className="mt-1"
+                className="mt-0.5"
               />
             </div>
             <div>
@@ -244,7 +244,7 @@ export function PropertyDamageSection({
                 id="spartaNumber"
                 value={claimFormData.spartaNumber || ""}
                 readOnly
-                className="bg-gray-50 mt-1 border-gray-200"
+                className="bg-gray-50 mt-0.5 border-gray-200"
               />
             </div>
             <div>
@@ -259,7 +259,7 @@ export function PropertyDamageSection({
                   handleFormChange("handlerEmail", event.handlerEmail || "")
                   handleFormChange("handlerPhone", event.handlerPhone || "")
                 }}
-                className="mt-1"
+                className="mt-0.5"
               />
             </div>
           </div>
@@ -267,7 +267,7 @@ export function PropertyDamageSection({
 
         <div className="border-t border-gray-200 my-8" />
 
-        <div className="space-y-6">
+        <div className="space-y-4">
           <div className="relative z-10">
             <Label
               htmlFor="insuranceCompany"
@@ -312,7 +312,7 @@ export function PropertyDamageSection({
 
         <div className="border-t border-gray-200 my-8" />
 
-        <div className="space-y-6">
+        <div className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="propertyDamageSubject">Przedmiot szkody</Label>
             <Textarea

--- a/components/claim-form/property-participants-section.tsx
+++ b/components/claim-form/property-participants-section.tsx
@@ -17,7 +17,7 @@ export function PropertyParticipantsSection({ claimFormData, handleFormChange }:
           Poszkodowany / Sprawca
         </CardTitle>
       </CardHeader>
-      <CardContent className="p-6 space-y-6">
+      <CardContent className="p-6 space-y-4">
         <div className="space-y-2">
           <Label htmlFor="injuredData">Dane poszkodowanego</Label>
           <Textarea

--- a/components/claim-form/recourse-section.tsx
+++ b/components/claim-form/recourse-section.tsx
@@ -498,7 +498,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <div className="flex items-center gap-3 bg-gray-100 p-3 rounded-md mb-4 border border-[#d1d9e6]">
         <div className="text-[#1a3a6c]">
           <DollarSign className="h-5 w-5" />
@@ -528,7 +528,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
             </h3>
           </div>
           <div className="p-6">
-            <form onSubmit={handleSubmit} className="space-y-6">
+            <form onSubmit={handleSubmit} className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-2">
                   <Label className="text-sm font-medium text-gray-700">Czy regres zasadny</Label>
@@ -677,7 +677,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
                             setFormData({ ...formData, documentDescription: e.target.value })
                           }
                           rows={2}
-                          className="mt-1"
+                          className="mt-0.5"
                         />
                       </div>
                     )}
@@ -768,9 +768,9 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
                           }
                           placeholder="Dodaj opis dokumentu (np. 'Pismo w sprawie regresu', 'Potwierdzenie wpłaty', itp.)"
                           rows={2}
-                          className="mt-1"
+                          className="mt-0.5"
                         />
-                        <p className="text-xs text-muted-foreground mt-1">
+                        <p className="text-xs text-muted-foreground mt-0.5">
                           Opis pomoże w łatwiejszej identyfikacji dokumentu w przyszłości.
                         </p>
                       </div>
@@ -789,7 +789,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
                   {Object.keys(totalRecourseAmounts).length > 0 ? (
                     <div>
                       Łączna kwota regresów:
-                      <ul className="list-none ml-2 mt-1">
+                      <ul className="list-none ml-2 mt-0.5">
                         {Object.entries(totalRecourseAmounts).map(([currency, amount]) => (
                           <li key={currency} className="font-bold">
                             {formatCurrency(amount, currency)}

--- a/components/claim-form/repair-details-section.tsx
+++ b/components/claim-form/repair-details-section.tsx
@@ -226,7 +226,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
           <CardContent className="p-8">
             <form onSubmit={handleSubmit} className="space-y-8">
               {/* Basic information */}
-              <div className="space-y-6">
+              <div className="space-y-4">
                 <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
                   <Car className="h-5 w-5 text-primary" />
                   Informacje podstawowe
@@ -294,7 +294,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
               </div>
 
               {/* Dates */}
-              <div className="space-y-6">
+              <div className="space-y-4">
                 <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
                   <Calendar className="h-5 w-5 text-primary" /> Daty i terminy
                 </h3>
@@ -347,7 +347,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
               </div>
 
               {/* Damage description */}
-              <div className="space-y-6">
+              <div className="space-y-4">
                 <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
                   <AlertTriangle className="h-5 w-5 text-accent" /> Opis uszkodzeń
                 </h3>
@@ -362,11 +362,11 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
               </div>
 
               {/* Vehicle options */}
-              <div className="space-y-6">
+              <div className="space-y-4">
                 <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
                   <Car className="h-5 w-5 text-primary" /> Opcje pojazdów
                 </h3>
-                <div className="space-y-6">
+                <div className="space-y-4">
                   <div className="space-y-3">
                     <div className="flex items-center space-x-3">
                       <Checkbox
@@ -417,7 +417,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
               </div>
 
               {/* Work hours */}
-              <div className="space-y-6">
+              <div className="space-y-4">
                 <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
                   <Timer className="h-5 w-5 text-primary" /> Godziny pracy
                 </h3>
@@ -485,7 +485,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
               </div>
 
               {/* Additional info */}
-              <div className="space-y-6">
+              <div className="space-y-4">
                 <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
                   <FileText className="h-5 w-5 text-muted-foreground" /> Informacje dodatkowe
                 </h3>
@@ -544,11 +544,11 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
         </Card>
       )}
 
-      <div className="space-y-6">
+      <div className="space-y-4">
         {details.length === 0 ? (
           <Card className="border-2 border-dashed border-border bg-muted/20 rounded-2xl">
             <CardContent className="text-center py-16">
-              <div className="space-y-6">
+              <div className="space-y-4">
                 <div className="p-6 bg-primary/10 rounded-2xl w-fit mx-auto border border-border">
                   <FileText className="h-16 w-16 text-primary" />
                 </div>
@@ -604,7 +604,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
                   </div>
                 </div>
               </CardHeader>
-              <CardContent className="space-y-6">
+              <CardContent className="space-y-4">
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div className="space-y-2">
                     <p className="text-xs text-muted-foreground">Przystąpienie do naprawy</p>

--- a/components/claim-form/repair-schedule-section.tsx
+++ b/components/claim-form/repair-schedule-section.tsx
@@ -399,7 +399,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
                   <div className={`text-xs font-medium ${stage.completed ? "text-primary" : "text-muted-foreground"}`}>
                     {stage.label}
                   </div>
-                  {stage.date && <div className="text-xs text-muted-foreground mt-1">{formatDate(stage.date)}</div>}
+                  {stage.date && <div className="text-xs text-muted-foreground mt-0.5">{formatDate(stage.date)}</div>}
                 </div>
               </div>
             )
@@ -412,7 +412,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
   if (loading) {
     return (
       <div className="flex items-center justify-center py-16">
-        <div className="text-center space-y-6 animate-fade-in">
+        <div className="text-center space-y-4 animate-fade-in">
           <div className="relative">
             <div className="w-16 h-16 border-4 border-primary/20 border-t-primary rounded-full animate-spin mx-auto"></div>
           </div>
@@ -467,7 +467,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
 
           <CardContent className="p-8">
             <div className="space-y-8 animate-slide-up">
-              <div className="space-y-6">
+              <div className="space-y-4">
                 <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
                   <Car className="h-5 w-5 text-primary" />
                   Podstawowe informacje
@@ -521,7 +521,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
                 </div>
               </div>
 
-              <div className="space-y-6">
+              <div className="space-y-4">
                 <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
                   <Calendar className="h-5 w-5 text-primary" />
                   Harmonogram napraw
@@ -582,12 +582,12 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
                 </div>
               </div>
 
-              <div className="space-y-6">
+              <div className="space-y-4">
                 <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
                   <AlertTriangle className="h-5 w-5 text-accent" />
                   Status operacyjny
                 </h3>
-                <div className="space-y-6">
+                <div className="space-y-4">
                   <div className="space-y-3">
                     <Label htmlFor="whyNotOperational" className="flex items-center gap-2 text-sm font-semibold">
                       <AlertTriangle className="h-4 w-4 text-accent" />
@@ -659,7 +659,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
                 </div>
               </div>
 
-              <div className="space-y-6">
+              <div className="space-y-4">
                 <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
                   <User className="h-5 w-5 text-primary" />
                   Kontakty
@@ -749,11 +749,11 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
         </Card>
       )}
 
-      <div className="space-y-6">
+      <div className="space-y-4">
         {schedules.length === 0 ? (
           <Card className="border-2 border-dashed border-border bg-muted/20 rounded-2xl animate-fade-in">
             <CardContent className="text-center py-16">
-              <div className="space-y-6">
+              <div className="space-y-4">
                 <div className="p-6 bg-primary/10 rounded-2xl w-fit mx-auto border border-border">
                   <Calendar className="h-16 w-16 text-primary" />
                 </div>
@@ -831,7 +831,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
                   </div>
                 </CardHeader>
 
-                <CardContent className="space-y-6">
+                <CardContent className="space-y-4">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div className="space-y-2">
                       <p className="text-xs text-muted-foreground flex items-center gap-2">

--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -506,7 +506,7 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
                 {isEditing ? `Edytuj ugodę #${editingSettlementId}` : "Dodaj nową ugodę"}
               </h3>
               {isEditing && (
-                <p className="text-sm text-gray-600 mt-1">
+                <p className="text-sm text-gray-600 mt-0.5">
                   Edytujesz istniejącą ugodę. Możesz zmienić wszystkie dane i załączyć nowy dokument.
                 </p>
               )}
@@ -750,7 +750,7 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
                             placeholder="Dodaj opis dokumentu (np. 'Umowa ugody', 'Protokół ugody', itp.)"
                             rows={2}
                           />
-                          <p className="text-xs text-gray-500 mt-1">
+                          <p className="text-xs text-gray-500 mt-0.5">
                             Opis pomoże w łatwiejszej identyfikacji dokumentu w przyszłości.
                           </p>
                         </div>

--- a/components/claim-form/transport-claim-form.tsx
+++ b/components/claim-form/transport-claim-form.tsx
@@ -70,7 +70,7 @@ export function TransportClaimForm({
   loadingStatuses,
 }: TransportClaimFormProps) {
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <DamageDataSection
         claimFormData={claimFormData}
         handleFormChange={handleFormChange}

--- a/components/claim-form/transport-claim-summary.tsx
+++ b/components/claim-form/transport-claim-summary.tsx
@@ -183,7 +183,7 @@ export function TransportClaimSummary({
                   className="border-l-4 border-blue-500 pl-4 py-2 bg-gray-50 rounded-r-lg"
                 >
                   <h4 className="font-medium text-gray-900 text-sm">{note.title}</h4>
-                  <p className="text-sm text-gray-600 mt-1">{note.description}</p>
+                  <p className="text-sm text-gray-600 mt-0.5">{note.description}</p>
                   <div className="flex items-center space-x-4 text-xs text-gray-500 mt-2">
                     {note.user && <span>{note.user}</span>}
                     {note.createdAt && (

--- a/components/claim-form/transport-damage-section.tsx
+++ b/components/claim-form/transport-damage-section.tsx
@@ -67,7 +67,7 @@ export function TransportDamageSection({
       <CardHeader>
         <CardTitle>Szkoda w transporcie</CardTitle>
       </CardHeader>
-      <CardContent className="space-y-6">
+      <CardContent className="space-y-4">
         <div className="space-y-2">
           <Label htmlFor="cargoDescription">Opis ładunku / lista strat</Label>
           <Textarea

--- a/components/claim-form/transport-participants-section.tsx
+++ b/components/claim-form/transport-participants-section.tsx
@@ -17,7 +17,7 @@ export function TransportParticipantsSection({ claimFormData, handleFormChange }
           Poszkodowany / Sprawca
         </CardTitle>
       </CardHeader>
-      <CardContent className="p-6 space-y-6">
+      <CardContent className="p-6 space-y-4">
         <div className="space-y-2">
           <Label htmlFor="injuredData">Dane poszkodowanego</Label>
           <Textarea

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -80,7 +80,7 @@ const FormItem = React.forwardRef<
 
   return (
     <FormItemContext.Provider value={{ id }}>
-      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+      <div ref={ref} className={cn("space-y-1", className)} {...props} />
     </FormItemContext.Provider>
   )
 })

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -97,6 +97,6 @@
     @apply p-1;
   }
   form > * + * {
-    @apply mt-1;
+    @apply mt-0.5;
   }
 }


### PR DESCRIPTION
## Summary
- Lower margin between successive form elements to tighten layouts globally
- Use smaller spacing within form items and across claim form sections

## Testing
- `pnpm install` *(fails: No authorization header was set for the request, 403)*
- `pnpm lint` *(fails: next: not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*

------
https://chatgpt.com/codex/tasks/task_e_68a4874b15e8832cb843492c58d36d27