### PR TITLE
feat: allow renaming uploaded documents

### DIFF
--- a/backend/Controllers/DocumentsController.cs
+++ b/backend/Controllers/DocumentsController.cs
@@ -177,6 +177,7 @@ namespace AutomotiveClaimsApi.Controllers
 
             document.Description = updateDto.Description ?? document.Description;
             document.DocumentType = updateDto.DocumentType ?? document.DocumentType;
+            document.OriginalFileName = updateDto.OriginalFileName ?? document.OriginalFileName;
             // Assuming DocumentStatusId maps to Status string. This might need a lookup table.
             // document.Status = updateDto.DocumentStatusId?.ToString() ?? document.Status;
             document.UpdatedAt = DateTime.UtcNow;

--- a/backend/DTOs/UpdateDocumentDto.cs
+++ b/backend/DTOs/UpdateDocumentDto.cs
@@ -5,5 +5,6 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Description { get; set; }
         public int? DocumentStatusId { get; set; }
         public string? DocumentType { get; set; }
+        public string? OriginalFileName { get; set; }
     }
 }

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -633,7 +633,79 @@ export const DocumentsSection = React.forwardRef<
     }
   }
 
-  const handleDescriptionChange = async (documentId: string | number, description: string) => {
+  const handleFileNameChange = async (documentId: string | number, name: string) => {
+    const pendingIndex = pendingFiles.findIndex((f) => f.id === documentId)
+
+    if (pendingIndex !== -1) {
+      setPendingFiles?.((prev) =>
+        prev.map((f) => (f.id === documentId ? { ...f, name } : f)),
+      )
+      setUploadedFiles((prev) =>
+        prev.map((f) =>
+          f.id === documentId.toString() ? { ...f, name } : f,
+        ),
+      )
+      setPreviewDocument((prev) =>
+        prev?.id === documentId ? { ...prev, originalFileName: name } : prev,
+      )
+      return
+    }
+
+    // Optimistic update
+    setDocuments((prev) =>
+      prev.map((doc) =>
+        doc.id === documentId ? { ...doc, originalFileName: name } : doc,
+      ),
+    )
+    setPreviewDocument((prev) =>
+      prev?.id === documentId ? { ...prev, originalFileName: name } : prev,
+    )
+    setUploadedFiles((prev) =>
+      prev.map((f) =>
+        f.id === documentId.toString() ? { ...f, name } : f,
+      ),
+    )
+
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/documents/${documentId}`,
+        {
+          method: "PUT",
+          credentials: "include",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ originalFileName: name }),
+        },
+      )
+
+      if (response.ok) {
+        const updatedDocument = await response.json()
+        setDocuments((prev) =>
+          prev.map((doc) =>
+            doc.id === documentId ? { ...doc, ...updatedDocument } : doc,
+          ),
+        )
+        setPreviewDocument((prev) =>
+          prev?.id === documentId ? { ...prev, ...updatedDocument } : prev,
+        )
+        setUploadedFiles((prev) =>
+          prev.map((f) =>
+            f.id === documentId.toString()
+              ? { ...f, name: updatedDocument.originalFileName }
+              : f,
+          ),
+        )
+      }
+    } catch (error) {
+      console.error("Error updating document name:", error)
+    }
+  }
+
+  const handleDescriptionChange = async (
+    documentId: string | number,
+    description: string,
+  ) => {
     const pendingIndex = pendingFiles.findIndex((f) => f.id === documentId)
 
     if (pendingIndex !== -1) {
@@ -1127,9 +1199,12 @@ export const DocumentsSection = React.forwardRef<
         )}
       </div>
       <div className="p-3">
-        <p className="text-sm font-medium text-gray-800 truncate" title={doc.originalFileName}>
-          {doc.originalFileName}
-        </p>
+        <Input
+          value={doc.originalFileName}
+          onChange={(e) => handleFileNameChange(doc.id, e.target.value)}
+          className="text-sm mb-1"
+          title={doc.originalFileName}
+        />
         <p className="text-xs text-gray-500">{new Date(doc.createdAt).toLocaleDateString()}</p>
         <p className="text-xs text-gray-400">{formatBytes(doc.fileSize)}</p>
       </div>
@@ -1399,7 +1474,13 @@ export const DocumentsSection = React.forwardRef<
                                 </td>
                                 <td className="p-3 font-medium flex items-center gap-2">
                                   {getFileIcon(doc.contentType)}
-                                  <span className="truncate">{doc.originalFileName}</span>
+                                  <Input
+                                    value={doc.originalFileName}
+                                    onChange={(e) =>
+                                      handleFileNameChange(doc.id, e.target.value)
+                                    }
+                                    className="text-sm h-8"
+                                  />
                                 </td>
                                 <td className="p-3">
                                   <div className="flex items-center gap-1">

--- a/lib/api/documents.ts
+++ b/lib/api/documents.ts
@@ -1,4 +1,5 @@
 import { API_BASE_URL } from "../api";
+import type { DocumentDto } from "../api";
 
 export async function deleteDocument(id: string): Promise<void> {
   const res = await fetch(`${API_BASE_URL}/documents/${id}`, {
@@ -9,4 +10,23 @@ export async function deleteDocument(id: string): Promise<void> {
     const text = await res.text();
     throw new Error(text || "Failed to delete document");
   }
+}
+
+export async function renameDocument(
+  id: string,
+  originalFileName: string,
+): Promise<DocumentDto> {
+  const res = await fetch(`${API_BASE_URL}/documents/${id}`, {
+    method: "PUT",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ originalFileName }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || "Failed to rename document");
+  }
+  return (await res.json()) as DocumentDto;
 }


### PR DESCRIPTION
## Summary
- allow updating document names through API and controllers
- add helper for renaming documents on the client
- expose rename controls in documents section UI

## Testing
- `dotnet test` *(fails: command not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm install` *(fails: GET https://registry.npmjs.org/input-otp: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aab028b4832cb9358ce50788f509