### PR TITLE
Handle failed tasks fetch gracefully

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,7 +39,14 @@ function HomePage({ user, onLogout }: PageProps) {
     async function loadTasks() {
       try {
         const res = await fetch("/api/notes?category=task")
-        if (!res.ok) throw new Error("Failed to fetch tasks")
+        if (!res.ok) {
+          console.warn(
+            "Failed to fetch tasks:",
+            res.status,
+            res.statusText,
+          )
+          return
+        }
         const data = await res.json()
         const mapped = data.map((note: any) => ({
           title: note.title || note.content,


### PR DESCRIPTION
## Summary
- Avoid throwing errors when tasks fetch fails on dashboard
- Log status details and skip mapping when API call isn't successful

## Testing
- `pnpm lint` (fails: next not found)
- `pnpm test` (fails: Cannot find module 'tsconfig-paths/register')

------
https://chatgpt.com/codex/tasks/task_e_68a4438af238832ca9b3600f9ea86750