### PR TITLE
fix: keep claim form sidebar fixed

### DIFF
--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -204,9 +204,9 @@ export default function EditClaimPage() {
   }
 
   return (
-    <div className="flex flex-col min-h-screen bg-white">
+    <div className="flex flex-col h-screen bg-white">
       <ClaimTopHeader claimFormData={claimFormData} onClose={handleClose} />
-      <div className="flex flex-1 min-h-0">
+      <div className="flex flex-1 overflow-hidden min-h-0">
         <ClaimFormSidebar
           activeClaimSection={activeClaimSection}
           setActiveClaimSection={setActiveClaimSection}

--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -413,10 +413,10 @@ export default function NewClaimPage() {
   }
 
   return (
-    <div className="flex flex-col min-h-screen bg-white">
+    <div className="flex flex-col h-screen bg-white">
       <ClaimTopHeader claimFormData={claimFormData} onClose={handleClose} />
 
-      <div className="flex flex-1 min-h-0">
+      <div className="flex flex-1 overflow-hidden min-h-0">
         <ClaimFormSidebar
           activeClaimSection={activeClaimSection}
           setActiveClaimSection={setActiveClaimSection}

--- a/components/claim-form/claim-form-sidebar.tsx
+++ b/components/claim-form/claim-form-sidebar.tsx
@@ -133,7 +133,7 @@ function ClaimFormSidebar({ activeClaimSection, setActiveClaimSection, claimObje
     return { ...section, items }
   })
   return (
-    <div className="h-full w-64 bg-white border-r border-gray-200 overflow-y-auto flex-shrink-0">
+    <div className="h-screen sticky top-0 w-64 bg-white border-r border-gray-200 overflow-y-auto flex-shrink-0">
       <div className="p-3">
         <div className="space-y-4">
           {sections.map((section, sectionIndex) => (


### PR DESCRIPTION
## Summary
- keep claim form sidebar fixed via sticky positioning
- ensure claim form pages use full-height layout so the sidebar remains visible while scrolling

## Testing
- `pnpm install` (fails: 403 Forbidden fetching packages)
- `pnpm test` (fails: Cannot find module 'tsconfig-paths/register')


------
https://chatgpt.com/codex/tasks/task_e_68a5906558bc832c84979973ae40bf10