### PR TITLE
Fix dropdown portal positioning

### DIFF
--- a/components/client-dropdown.tsx
+++ b/components/client-dropdown.tsx
@@ -122,8 +122,8 @@ export default function ClientDropdown({
     if (buttonRef.current) {
       const rect = buttonRef.current.getBoundingClientRect()
       setDropdownPosition({
-        top: rect.bottom + window.scrollY + 4,
-        left: rect.left + window.scrollX,
+        top: rect.bottom + 4,
+        left: rect.left,
         width: rect.width,
       })
     }

--- a/components/handler-dropdown.tsx
+++ b/components/handler-dropdown.tsx
@@ -124,8 +124,8 @@ export default function HandlerDropdown({
     if (buttonRef.current) {
       const rect = buttonRef.current.getBoundingClientRect()
       setDropdownPosition({
-        top: rect.bottom + window.scrollY + 4,
-        left: rect.left + window.scrollX,
+        top: rect.bottom + 4,
+        left: rect.left,
         width: rect.width,
       })
     }

--- a/components/insurance-dropdown.tsx
+++ b/components/insurance-dropdown.tsx
@@ -100,8 +100,8 @@ export default function InsuranceDropdown({
     if (buttonRef.current) {
       const rect = buttonRef.current.getBoundingClientRect()
       setDropdownPosition({
-        top: rect.bottom + window.scrollY + 4,
-        left: rect.left + window.scrollX,
+        top: rect.bottom + 4,
+        left: rect.left,
         width: rect.width,
       })
     }

--- a/components/leasing-dropdown.tsx
+++ b/components/leasing-dropdown.tsx
@@ -100,8 +100,8 @@ export default function LeasingDropdown({
     if (buttonRef.current) {
       const rect = buttonRef.current.getBoundingClientRect()
       setDropdownPosition({
-        top: rect.bottom + window.scrollY + 4,
-        left: rect.left + window.scrollX,
+        top: rect.bottom + 4,
+        left: rect.left,
         width: rect.width,
       })
     }


### PR DESCRIPTION
## Summary
- adjust dropdown positioning to use viewport offsets for insurance, leasing, client, and handler dropdowns

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm install` *(fails: registry access forbidden)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*


------
https://chatgpt.com/codex/tasks/task_e_68a58feb2fe4832c850b7c13c4a83720