### PR TITLE
Avoid saving empty claim record during initialization

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -211,24 +211,12 @@ namespace AutomotiveClaimsApi.Controllers
         }
 
         [HttpPost("initialize")]
-        public async Task<ActionResult<object>> InitializeClaim()
+        public ActionResult<object> InitializeClaim()
         {
             try
             {
-                var eventEntity = new Event
-                {
-                    Id = Guid.NewGuid(),
-                    Status = "Nowa",
-                    Currency = "PLN",
-                    CreatedAt = DateTime.UtcNow,
-                    UpdatedAt = DateTime.UtcNow,
-                    RegisteredById = User.FindFirstValue(ClaimTypes.NameIdentifier)
-                };
-
-                _context.Events.Add(eventEntity);
-                await _context.SaveChangesAsync();
-
-                return Ok(new { id = eventEntity.Id });
+                var id = Guid.NewGuid();
+                return Ok(new { id });
             }
             catch (Exception ex)
             {

--- a/backend/Controllers/README.md
+++ b/backend/Controllers/README.md
@@ -13,3 +13,8 @@ Persists a new damage using the id from the init endpoint and the submitted deta
 Provides CRUD operations for risk types at `/api/RiskTypes`.
 
 `/api/dictionaries/risk-types` exposes the same data as a read-only dictionary endpoint.
+
+## ClaimsController
+
+### POST /api/claims/initialize
+Generates and returns a new `Guid` for a claim without persisting it. Use the returned id when creating a claim via `POST /api/claims`.


### PR DESCRIPTION
## Summary
- Stop persisting an empty `Event` when `/api/claims/initialize` is called and return only a new id
- Document the claim initialization endpoint

## Testing
- `npm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm install` *(fails: GET https://registry.npmjs.org/typescript: Forbidden - 403)*
- `dotnet test backend` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f08141f4832c8780f46071c96cfd