### PR TITLE
fix: wrap auth provider in parentheses

### DIFF
--- a/hooks/use-auth.tsx
+++ b/hooks/use-auth.tsx
@@ -76,7 +76,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
   )
 }
 


### PR DESCRIPTION
## Summary
- wrap AuthProvider JSX in parentheses to satisfy parser

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*


------
https://chatgpt.com/codex/tasks/task_e_68a5f92f08b8832c87931961c4d1eb80