### PR TITLE
feat: arrange schedule cards in responsive grid

### DIFF
--- a/components/claim-form/repair-schedule-section.tsx
+++ b/components/claim-form/repair-schedule-section.tsx
@@ -749,9 +749,9 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
         </Card>
       )}
 
-      <div className="space-y-4">
+      <div className={`grid gap-4 ${schedules.length === 0 ? '' : 'sm:grid-cols-2 lg:grid-cols-3'}`}>
         {schedules.length === 0 ? (
-          <Card className="border-2 border-dashed border-border bg-muted/20 rounded-2xl animate-fade-in">
+          <Card className="col-span-full border-2 border-dashed border-border bg-muted/20 rounded-2xl animate-fade-in max-w-md mx-auto">
             <CardContent className="text-center py-16">
               <div className="space-y-4">
                 <div className="p-6 bg-primary/10 rounded-2xl w-fit mx-auto border border-border">


### PR DESCRIPTION
## Summary
- display repair schedule cards in a responsive grid layout
- center the empty-state card and limit its width for a cleaner look

## Testing
- `pnpm lint` *(fails: next: not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*

------
https://chatgpt.com/codex/tasks/task_e_68a4914433ac832c97444550679f661f