### PR TITLE
feat: allow hiding claim link on recourse forms

### DIFF
--- a/components/claim-form/recourse-section.tsx
+++ b/components/claim-form/recourse-section.tsx
@@ -599,6 +599,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
                       })
                     }
                     className="relative z-20"
+                    showClaimLink={false}
                   />
                 </div>
 

--- a/components/insurance-dropdown.tsx
+++ b/components/insurance-dropdown.tsx
@@ -13,6 +13,12 @@ interface InsuranceDropdownProps {
   selectedCompanyId?: number
   onCompanySelected?: (event: CompanySelectionEvent) => void
   className?: string
+  /**
+   * Controls visibility of the claim reporting section with a link to the
+   * external form. Defaults to true so existing usages keep the current
+   * behaviour.
+   */
+  showClaimLink?: boolean
 }
 
 interface DropdownPosition {
@@ -25,6 +31,7 @@ export default function InsuranceDropdown({
   selectedCompanyId,
   onCompanySelected,
   className = "",
+  showClaimLink = true,
 }: InsuranceDropdownProps) {
   const [companies] = useState<InsuranceCompany[]>(
     InsuranceCompaniesService.sortCompaniesAlphabetically(InsuranceCompaniesService.getCompanies()),
@@ -282,30 +289,32 @@ export default function InsuranceDropdown({
             </div>
 
             {/* Form Section */}
-            <div className="pt-4 border-t border-gray-200">
-              <h3 className="flex items-center text-sm font-medium mb-3 text-gray-700">
-                <AlertCircle className="h-4 w-4 mr-2 text-blue-600" />
-                Zgłoszenie szkody
-              </h3>
+            {showClaimLink && (
+              <div className="pt-4 border-t border-gray-200">
+                <h3 className="flex items-center text-sm font-medium mb-3 text-gray-700">
+                  <AlertCircle className="h-4 w-4 mr-2 text-blue-600" />
+                  Zgłoszenie szkody
+                </h3>
 
-              {hasFormLink(selectedCompany.formLink) ? (
-                <a
-                  href={selectedCompany.formLink}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
-                >
-                  Przejdź do formularza zgłoszenia szkody
-                  <ExternalLink className="h-4 w-4 ml-2" />
-                </a>
-              ) : (
-                <div className="p-3 bg-orange-50 border border-orange-200 rounded-md">
-                  <p className="text-orange-800 text-sm">
-                    Brak formularza online. Skontaktuj się telefonicznie lub mailowo.
-                  </p>
-                </div>
-              )}
-            </div>
+                {hasFormLink(selectedCompany.formLink) ? (
+                  <a
+                    href={selectedCompany.formLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
+                  >
+                    Przejdź do formularza zgłoszenia szkody
+                    <ExternalLink className="h-4 w-4 ml-2" />
+                  </a>
+                ) : (
+                  <div className="p-3 bg-orange-50 border border-orange-200 rounded-md">
+                    <p className="text-orange-800 text-sm">
+                      Brak formularza online. Skontaktuj się telefonicznie lub mailowo.
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
           </CardContent>
         </Card>
       )}


### PR DESCRIPTION
## Summary
- add optional `showClaimLink` prop to InsuranceDropdown
- hide claim reporting link on recourse form

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm install` *(fails: GET https://registry.npmjs.org/tailwindcss: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a59a778e48832c9578dd4f48c03753