### PR TITLE
fix: remove duplicate FormHeader import

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -12,7 +12,6 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
 import { AlertTriangle, User, Wrench, Car, X, MessageSquare, Clock, FileCheck, FileText, Search, Mail, Plus, CheckCircle, Trash2, Save, Calendar, Phone, Paperclip, DollarSign, Gavel, ArrowUpDown, HandHeart, Users, CreditCard, Shield, UserCheck, Download } from 'lucide-react'
-import { FormHeader } from "@/components/ui/form-header"
 import { DamageDiagram } from "@/components/damage-diagram"
 import { ParticipantForm } from "./participant-form"
 import { DocumentsSection } from "../documents-section"


### PR DESCRIPTION
## Summary
- remove duplicate `FormHeader` import in claim form main content

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm install` *(fails: GET https://registry.npmjs.org/typescript: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a59eb76e18832c8943a45488ef129b