### PR TITLE
Allow saving damages without event relation

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -1830,7 +1830,7 @@ namespace AutomotiveClaimsApi.Controllers
             Damages = e.Damages.Select(d => new DamageDto
             {
                 Id = d.Id.ToString(),
-                EventId = d.EventId.ToString(),
+                EventId = d.EventId?.ToString(),
                 Description = d.Description,
                 Detail = d.Detail,
                 Location = d.Location,

--- a/backend/Controllers/DamagesController.cs
+++ b/backend/Controllers/DamagesController.cs
@@ -69,20 +69,10 @@ namespace AutomotiveClaimsApi.Controllers
                 {
                     return BadRequest("Damage ID is required. Use the init endpoint to obtain one.");
                 }
-                if (!upsertDto.EventId.HasValue || upsertDto.EventId == Guid.Empty)
-                {
-                    return BadRequest("EventId is required.");
-                }
-
-                if (!await _context.Events.AnyAsync(e => e.Id == upsertDto.EventId.Value))
-                {
-                    return BadRequest($"Event with id {upsertDto.EventId.Value} not found");
-                }
-
                 var damage = new Damage
                 {
                     Id = upsertDto.Id.Value,
-                    EventId = upsertDto.EventId.Value,
+                    EventId = upsertDto.EventId,
                     Description = upsertDto.Description,
                     Detail = upsertDto.Detail,
                     Location = upsertDto.Location,
@@ -161,7 +151,7 @@ namespace AutomotiveClaimsApi.Controllers
         private static DamageDto MapDamageToDto(Damage d) => new DamageDto
         {
             Id = d.Id.ToString(),
-            EventId = d.EventId.ToString(),
+            EventId = d.EventId?.ToString(),
             Description = d.Description,
             Detail = d.Detail,
             Location = d.Location,

--- a/backend/DTOs/DamageDto.cs
+++ b/backend/DTOs/DamageDto.cs
@@ -5,7 +5,7 @@ namespace AutomotiveClaimsApi.DTOs
     public class DamageDto
     {
         public string Id { get; set; } = string.Empty;
-        public string EventId { get; set; } = string.Empty;
+        public string? EventId { get; set; }
         public string? Description { get; set; }
         public string? Detail { get; set; }
         public string? Location { get; set; }

--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -73,7 +73,10 @@ namespace AutomotiveClaimsApi.Data
                       .HasForeignKey(e => e.ClaimStatusId)
                       .OnDelete(DeleteBehavior.SetNull);
 
-                entity.HasMany(e => e.Damages).WithOne(d => d.Event).HasForeignKey(d => d.EventId).OnDelete(DeleteBehavior.Cascade);
+                entity.HasMany(e => e.Damages)
+                      .WithOne()
+                      .HasForeignKey(d => d.EventId)
+                      .OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.Appeals).WithOne(a => a.Event).HasForeignKey(a => a.EventId).OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.ClientClaims).WithOne(c => c.Event).HasForeignKey(c => c.EventId).OnDelete(DeleteBehavior.Cascade);
                 entity.HasMany(e => e.Decisions).WithOne(d => d.Event).HasForeignKey(d => d.EventId).OnDelete(DeleteBehavior.Cascade);

--- a/backend/Models/Damage.cs
+++ b/backend/Models/Damage.cs
@@ -9,8 +9,7 @@ namespace AutomotiveClaimsApi.Models
         [Key]
         public Guid Id { get; set; }
 
-        [Required]
-        public Guid EventId { get; set; }
+        public Guid? EventId { get; set; }
 
         [MaxLength(500)]
         public string? Description { get; set; }
@@ -42,8 +41,6 @@ namespace AutomotiveClaimsApi.Models
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 
-        // Navigation properties
-        [ForeignKey("EventId")]
-        public virtual Event Event { get; set; } = null!;
+        // No navigation properties to avoid foreign key constraints
     }
 }


### PR DESCRIPTION
## Summary
- allow Damage entity to be created without an Event relationship
- adjust controllers and DTO mapping for nullable damage EventId
- update DbContext mapping to remove explicit foreign key navigation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a74ed45bb0832c8d40941c8afd6528