### PR TITLE
feat: allow moving attachments between sections

### DIFF
--- a/backend/Controllers/DocumentsController.cs
+++ b/backend/Controllers/DocumentsController.cs
@@ -176,6 +176,7 @@ namespace AutomotiveClaimsApi.Controllers
                 return NotFound();
 
             document.Description = updateDto.Description ?? document.Description;
+            document.DocumentType = updateDto.DocumentType ?? document.DocumentType;
             // Assuming DocumentStatusId maps to Status string. This might need a lookup table.
             // document.Status = updateDto.DocumentStatusId?.ToString() ?? document.Status;
             document.UpdatedAt = DateTime.UtcNow;

--- a/backend/DTOs/UpdateDocumentDto.cs
+++ b/backend/DTOs/UpdateDocumentDto.cs
@@ -4,5 +4,6 @@ namespace AutomotiveClaimsApi.DTOs
     {
         public string? Description { get; set; }
         public int? DocumentStatusId { get; set; }
+        public string? DocumentType { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- enable updating document type via API
- add drag-and-drop support to move attachments between sections

## Testing
- `pnpm lint` *(fails: next: not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a586a6816c832ca555f4dadf44b7fe