### PR TITLE
feat: add simple claim form with driver data

### DIFF
--- a/app/claims/layout.tsx
+++ b/app/claims/layout.tsx
@@ -9,11 +9,17 @@ import { useAuth } from '@/hooks/use-auth'
 export default function ClaimsLayout({ children }: { children: ReactNode }) {
   const [activeTab, setActiveTab] = useState('claims')
   const { user, logout } = useAuth()
+  const isBasicUser =
+    user?.roles?.length === 1 && user.roles[0].toLowerCase() === 'user'
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
-      <div className="ml-16 flex flex-col min-h-screen">
+      {!isBasicUser && (
+        <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+      )}
+      <div
+        className={`${isBasicUser ? '' : 'ml-16'} flex flex-col min-h-screen`}
+      >
         <Header onMenuClick={() => {}} user={user ?? undefined} onLogout={logout} />
         <main className="flex-1">
           {children}

--- a/app/claims/simple/page.tsx
+++ b/app/claims/simple/page.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import SimpleClaimForm from "@/components/claim-form/simple-claim-form"
+
+export default function SimpleClaimPage() {
+  return (
+    <div className="p-4">
+      <Card className="border border-gray-200 shadow-sm">
+        <CardHeader>
+          <CardTitle>Dodaj prostą szkodę</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <SimpleClaimForm />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,6 +30,8 @@ function HomePage({ user, onLogout }: PageProps) {
   const router = useRouter()
   const [activeTab, setActiveTab] = useState("dashboard")
   const [tasks, setTasks] = useState<Task[]>([])
+  const isBasicUser =
+    user?.roles?.length === 1 && user.roles?.[0].toLowerCase() === "user"
 
   useEffect(() => {
     // additional effects can go here
@@ -123,8 +125,10 @@ function HomePage({ user, onLogout }: PageProps) {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
-      <div className="ml-16 flex flex-col min-h-screen">
+      {!isBasicUser && (
+        <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+      )}
+      <div className={`${isBasicUser ? "" : "ml-16"} flex flex-col min-h-screen`}>
         <Header onMenuClick={() => {}} user={user} onLogout={onLogout} />
         <main className="flex-1 p-0">
           <div className="w-full">

--- a/components/claim-form/simple-claim-form.tsx
+++ b/components/claim-form/simple-claim-form.tsx
@@ -1,0 +1,93 @@
+"use client"
+
+import { useState } from "react"
+import { useAuth } from "@/hooks/use-auth"
+import { Card, CardContent } from "@/components/ui/card"
+import { FormHeader } from "@/components/ui/form-header"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { FileText } from "lucide-react"
+import { DriverForm } from "./driver-form"
+import type { DriverInfo } from "@/types"
+
+export function SimpleClaimForm() {
+  const { user } = useAuth()
+  const isReadOnly = user?.roles?.includes("user")
+  const [description, setDescription] = useState("")
+  const [driver, setDriver] = useState<DriverInfo & Record<string, any>>({
+    id: Date.now().toString(),
+    name: "",
+    licenseNumber: "",
+    role: "driver",
+    firstName: "",
+    lastName: "",
+    phone: "",
+    email: "",
+    address: "",
+    city: "",
+    postalCode: "",
+    country: "PL",
+    personalId: "",
+    identityNumber: "",
+    owner: "",
+    coOwner: "",
+    citizenship: "PL",
+    street: "",
+    houseNumber: "",
+    flatNumber: "",
+    emailConsent: false,
+    additionalInfo: "",
+  })
+
+  const handleDriverChange = (field: keyof DriverInfo | string, value: any) => {
+    setDriver((prev) => ({ ...prev, [field]: value }))
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    console.log({ description, driver })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <fieldset disabled={isReadOnly} className="space-y-6">
+        <Card className="border border-gray-200 bg-white shadow-sm">
+          <FormHeader icon={FileText} title="Dane szkody" />
+          <CardContent className="p-6 space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="description">Opis szkody</Label>
+              <Textarea
+                id="description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Krótki opis szkody"
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <DriverForm
+          driverData={driver}
+          onDriverChange={handleDriverChange}
+          onRemove={() => {}}
+          isRemovable={false}
+        />
+
+        {!isReadOnly && (
+          <Button type="submit" className="bg-blue-600 text-white">
+            Zapisz
+          </Button>
+        )}
+      </fieldset>
+      {isReadOnly && (
+        <p className="text-sm text-gray-500">
+          Brak uprawnień do dodawania lub edycji
+        </p>
+      )}
+    </form>
+  )
+}
+
+export default SimpleClaimForm
+

--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -29,6 +29,7 @@ import {
 
 import { useClaims } from "@/hooks/use-claims"
 import { useToast } from "@/hooks/use-toast"
+import { useAuth } from "@/hooks/use-auth"
 import type { Claim } from "@/types"
 
 
@@ -101,6 +102,8 @@ export function ClaimsList({
     totalCount,
   } = useClaims()
   const { toast } = useToast()
+  const { user } = useAuth()
+  const isAdmin = user?.roles?.some((r) => r.toLowerCase() === "admin")
 
   const claims = initialClaims?.length ? initialClaims : fetchedClaims
   const totalRecords = initialClaims?.length ? initialClaims.length : totalCount
@@ -269,6 +272,14 @@ export function ClaimsList({
 
   const handleDeleteClaim = async (claimId: string | undefined, claimNumber: string | undefined) => {
     if (!claimId) return
+    if (!isAdmin) {
+      toast({
+        title: "Brak uprawnień",
+        description: "Tylko administrator może usuwać szkody.",
+        variant: "destructive",
+      })
+      return
+    }
 
     if (window.confirm(`Czy na pewno chcesz usunąć szkodę ${claimNumber}?`)) {
       try {
@@ -599,15 +610,17 @@ export function ClaimsList({
                         >
                           <Edit className="h-4 w-4 text-green-600" />
                         </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-8 w-8 p-0 hover:bg-red-50"
-                          onClick={() => handleDeleteClaim(claim.id, claim.claimNumber)}
-                          title="Usuń"
-                        >
-                          <Trash2 className="h-4 w-4 text-red-600" />
-                        </Button>
+                        {isAdmin && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 w-8 p-0 hover:bg-red-50"
+                            onClick={() => handleDeleteClaim(claim.id, claim.claimNumber)}
+                            title="Usuń"
+                          >
+                            <Trash2 className="h-4 w-4 text-red-600" />
+                          </Button>
+                        )}
                       </div>
                     </td>
                   </tr>

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useCallback } from "react"
+import { useAuth } from "@/hooks/use-auth"
 import {
   apiService,
   type ClaimUpsertDto,
@@ -377,6 +378,7 @@ export function useClaims() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [totalCount, setTotalCount] = useState(0)
+  const { user } = useAuth()
 
   const fetchClaims = useCallback(
     async (
@@ -494,6 +496,11 @@ export function useClaims() {
   }
 
   const deleteClaim = async (id: string): Promise<boolean> => {
+    const isAdmin = user?.roles?.some((r) => r.toLowerCase() === "admin")
+    if (!isAdmin) {
+      setError("Only administrators can delete claims")
+      return false
+    }
     try {
       setError(null)
       await apiService.deleteClaim(id)


### PR DESCRIPTION
## Summary
- add SimpleClaimForm component for a lightweight claim entry including driver information
- add dedicated page rendering the simplified form
- disable editing and hide sidebar for basic users
- allow only administrators to delete claims

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a5cdb49c832cb2b0f39e43616aac