### PR TITLE
refactor: use numeric claim status IDs

### DIFF
--- a/app/api/claim-statuses/route.ts
+++ b/app/api/claim-statuses/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
 
     // Transform the data to match frontend expectations
     const transformedData = data.map((item: any) => ({
-      id: item.id,
+      id: Number(item.id),
       code: item.code,
       name: item.name,
       label: item.name,

--- a/app/api/dictionaries/claim-statuses/route.ts
+++ b/app/api/dictionaries/claim-statuses/route.ts
@@ -16,7 +16,11 @@ export async function GET(request: NextRequest) {
     }
 
     const data = await response.json()
-    return NextResponse.json(data)
+    const items = (data.items ?? []).map((item: any) => ({
+      ...item,
+      id: Number(item.id),
+    }))
+    return NextResponse.json({ ...data, items })
   } catch (error) {
     console.error('Error fetching claim statuses:', error)
     return NextResponse.json(

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -377,7 +377,9 @@ export const ClaimMainContent = ({
       )
       if (response.ok) {
         const data = await response.json()
-        setClaimStatuses(data.items ?? [])
+        setClaimStatuses(
+          (data.items ?? []).map((item: any) => ({ ...item, id: Number(item.id) })),
+        )
       } else {
         throw new Error(`HTTP error! status: ${response.status}`)
       }
@@ -628,9 +630,9 @@ export const ClaimMainContent = ({
   }
 
   // Get status label from code
-  const getStatusLabel = (statusId?: string) => {
-    const status = claimStatuses.find((s) => s.id.toString() === statusId)
-    return status ? status.name : statusId || "Nie wybrano"
+  const getStatusLabel = (statusId?: number) => {
+    const status = claimStatuses.find((s) => s.id === statusId)
+    return status ? status.name : statusId?.toString() || "Nie wybrano"
   }
 
   // Get risk type label from code

--- a/components/claim-form/communication-claim-summary.tsx
+++ b/components/claim-form/communication-claim-summary.tsx
@@ -21,8 +21,13 @@ import type {
   UploadedFile,
   ParticipantInfo,
   RequiredDocument,
-  ClaimStatus,
 } from "@/types"
+
+interface ClaimStatus {
+  id: number
+  name: string
+  description: string
+}
 
 interface RiskType {
   value: string
@@ -127,9 +132,9 @@ const CommunicationClaimSummary = ({
 }: CommunicationClaimSummaryProps) => {
   const visibleNotes = notes.filter((note) => !note.type || note.type === "note")
 
-  const getStatusLabel = (statusId?: string) => {
-    const status = claimStatuses.find((s) => s.id.toString() === statusId)
-    return status ? status.name : statusId || "Nie wybrano"
+  const getStatusLabel = (statusId?: number) => {
+    const status = claimStatuses.find((s) => s.id === statusId)
+    return status ? status.name : statusId?.toString() || "Nie wybrano"
   }
 
   const getRiskTypeLabel = (riskTypeCode?: string) => {

--- a/components/claim-form/damage-data-section.tsx
+++ b/components/claim-form/damage-data-section.tsx
@@ -124,7 +124,7 @@ export function DamageDataSection({
               </Label>
               <Select
                 value={claimFormData.status?.toString() || ""}
-                onValueChange={(value) => handleFormChange("status", value)}
+                onValueChange={(value) => handleFormChange("status", Number(value))}
                 disabled={loadingStatuses}
               >
                 <SelectTrigger className="mt-0.5">

--- a/components/claim-form/property-claim-summary.tsx
+++ b/components/claim-form/property-claim-summary.tsx
@@ -2,7 +2,13 @@
 
 import { FileText, MessageSquare } from "lucide-react"
 import { DocumentsSection } from "../documents-section"
-import type { Claim, Note, UploadedFile, ClaimStatus } from "@/types"
+import type { Claim, Note, UploadedFile } from "@/types"
+
+interface ClaimStatus {
+  id: number
+  name: string
+  description: string
+}
 
 interface RiskType {
   value: string
@@ -40,9 +46,9 @@ export function PropertyClaimSummary({
 }: PropertyClaimSummaryProps) {
   const visibleNotes = notes.filter((note) => !note.type || note.type === "note")
 
-  const getStatusLabel = (statusId?: string) => {
-    const status = claimStatuses.find((s) => s.id.toString() === statusId)
-    return status ? status.name : statusId || "Nie wybrano"
+  const getStatusLabel = (statusId?: number) => {
+    const status = claimStatuses.find((s) => s.id === statusId)
+    return status ? status.name : statusId?.toString() || "Nie wybrano"
   }
 
   const getRiskTypeLabel = (riskTypeCode?: string) => {

--- a/components/claim-form/property-damage-section.tsx
+++ b/components/claim-form/property-damage-section.tsx
@@ -136,7 +136,7 @@ export function PropertyDamageSection({
               </Label>
               <Select
                 value={claimFormData.status?.toString() || ""}
-                onValueChange={(value) => handleFormChange("status", value)}
+                onValueChange={(value) => handleFormChange("status", Number(value))}
                 disabled={loadingStatuses}
               >
                 <SelectTrigger className="mt-0.5">

--- a/components/claim-form/transport-claim-summary.tsx
+++ b/components/claim-form/transport-claim-summary.tsx
@@ -2,7 +2,13 @@
 
 import { FileText, MessageSquare } from "lucide-react"
 import { DocumentsSection } from "../documents-section"
-import type { Claim, Note, UploadedFile, ClaimStatus } from "@/types"
+import type { Claim, Note, UploadedFile } from "@/types"
+
+interface ClaimStatus {
+  id: number
+  name: string
+  description: string
+}
 
 interface RiskType {
   value: string
@@ -40,9 +46,9 @@ export function TransportClaimSummary({
 }: TransportClaimSummaryProps) {
   const visibleNotes = notes.filter((note) => !note.type || note.type === "note")
 
-  const getStatusLabel = (statusId?: string) => {
-    const status = claimStatuses.find((s) => s.id.toString() === statusId)
-    return status ? status.name : statusId || "Nie wybrano"
+  const getStatusLabel = (statusId?: number) => {
+    const status = claimStatuses.find((s) => s.id === statusId)
+    return status ? status.name : statusId?.toString() || "Nie wybrano"
   }
 
   const getRiskTypeLabel = (riskTypeCode?: string) => {

--- a/hooks/use-dictionaries.ts
+++ b/hooks/use-dictionaries.ts
@@ -14,7 +14,11 @@ export function useDictionary(type: string) {
       setLoading(true)
       setError(null)
       const result = await dictionaryService.getDictionary(type)
-      setData(result.items)
+      const items =
+        type === 'claim-statuses'
+          ? result.items.map((item) => ({ ...item, id: Number(item.id) }))
+          : result.items
+      setData(items)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error')
     } finally {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -40,7 +40,7 @@ export interface EventListItemDto {
   liquidator?: string
   brand?: string
   status?: string
-  claimStatusId?: string
+  claimStatusId?: number
   damageDate?: string
   totalClaim?: number
   payout?: number
@@ -152,7 +152,7 @@ export interface EventUpsertDto {
   liquidator?: string
   brand?: string
   status?: string
-  claimStatusId?: string
+  claimStatusId?: number
   riskType?: string
   damageType?: string
   objectTypeId?: number

--- a/lib/dictionary-service.ts
+++ b/lib/dictionary-service.ts
@@ -1,5 +1,5 @@
 interface DictionaryItemDto {
-  id: string
+  id: string | number
   code?: string
   name: string
   description?: string


### PR DESCRIPTION
## Summary
- switch claim status IDs from strings to numbers in API types
- normalize fetched claim status dictionaries to numeric IDs
- update claim form components to work with numeric status IDs

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a411db54832cae3b1340065c00f9