### PR TITLE
Allow appeals submission without attachments

### DIFF
--- a/components/claim-form/appeals-section.tsx
+++ b/components/claim-form/appeals-section.tsx
@@ -279,15 +279,6 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
       return
     }
 
-    if (selectedFiles.length === 0) {
-      toast({
-        title: "Błąd",
-        description: "Musisz dodać plik",
-        variant: "destructive",
-      })
-      return
-    }
-
     setIsLoading(true)
     try {
       const status = formData.responseDate ? "Zamknięte" : formData.status


### PR DESCRIPTION
## Summary
- remove error toast that required at least one file when creating an appeal

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm install` *(fails: GET https://registry.npmjs.org/typescript: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e053eec4832cbafa454aaf2ad5d8