### PR TITLE
Use FormHeader across participant sections

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -1316,8 +1316,6 @@ export const ClaimMainContent = ({
             </CardHeader>
             <CardContent className="p-6 bg-white">
               <ParticipantForm
-                title="Sprawca"
-                icon={<AlertTriangle className="h-5 w-5 text-red-500" />}
                 participantData={getParticipantData("perpetrator")}
                 onParticipantChange={(field, value) => handleParticipantChange("perpetrator", field, value)}
                 onDriverChange={(driverIndex, field, value) =>

--- a/components/claim-form/injured-party-section.tsx
+++ b/components/claim-form/injured-party-section.tsx
@@ -26,8 +26,6 @@ export function InjuredPartySection({
       <FormHeader icon={User} title="Poszkodowany" />
       <CardContent className="p-6 bg-white">
         <ParticipantForm
-          title="Poszkodowany"
-          icon={<User className="h-5 w-5 text-blue-600" />}
           participantData={participantData}
           onParticipantChange={onParticipantChange}
           onDriverChange={onDriverChange}

--- a/components/claim-form/participant-form.tsx
+++ b/components/claim-form/participant-form.tsx
@@ -40,13 +40,11 @@ const DateInput: React.FC<DateInputProps> = ({ value, onChange, disabled, placeh
 }
 
 interface ParticipantFormProps {
-  title: string
   participantData: ParticipantInfo
   onParticipantChange: (field: keyof Omit<ParticipantInfo, "drivers">, value: any) => void
   onDriverChange: (driverIndex: number, field: keyof DriverInfo, value: any) => void
   onAddDriver: () => void
   onRemoveDriver: (driverIndex: number) => void
-  onRemoveParticipant?: () => void
   isVictim?: boolean
   disabled?: boolean
 }
@@ -79,13 +77,11 @@ const personRoles = [
 ]
 
 export const ParticipantForm: React.FC<ParticipantFormProps> = ({
-  title,
   participantData,
   onParticipantChange,
   onDriverChange,
   onAddDriver,
   onRemoveDriver,
-  onRemoveParticipant,
   isVictim = false,
   disabled = false,
 }) => {
@@ -98,22 +94,6 @@ export const ParticipantForm: React.FC<ParticipantFormProps> = ({
 
   return (
     <div className="container-fluid p-4">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-semibold text-[#1a3a6c]">{title}</h2>
-        {onRemoveParticipant && (
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={onRemoveParticipant}
-            disabled={disabled}
-          >
-            <Trash2 className="h-4 w-4 mr-2" />
-            Usuń uczestnika
-          </Button>
-        )}
-      </div>
-
       {/* Two-column layout */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Left column */}

--- a/components/claim-form/participants-section.tsx
+++ b/components/claim-form/participants-section.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import React, { useState } from 'react'
+import React from 'react'
 import { Button } from '@/components/ui/button'
-import { Plus } from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import { FormHeader } from '@/components/ui/form-header'
+import { Plus, User, AlertTriangle, Trash2 } from 'lucide-react'
 import { ParticipantForm } from './participant-form'
 import type { ParticipantInfo, DriverInfo } from '@/types'
 
@@ -195,36 +197,58 @@ export function ParticipantsSection({
 
       {/* Injured Party Form */}
       {injuredParty && (
-        <div className="border border-blue-300 rounded-lg bg-blue-50/30">
-          <ParticipantForm
-            title="Poszkodowany"
-            participantData={injuredParty}
-            onParticipantChange={updateInjuredParty}
-            onDriverChange={updateInjuredPartyDriver}
-            onAddDriver={addInjuredPartyDriver}
-            onRemoveDriver={removeInjuredPartyDriver}
-            onRemoveParticipant={removeInjuredParty}
-            isVictim={true}
-            disabled={disabled}
-          />
-        </div>
+        <Card className="border border-blue-300 bg-blue-50/30 rounded-lg overflow-hidden">
+          <FormHeader icon={User} title="Poszkodowany">
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={removeInjuredParty}
+              disabled={disabled}
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              Usuń uczestnika
+            </Button>
+          </FormHeader>
+          <CardContent className="p-0">
+            <ParticipantForm
+              participantData={injuredParty}
+              onParticipantChange={updateInjuredParty}
+              onDriverChange={updateInjuredPartyDriver}
+              onAddDriver={addInjuredPartyDriver}
+              onRemoveDriver={removeInjuredPartyDriver}
+              isVictim={true}
+              disabled={disabled}
+            />
+          </CardContent>
+        </Card>
       )}
 
       {/* Perpetrator Form */}
       {perpetrator && (
-        <div className="border border-red-300 rounded-lg bg-red-50/30">
-          <ParticipantForm
-            title="Sprawca"
-            participantData={perpetrator}
-            onParticipantChange={updatePerpetrator}
-            onDriverChange={updatePerpetratorDriver}
-            onAddDriver={addPerpetratorDriver}
-            onRemoveDriver={removePerpetratorDriver}
-            onRemoveParticipant={removePerpetrator}
-            isVictim={false}
-            disabled={disabled}
-          />
-        </div>
+        <Card className="border border-red-300 bg-red-50/30 rounded-lg overflow-hidden">
+          <FormHeader icon={AlertTriangle} title="Sprawca">
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={removePerpetrator}
+              disabled={disabled}
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              Usuń uczestnika
+            </Button>
+          </FormHeader>
+          <CardContent className="p-0">
+            <ParticipantForm
+              participantData={perpetrator}
+              onParticipantChange={updatePerpetrator}
+              onDriverChange={updatePerpetratorDriver}
+              onAddDriver={addPerpetratorDriver}
+              onRemoveDriver={removePerpetratorDriver}
+              isVictim={false}
+              disabled={disabled}
+            />
+          </CardContent>
+        </Card>
       )}
 
       {!injuredParty && !perpetrator && (

--- a/components/ui/form-header.tsx
+++ b/components/ui/form-header.tsx
@@ -18,14 +18,14 @@ export function FormHeader({
   return (
     <div
       className={cn(
-        "px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200",
+        "px-4 py-3 bg-[var(--claims-form-bg)] border-b border-[var(--claims-form-border)]",
         className,
       )}
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center space-x-2">
-          {Icon && <Icon className="h-4 w-4 text-blue-600" />}
-          <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+          {Icon && <Icon className="h-4 w-4 text-[var(--claims-form-header)]" />}
+          <h3 className="text-sm font-semibold text-[var(--claims-form-header)]">{title}</h3>
         </div>
         {children}
       </div>


### PR DESCRIPTION
## Summary
- remove internal header from `ParticipantForm` to prevent duplicate titles
- wrap participant forms with `FormHeader` and move remove buttons to header actions
- update claim form sections to rely on shared `FormHeader` styling

## Testing
- `pnpm test` (fails: Cannot find module 'tsconfig-paths/register')
- `pnpm lint` (fails: next command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a4e36764d8832c97edef810a88f83a