### PR TITLE
feat: add reusable form headers

### DIFF
--- a/components/claim-form/damage-data-section.tsx
+++ b/components/claim-form/damage-data-section.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
+import { FormHeader } from "@/components/ui/form-header"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
@@ -68,12 +69,7 @@ export function DamageDataSection({
 }: DamageDataSectionProps) {
   return (
     <Card className="overflow-hidden shadow-sm border-gray-200 rounded-xl">
-      <CardHeader className="flex flex-row items-center space-x-4 bg-gradient-to-r from-blue-600 to-blue-700 text-white p-4">
-        <div className="w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center">
-          <FileText className="h-4 w-4" />
-        </div>
-        <CardTitle className="text-lg font-semibold">Dane szkody</CardTitle>
-      </CardHeader>
+      <FormHeader icon={FileText} title="Dane szkody" />
       <CardContent className="p-6 bg-white">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
           <div className="space-y-4">

--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -2,12 +2,14 @@
 
 import React, { useState, useEffect, useRef } from 'react'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
+import { FormHeader } from '@/components/ui/form-header'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 import { Checkbox } from '@/components/ui/checkbox'
+import { FileText, Users } from 'lucide-react'
 import { ParticipantsSection } from './participants-section'
 import { DocumentsSection } from '../documents-section'
 import { useClaims } from '@/hooks/use-claims'
@@ -215,9 +217,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
       <form onSubmit={handleSubmit} className="space-y-8">
         {/* Basic Information */}
         <Card>
-          <CardHeader>
-            <CardTitle>Podstawowe informacje</CardTitle>
-          </CardHeader>
+          <FormHeader icon={FileText} title="Podstawowe informacje" />
           <CardContent className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             <div className="space-y-2">
               <Label htmlFor="spartaNumber">Numer Sparta</Label>
@@ -294,9 +294,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
 
         {/* Event Description */}
         <Card>
-          <CardHeader>
-            <CardTitle>Opis zdarzenia</CardTitle>
-          </CardHeader>
+          <FormHeader icon={FileText} title="Opis zdarzenia" />
           <CardContent className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="eventDescription">Opis zdarzenia</Label>
@@ -365,9 +363,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
 
         {/* Participants Section */}
         <Card>
-          <CardHeader>
-            <CardTitle>Uczestnicy zdarzenia</CardTitle>
-          </CardHeader>
+          <FormHeader icon={Users} title="Uczestnicy zdarzenia" />
           <CardContent>
             <ParticipantsSection
               injuredParty={formData.injuredParty}
@@ -381,9 +377,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
 
         {/* Documents Section */}
         <Card>
-          <CardHeader>
-            <CardTitle>Dokumenty</CardTitle>
-          </CardHeader>
+          <FormHeader icon={FileText} title="Dokumenty" />
           <CardContent>
 
             <DocumentsSection

--- a/components/claim-form/injured-party-section.tsx
+++ b/components/claim-form/injured-party-section.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
+import { FormHeader } from "@/components/ui/form-header"
 import { User } from "lucide-react"
 import { ParticipantForm } from "./participant-form"
 import type { ParticipantInfo, DriverInfo } from "@/types"
@@ -22,12 +23,7 @@ export function InjuredPartySection({
 }: InjuredPartySectionProps) {
   return (
     <Card className="overflow-hidden shadow-sm border-gray-200 rounded-xl">
-      <CardHeader className="flex flex-row items-center space-x-4 bg-gradient-to-r from-blue-600 to-blue-700 text-white p-4">
-        <div className="w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center">
-          <User className="h-4 w-4" />
-        </div>
-        <CardTitle className="text-lg font-semibold">Poszkodowany</CardTitle>
-      </CardHeader>
+      <FormHeader icon={User} title="Poszkodowany" />
       <CardContent className="p-6 bg-white">
         <ParticipantForm
           title="Poszkodowany"

--- a/components/claim-form/property-damage-section.tsx
+++ b/components/claim-form/property-damage-section.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
+import { FormHeader } from "@/components/ui/form-header"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
@@ -78,12 +79,7 @@ export function PropertyDamageSection({
 
   return (
     <Card className="overflow-hidden shadow-sm border-gray-200 rounded-xl">
-      <CardHeader className="flex flex-row items-center space-x-4 bg-gradient-to-r from-blue-600 to-blue-700 text-white p-4">
-        <div className="w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center">
-          <FileText className="h-4 w-4" />
-        </div>
-        <CardTitle className="text-lg font-semibold">Szkoda w mieniu</CardTitle>
-      </CardHeader>
+      <FormHeader icon={FileText} title="Szkoda w mieniu" />
       <CardContent className="p-6 bg-white">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
           <div className="space-y-4">

--- a/components/claim-form/property-participants-section.tsx
+++ b/components/claim-form/property-participants-section.tsx
@@ -1,8 +1,10 @@
 "use client"
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
+import { FormHeader } from "@/components/ui/form-header"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { FileText } from "lucide-react"
 
 interface PropertyParticipantsSectionProps {
   claimFormData: Record<string, any>
@@ -12,11 +14,7 @@ interface PropertyParticipantsSectionProps {
 export function PropertyParticipantsSection({ claimFormData, handleFormChange }: PropertyParticipantsSectionProps) {
   return (
     <Card className="border border-gray-200 bg-white shadow-sm">
-      <CardHeader className="bg-gray-50 border-b">
-        <CardTitle className="text-lg font-semibold text-gray-700">
-          Poszkodowany / Sprawca
-        </CardTitle>
-      </CardHeader>
+      <FormHeader icon={FileText} title="Poszkodowany / Sprawca" />
       <CardContent className="p-6 space-y-4">
         <div className="space-y-2">
           <Label htmlFor="injuredData">Dane poszkodowanego</Label>

--- a/components/claim-form/repair-details-section.tsx
+++ b/components/claim-form/repair-details-section.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { FormHeader } from "@/components/ui/form-header"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -210,19 +211,16 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
     <div className="space-y-8 animate-fade-in">
       {showForm && (
         <Card className="border shadow-lg bg-card animate-scale-in">
-          <CardHeader className="bg-muted/30 border-b border-border rounded-t-xl">
-            <div className="flex items-center justify-between">
-              <CardTitle className="flex items-center gap-4 text-2xl">
-                <div className="p-3 bg-primary/15 rounded-xl border border-primary/20">
-                  <FileText className="h-6 w-6 text-primary" />
-                </div>
-                <div>{editing ? "Edytuj opis naprawy" : "Nowy opis naprawy"}</div>
-              </CardTitle>
-              <Button variant="ghost" size="icon" onClick={resetForm} className="rounded-xl hover:bg-destructive/10 hover:text-destructive">
-                <X className="h-5 w-5" />
-              </Button>
-            </div>
-          </CardHeader>
+          <FormHeader icon={FileText} title={editing ? "Edytuj opis naprawy" : "Nowy opis naprawy"}>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={resetForm}
+              className="rounded-xl hover:bg-destructive/10 hover:text-destructive"
+            >
+              <X className="h-5 w-5" />
+            </Button>
+          </FormHeader>
           <CardContent className="p-8">
             <form onSubmit={handleSubmit} className="space-y-8">
               {/* Basic information */}

--- a/components/claim-form/repair-schedule-section.tsx
+++ b/components/claim-form/repair-schedule-section.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 import { useState, useEffect } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { FormHeader } from "@/components/ui/form-header"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -442,28 +443,16 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
 
       {showForm && (
         <Card className="border shadow-lg bg-card animate-scale-in">
-          <CardHeader className="bg-muted/30 border-b border-border rounded-t-xl">
-            <div className="flex items-center justify-between">
-              <CardTitle className="flex items-center gap-4 text-2xl">
-                <div className="p-3 bg-primary/15 rounded-xl border border-primary/20">
-                  <Calendar className="h-6 w-6 text-primary" />
-                </div>
-                <div>
-                  <div className="text-foreground">
-                    {editingSchedule ? "Edytuj harmonogram" : "Nowy harmonogram naprawy"}
-                  </div>
-                </div>
-              </CardTitle>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={resetForm}
-                className="rounded-xl hover:bg-destructive/10 hover:text-destructive"
-              >
-                <X className="h-5 w-5" />
-              </Button>
-            </div>
-          </CardHeader>
+          <FormHeader icon={Calendar} title={editingSchedule ? "Edytuj harmonogram" : "Nowy harmonogram naprawy"}>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={resetForm}
+              className="rounded-xl hover:bg-destructive/10 hover:text-destructive"
+            >
+              <X className="h-5 w-5" />
+            </Button>
+          </FormHeader>
 
           <CardContent className="p-8">
             <div className="space-y-8 animate-slide-up">

--- a/components/claim-form/subcontractor-section.tsx
+++ b/components/claim-form/subcontractor-section.tsx
@@ -1,7 +1,9 @@
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
+import { FormHeader } from "@/components/ui/form-header"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Checkbox } from "@/components/ui/checkbox"
+import { FileText } from "lucide-react"
 import type { Claim, SubcontractorInfo } from "@/types"
 
 interface SubcontractorSectionProps {
@@ -40,9 +42,7 @@ export default function SubcontractorSection({
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Podwykonawca</CardTitle>
-      </CardHeader>
+      <FormHeader icon={FileText} title="Podwykonawca" />
       <CardContent className="space-y-4">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Input

--- a/components/claim-form/transport-damage-section.tsx
+++ b/components/claim-form/transport-damage-section.tsx
@@ -1,12 +1,12 @@
 "use client"
 
-
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
+import { FormHeader } from "@/components/ui/form-header"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
-import { Plus, Trash2 } from "lucide-react"
+import { FileText, Plus, Trash2 } from "lucide-react"
 
 interface TransportDamage {
   cargoDescription: string
@@ -64,9 +64,7 @@ export function TransportDamageSection({
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Szkoda w transporcie</CardTitle>
-      </CardHeader>
+      <FormHeader icon={FileText} title="Szkoda w transporcie" />
       <CardContent className="space-y-4">
         <div className="space-y-2">
           <Label htmlFor="cargoDescription">Opis ładunku / lista strat</Label>

--- a/components/claim-form/transport-participants-section.tsx
+++ b/components/claim-form/transport-participants-section.tsx
@@ -1,8 +1,10 @@
 "use client"
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
+import { FormHeader } from "@/components/ui/form-header"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { FileText } from "lucide-react"
 
 interface TransportParticipantsSectionProps {
   claimFormData: Record<string, any>
@@ -12,11 +14,7 @@ interface TransportParticipantsSectionProps {
 export function TransportParticipantsSection({ claimFormData, handleFormChange }: TransportParticipantsSectionProps) {
   return (
     <Card className="border border-gray-200 bg-white shadow-sm">
-      <CardHeader className="bg-gray-50 border-b">
-        <CardTitle className="text-lg font-semibold text-gray-700">
-          Poszkodowany / Sprawca
-        </CardTitle>
-      </CardHeader>
+      <FormHeader icon={FileText} title="Poszkodowany / Sprawca" />
       <CardContent className="p-6 space-y-4">
         <div className="space-y-2">
           <Label htmlFor="injuredData">Dane poszkodowanego</Label>

--- a/components/ui/form-header.tsx
+++ b/components/ui/form-header.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react"
+import { FileText, type LucideIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+interface FormHeaderProps {
+  title: string
+  icon?: LucideIcon
+  children?: ReactNode
+  className?: string
+}
+
+export function FormHeader({
+  title,
+  icon: Icon = FileText,
+  children,
+  className,
+}: FormHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-2">
+          {Icon && <Icon className="h-4 w-4 text-blue-600" />}
+          <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default FormHeader

--- a/components/user-form.tsx
+++ b/components/user-form.tsx
@@ -9,6 +9,8 @@ import { Label } from '@/components/ui/label'
 import { SearchableSelect } from '@/components/ui/searchable-select'
 import { Switch } from '@/components/ui/switch'
 import { Badge } from '@/components/ui/badge'
+import { FormHeader } from '@/components/ui/form-header'
+import { User } from 'lucide-react'
 
 interface UserFormProps {
   userId?: string
@@ -103,12 +105,14 @@ export default function UserForm({ userId }: UserFormProps) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="max-w-md space-y-4 p-4">
-      <div>
-        <Label htmlFor="userName">Nazwa użytkownika</Label>
-        <Input id="userName" value={userName} onChange={(e) => setUserName(e.target.value)} />
-        {errors.userName && <p className="text-sm text-red-500">{errors.userName}</p>}
-      </div>
+    <div className="max-w-md">
+      <FormHeader icon={User} title={isEdit ? 'Edytuj użytkownika' : 'Nowy użytkownik'} />
+      <form onSubmit={handleSubmit} className="space-y-4 p-4">
+        <div>
+          <Label htmlFor="userName">Nazwa użytkownika</Label>
+          <Input id="userName" value={userName} onChange={(e) => setUserName(e.target.value)} />
+          {errors.userName && <p className="text-sm text-red-500">{errors.userName}</p>}
+        </div>
       <div>
         <Label htmlFor="firstName">Imię</Label>
         <Input id="firstName" value={firstName} onChange={(e) => setFirstName(e.target.value)} />
@@ -169,8 +173,9 @@ export default function UserForm({ userId }: UserFormProps) {
           </div>
         )}
       </div>
-      <Button type="submit">{isEdit ? 'Zapisz' : 'Utwórz'} użytkownika</Button>
-    </form>
+        <Button type="submit">{isEdit ? 'Zapisz' : 'Utwórz'} użytkownika</Button>
+      </form>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- add `FormHeader` component for consistent form titles
- apply new header to claim and user forms

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dd28c69c832ca1c94f3761ace0bb