### PR TITLE
Queue emails before sending

### DIFF
--- a/backend/Controllers/EmailsController.cs
+++ b/backend/Controllers/EmailsController.cs
@@ -108,6 +108,13 @@ namespace AutomotiveClaimsApi.Controllers
             return Ok(new { message = "Emails fetched successfully" });
         }
 
+        [HttpPost("process-pending")]
+        public async Task<IActionResult> ProcessPendingEmails()
+        {
+            var count = await _emailService.ProcessPendingEmailsAsync();
+            return Ok(new { processed = count });
+        }
+
         [HttpPost("assign-to-claim")]
         public async Task<IActionResult> AssignToClaim(AssignEmailToClaimDto dto)
         {

--- a/backend/DTOs/EmailDto.cs
+++ b/backend/DTOs/EmailDto.cs
@@ -27,6 +27,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Category { get; set; }
         public string? ErrorMessage { get; set; }
         public int RetryCount { get; set; }
+        public bool NeedsSending { get; set; }
         public string? ClaimNumber { get; set; }
         public List<string> ClaimIds { get; set; } = new List<string>();
         public Guid? EventId { get; set; }

--- a/backend/Migrations/20240130000011_AddNeedsSendingToEmails.cs
+++ b/backend/Migrations/20240130000011_AddNeedsSendingToEmails.cs
@@ -1,0 +1,30 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNeedsSendingToEmails : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "NeedsSending",
+                table: "Emails",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "NeedsSending",
+                table: "Emails");
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -729,6 +729,9 @@ namespace AutomotiveClaimsApi.Migrations
                     b.Property<bool>("IsHtml")
                         .HasColumnType("boolean");
 
+                    b.Property<bool>("NeedsSending")
+                        .HasColumnType("boolean");
+
                     b.Property<string>("Priority")
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");

--- a/backend/Models/Email.cs
+++ b/backend/Models/Email.cs
@@ -46,6 +46,7 @@ namespace AutomotiveClaimsApi.Models
         public string? Category { get; set; }
         public string? ErrorMessage { get; set; }
         public int RetryCount { get; set; } = 0;
+        public bool NeedsSending { get; set; } = false;
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;

--- a/backend/Services/EmailBackgroundService.cs
+++ b/backend/Services/EmailBackgroundService.cs
@@ -28,7 +28,8 @@ namespace AutomotiveClaimsApi.Services
                     var emailService = scope.ServiceProvider.GetRequiredService<IEmailService>();
                     
                     await emailService.FetchEmailsAsync();
-                    _logger.LogInformation("Email fetch completed at {Time}", DateTimeOffset.Now);
+                    await emailService.ProcessPendingEmailsAsync();
+                    _logger.LogInformation("Email fetch and send completed at {Time}", DateTimeOffset.Now);
                 }
                 catch (Exception ex)
                 {

--- a/backend/Services/IEmailService.cs
+++ b/backend/Services/IEmailService.cs
@@ -16,6 +16,7 @@ namespace AutomotiveClaimsApi.Services
         Task<bool> ToggleStarredAsync(Guid id);
         Task<bool> DeleteEmailAsync(Guid id);
         Task FetchEmailsAsync();
+        Task<int> ProcessPendingEmailsAsync();
         Task<bool> AssignEmailToClaimAsync(Guid emailId, IEnumerable<Guid> claimIds);
         Task<EmailAttachmentDto> UploadAttachmentAsync(Guid emailId, IFormFile file);
         Task<EmailAttachmentDto?> GetAttachmentByIdAsync(Guid id);


### PR DESCRIPTION
## Summary
- track emails that still need sending with a new `NeedsSending` flag
- queue outbound emails instead of sending immediately and process pending mail in the background service
- expose endpoint and migration to support the new send workflow

## Testing
- `dotnet test` *(fails: command not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*


------
https://chatgpt.com/codex/tasks/task_e_68a4e467ef70832c9a1b041e14532436