### PR TITLE
fix missing import for required docs in claim edit page

### DIFF
--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -13,6 +13,7 @@ import { useClaimForm } from "@/hooks/use-claim-form"
 import { useClaims, transformApiClaimToFrontend } from "@/hooks/use-claims"
 import { useAuth } from "@/hooks/use-auth"
 import type { UploadedFile, RequiredDocument } from "@/types"
+import { getRequiredDocumentsByObjectType } from "@/lib/required-documents"
 
 export default function EditClaimPage() {
   const params = useParams()


### PR DESCRIPTION
## Summary
- add missing `getRequiredDocumentsByObjectType` import to claim edit page

## Testing
- `pnpm lint` (fails: next: not found)
- `pnpm install` (fails: 403 Forbidden to npm registry)
- `pnpm test` (fails: Cannot find module 'tsconfig-paths/register')

------
https://chatgpt.com/codex/tasks/task_e_68a59236a9a4832c923cd2a07cc99d4b