### PR TITLE
fix login redirect loop by sharing auth state via context

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from '@/components/theme-provider'
 import { Toaster } from '@/components/ui/toaster'
 import Footer from '@/components/footer'
 import SessionGuard from '@/components/session-guard'
+import { AuthProvider } from '@/hooks/use-auth'
 
 function localStorageProvider(): Map<any, any> {
   if (typeof window === 'undefined') {
@@ -31,11 +32,13 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     >
       <QueryProvider>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
-          <SessionGuard>
-            <main className="flex-1">{children}</main>
-          </SessionGuard>
-          <Footer />
-          <Toaster />
+          <AuthProvider>
+            <SessionGuard>
+              <main className="flex-1">{children}</main>
+            </SessionGuard>
+            <Footer />
+            <Toaster />
+          </AuthProvider>
         </ThemeProvider>
       </QueryProvider>
     </SWRConfig>

--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react"
 import { apiService } from "@/lib/api"
 
 interface User {
@@ -16,7 +16,14 @@ interface AuthState {
   isLoading: boolean
 }
 
-export function useAuth() {
+interface AuthContextValue extends AuthState {
+  login: (username: string, password: string) => Promise<any>
+  logout: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
   const [authState, setAuthState] = useState<AuthState>({
     user: null,
     isAuthenticated: false,
@@ -60,11 +67,22 @@ export function useAuth() {
     }
   }
 
-  return {
+  const value: AuthContextValue = {
     user: authState.user,
     isAuthenticated: authState.isAuthenticated,
     isLoading: authState.isLoading,
     login,
     logout,
   }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider")
+  }
+  return context
+}
+


### PR DESCRIPTION
## Summary
- introduce AuthProvider context for shared auth state
- wrap application in AuthProvider to keep login state consistent

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*

------
https://chatgpt.com/codex/tasks/task_e_68a5ef132cac832ca1e4b50864568784