### PR TITLE
Fix missing preview URLs for uploaded documents

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -450,22 +450,27 @@ export const DocumentsSection = React.forwardRef<
         if (response.ok) {
           const documentDto = await response.json()
           const serverCategory = documentDto.documentType || documentDto.category
-          const doc: Document = {
-            ...documentDto,
-            documentType: serverCategory
-              ? mapCategoryCodeToName(serverCategory)
-              : categoryName || "Inne dokumenty",
-            categoryCode: serverCategory || mapCategoryNameToCode(categoryName),
-            canPreview:
-              documentDto.canPreview ??
-              (documentDto.contentType?.startsWith("image/") ||
-                documentDto.contentType === "application/pdf" ||
-                documentDto.contentType?.startsWith("video/") ||
-                documentDto.contentType ===
-                  "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
-                documentDto.contentType === "application/msword"),
-          }
-          return doc
+         const apiUrl = process.env.NEXT_PUBLIC_API_URL || ""
+         const doc: Document = {
+           ...documentDto,
+           documentType: serverCategory
+             ? mapCategoryCodeToName(serverCategory)
+             : categoryName || "Inne dokumenty",
+           categoryCode: serverCategory || mapCategoryNameToCode(categoryName),
+           canPreview:
+             documentDto.canPreview ??
+             (documentDto.contentType?.startsWith("image/") ||
+               documentDto.contentType === "application/pdf" ||
+               documentDto.contentType?.startsWith("video/") ||
+               documentDto.contentType ===
+                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
+               documentDto.contentType === "application/msword"),
+           previewUrl:
+             documentDto.cloudUrl ||
+             `${apiUrl}/documents/${documentDto.id}/preview`,
+           downloadUrl: `${apiUrl}/documents/${documentDto.id}/download`,
+         }
+         return doc
         } else {
           let errorMessage = `HTTP ${response.status}: ${response.statusText}`
           try {


### PR DESCRIPTION
## Summary
- ensure uploaded documents include `previewUrl` and `downloadUrl` so they can be previewed immediately after upload

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm install` *(fails: GET https://registry.npmjs.org/typescript: Forbidden - 403)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*

------
https://chatgpt.com/codex/tasks/task_e_68a7bb22ed64832c92797b1069cb78f3