### PR TITLE
Expose decision documents and use document URLs

### DIFF
--- a/backend/DTOs/DecisionDto.cs
+++ b/backend/DTOs/DecisionDto.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace AutomotiveClaimsApi.DTOs
 {
     public class DecisionDto
@@ -12,6 +15,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? DocumentDescription { get; set; }
         public string? DocumentName { get; set; }
         public string? DocumentPath { get; set; }
+        public List<DocumentDto>? Documents { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
     }

--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -326,9 +326,11 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
     const fileName = doc?.originalFileName || doc?.fileName || getDisplayFileName(decision)
 
     try {
-      const url = doc
-        ? `${API_BASE_URL}/claims/${claimId}/decisions/${decision.id}/documents/${doc.id}/download`
-        : `${API_BASE_URL}/claims/${claimId}/decisions/${decision.id}/download`
+      const url =
+        doc?.downloadUrl ??
+        (doc
+          ? `${API_BASE_URL}/documents/${doc.id}/download`
+          : `${API_BASE_URL}/claims/${claimId}/decisions/${decision.id}/download`)
 
       const response = await fetch(url, {
         method: "GET",
@@ -359,7 +361,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
 
   const loadPreview = async (decision: Decision, doc: DocumentDto) => {
     if (!claimId) return
-    const url = `${API_BASE_URL}/claims/${claimId}/decisions/${decision.id}/documents/${doc.id}/preview`
+    const url = doc.previewUrl ?? `${API_BASE_URL}/documents/${doc.id}/preview`
     const response = await fetch(url, { method: "GET", credentials: "include" })
     if (!response.ok) throw new Error("Failed to preview file")
     const blob = await response.blob()


### PR DESCRIPTION
## Summary
- extend decision DTO and controller to return associated documents with preview/download URLs
- use document-provided links when downloading or previewing decision files on the frontend

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm lint` *(fails: Local package.json exists, but node_modules missing)*
- `dotnet test backend` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ac5332c8832c80123425c15d5bc8