### PR TITLE
feat: add standalone email service project

### DIFF
--- a/emailservice/EmailClient.cs
+++ b/emailservice/EmailClient.cs
@@ -1,0 +1,70 @@
+using MailKit.Net.Imap;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+
+namespace EmailService;
+
+/// <summary>
+/// Simple client for sending and receiving e-mails using SMTP and IMAP.
+/// </summary>
+public class EmailClient
+{
+    private readonly string _smtpHost;
+    private readonly int _smtpPort;
+    private readonly string _imapHost;
+    private readonly int _imapPort;
+    private readonly string _username;
+    private readonly string _password;
+
+    public EmailClient(string smtpHost, int smtpPort, string imapHost, int imapPort, string username, string password)
+    {
+        _smtpHost = smtpHost;
+        _smtpPort = smtpPort;
+        _imapHost = imapHost;
+        _imapPort = imapPort;
+        _username = username;
+        _password = password;
+    }
+
+    /// <summary>
+    /// Sends a plain text e-mail message.
+    /// </summary>
+    public async Task SendEmailAsync(string to, string subject, string body)
+    {
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse(_username));
+        message.To.Add(MailboxAddress.Parse(to));
+        message.Subject = subject;
+        message.Body = new TextPart("plain") { Text = body };
+
+        using var client = new SmtpClient();
+        await client.ConnectAsync(_smtpHost, _smtpPort, SecureSocketOptions.StartTls);
+        await client.AuthenticateAsync(_username, _password);
+        await client.SendAsync(message);
+        await client.DisconnectAsync(true);
+    }
+
+    /// <summary>
+    /// Fetches unread e-mails from the inbox and marks them as read.
+    /// </summary>
+    public async Task<IList<MimeMessage>> FetchUnreadEmailsAsync()
+    {
+        using var client = new ImapClient();
+        await client.ConnectAsync(_imapHost, _imapPort, SecureSocketOptions.SslOnConnect);
+        await client.AuthenticateAsync(_username, _password);
+        await client.Inbox.OpenAsync(FolderAccess.ReadWrite);
+
+        var uids = await client.Inbox.SearchAsync(MailKit.Search.SearchQuery.NotSeen);
+        var messages = new List<MimeMessage>();
+        foreach (var uid in uids)
+        {
+            var message = await client.Inbox.GetMessageAsync(uid);
+            messages.Add(message);
+            await client.Inbox.AddFlagsAsync(uid, MessageFlags.Seen, true);
+        }
+
+        await client.DisconnectAsync(true);
+        return messages;
+    }
+}

--- a/emailservice/EmailService.csproj
+++ b/emailservice/EmailService.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MailKit" Version="4.8.0" />
+    <PackageReference Include="MimeKit" Version="4.8.0" />
+  </ItemGroup>
+</Project>

--- a/emailservice/Program.cs
+++ b/emailservice/Program.cs
@@ -1,0 +1,19 @@
+using EmailService;
+
+// Usage: EmailService <smtpHost> <smtpPort> <imapHost> <imapPort> <username> <password>
+if (args.Length < 6)
+{
+    Console.WriteLine("Usage: EmailService <smtpHost> <smtpPort> <imapHost> <imapPort> <username> <password>");
+    return;
+}
+
+var client = new EmailClient(
+    smtpHost: args[0],
+    smtpPort: int.Parse(args[1]),
+    imapHost: args[2],
+    imapPort: int.Parse(args[3]),
+    username: args[4],
+    password: args[5]
+);
+
+Console.WriteLine("EmailService ready. Implement custom logic to call SendEmailAsync or FetchUnreadEmailsAsync as needed.");

--- a/emailservice/README.md
+++ b/emailservice/README.md
@@ -1,0 +1,19 @@
+# EmailService
+
+A simple .NET 8 console project that provides a minimal client for sending and receiving e-mails using SMTP and IMAP via the MailKit library.
+
+## Usage
+
+Build the project:
+
+```bash
+dotnet build
+```
+
+Run the service passing connection details:
+
+```bash
+dotnet run --project EmailService.csproj smtp.example.com 587 imap.example.com 993 user@example.com supersecret
+```
+
+Then call `SendEmailAsync` or `FetchUnreadEmailsAsync` from your own code to send or retrieve messages.


### PR DESCRIPTION
## Summary
- add new EmailService .NET project using MailKit for SMTP/IMAP
- include EmailClient with send and receive helpers and sample Program entry

## Testing
- `dotnet build emailservice/EmailService.csproj` *(fails: command not found)*
- `dotnet test backend/AutomotiveClaimsApi.Tests/AutomotiveClaimsApi.Tests.csproj` *(fails: command not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*


------
https://chatgpt.com/codex/tasks/task_e_68a7a6d4b454832c847796bc769b1c47