### PR TITLE
feat: hide decisions documents

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -18,9 +18,13 @@ import type { DocumentsSectionProps, UploadedFile, DocumentsSectionRef } from "@
 import JSZip from "jszip"
 import { saveAs } from "file-saver"
 
+// Categories that have dedicated sections elsewhere and therefore should
+// not appear in the generic documents section for a claim folder.
 const DEFAULT_HIDDEN_CATEGORIES = [
   "Decyzje",
   "Decyzja",
+  "Decisions",
+  "Decision",
   "Regresy",
   "Regres",
   "Odwołania",


### PR DESCRIPTION
## Summary
- hide decisions document category in generic documents section

## Testing
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*
- `pnpm install` *(fails: GET https://registry.npmjs.org/geist: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b295819c832cbe61889838dd79e1