### PR TITLE
Fix duplicate damage entries when adding new damage

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -975,7 +975,6 @@ namespace AutomotiveClaimsApi.Controllers
                     UpdatedAt = DateTime.UtcNow
                 };
                 entity.Damages.Add(damage);
-                context.Damages.Add(damage);
             }
         }
 


### PR DESCRIPTION
## Summary
- prevent double insertion of damage records when updating a claim

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `dotnet test backend/AutomotiveClaimsApi.Tests/AutomotiveClaimsApi.Tests.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e8271418832cba768fa0f5a381fb