### PR TITLE
Display user menu in header and remove notification bell

### DIFF
--- a/app/claims/layout.tsx
+++ b/app/claims/layout.tsx
@@ -4,15 +4,17 @@ import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { Header } from '@/components/header'
 import { Sidebar } from '@/components/sidebar'
+import { useAuth } from '@/hooks/use-auth'
 
 export default function ClaimsLayout({ children }: { children: ReactNode }) {
   const [activeTab, setActiveTab] = useState('claims')
+  const { user, logout } = useAuth()
 
   return (
     <div className="min-h-screen bg-gray-50">
       <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
       <div className="ml-16 flex flex-col min-h-screen">
-        <Header onMenuClick={() => {}} />
+        <Header onMenuClick={() => {}} user={user ?? undefined} onLogout={logout} />
         <main className="flex-1">
           {children}
         </main>

--- a/app/emails/layout.tsx
+++ b/app/emails/layout.tsx
@@ -4,14 +4,16 @@ import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { Sidebar } from '@/components/sidebar'
 import { Header } from '@/components/header'
+import { useAuth } from '@/hooks/use-auth'
 
 export default function EmailsLayout({ children }: { children: ReactNode }) {
   const [activeTab, setActiveTab] = useState('unassigned')
+  const { user, logout } = useAuth()
   return (
     <div className="min-h-screen bg-gray-50">
       <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
       <div className="ml-16 flex flex-col min-h-screen">
-        <Header onMenuClick={() => {}} />
+        <Header onMenuClick={() => {}} user={user ?? undefined} onLogout={logout} />
         <main className="flex-1">{children}</main>
       </div>
     </div>

--- a/app/emails/unassigned/layout.tsx
+++ b/app/emails/unassigned/layout.tsx
@@ -4,14 +4,16 @@ import type { ReactNode } from "react"
 import { useState } from "react"
 import { Sidebar } from "@/components/sidebar"
 import { Header } from "@/components/header"
+import { useAuth } from "@/hooks/use-auth"
 
 export default function UnassignedEmailsLayout({ children }: { children: ReactNode }) {
   const [activeTab, setActiveTab] = useState("unassigned")
+  const { user, logout } = useAuth()
   return (
     <div className="min-h-screen bg-gray-50">
       <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
       <div className="ml-16 flex flex-col min-h-screen">
-        <Header onMenuClick={() => {}} />
+        <Header onMenuClick={() => {}} user={user ?? undefined} onLogout={logout} />
         <main className="flex-1">{children}</main>
       </div>
     </div>

--- a/app/reports/layout.tsx
+++ b/app/reports/layout.tsx
@@ -4,15 +4,17 @@ import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { Header } from '@/components/header'
 import { Sidebar } from '@/components/sidebar'
+import { useAuth } from '@/hooks/use-auth'
 
 export default function ReportsLayout({ children }: { children: ReactNode }) {
   const [activeTab, setActiveTab] = useState('reports')
+  const { user, logout } = useAuth()
 
   return (
     <div className="min-h-screen bg-gray-50">
       <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
       <div className="ml-16 flex flex-col min-h-screen">
-        <Header onMenuClick={() => {}} />
+        <Header onMenuClick={() => {}} user={user ?? undefined} onLogout={logout} />
         <main className="flex-1">
           {children}
         </main>

--- a/app/settings/layout.tsx
+++ b/app/settings/layout.tsx
@@ -8,10 +8,12 @@ import { Header } from '@/components/header'
 import { Sidebar } from '@/components/sidebar'
 import { ProtectedRoute } from '@/components/protected-route'
 import { cn } from '@/lib/utils'
+import { useAuth } from '@/hooks/use-auth'
 
 export default function SettingsLayout({ children }: { children: ReactNode }) {
   const [activeTab, setActiveTab] = useState('settings')
   const pathname = usePathname()
+  const { user, logout } = useAuth()
 
   const settingsItems = [
     { href: '/settings/clients', label: 'Klienci' },
@@ -27,7 +29,7 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
       <div className="min-h-screen bg-gray-50">
         <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
         <div className="ml-16 flex flex-col min-h-screen">
-          <Header onMenuClick={() => {}} />
+          <Header onMenuClick={() => {}} user={user ?? undefined} onLogout={logout} />
           <div className="flex flex-1">
             <nav className="w-48 border-r bg-white p-4 space-y-2">
               {settingsItems.map((item) => (

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
-import { Menu, Bell, User, LogOut, Settings } from 'lucide-react'
+import { Menu, User, LogOut, Settings } from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -65,14 +65,6 @@ export function Header({ onMenuClick, user, onLogout }: HeaderProps) {
         </div>
 
         <div className="flex items-center space-x-4">
-          {/* Notifications */}
-          <Button variant="ghost" size="icon" className="relative">
-            <Bell className="h-5 w-5" />
-            <span className="absolute -top-1 -right-1 h-4 w-4 bg-red-500 rounded-full text-xs text-white flex items-center justify-center">
-              3
-            </span>
-          </Button>
-
           {/* User Menu */}
           {user && (
             <DropdownMenu>


### PR DESCRIPTION
## Summary
- Remove notification bell from header
- Pass authenticated user to header in layouts and provide logout

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*

------
https://chatgpt.com/codex/tasks/task_e_68a59d7ce328832ca95b9d327b6563d6