### PR TITLE
feat: unify section heading sizes

### DIFF
--- a/app/claims/[id]/view/page.tsx
+++ b/app/claims/[id]/view/page.tsx
@@ -1100,7 +1100,7 @@ export default function ViewClaimPage() {
             <div>
               <div className="flex items-center mb-4">
                 <Calendar className="h-5 w-5 mr-2 text-indigo-600" />
-                <h3 className="text-lg font-semibold">Harmonogram naprawy</h3>
+                <h3 className="text-sm font-semibold">Harmonogram naprawy</h3>
               </div>
                 {repairSchedules.length === 0 ? (
                   <div className="text-center py-8 border-2 border-dashed border-gray-300 rounded-lg bg-gray-50">
@@ -1591,7 +1591,7 @@ export default function ViewClaimPage() {
 
             {/* Repair Time */}
             <div className="space-y-4">
-              <h3 className="text-base font-semibold text-gray-700">Czas naprawy (roboczogodziny)</h3>
+              <h3 className="text-sm font-semibold text-gray-700">Czas naprawy (roboczogodziny)</h3>
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                 <div>
                   <Label htmlFor="bodyworkHours">Prace blacharskie</Label>

--- a/app/claims/create/page.tsx
+++ b/app/claims/create/page.tsx
@@ -75,13 +75,13 @@ export default function CreateClaimPage() {
         onSubmit={handleSubmit}
         className="bg-white p-6 rounded-lg shadow-md w-full max-w-md space-y-4"
       >
-        <h2 className="text-lg font-semibold">Wybierz klienta</h2>
+        <h2 className="text-sm font-semibold">Wybierz klienta</h2>
         <ClientDropdown
           selectedClientId={clientId}
           onClientSelected={(e: ClientSelectionEvent) => setClientId(e.clientId)}
         />
 
-        <h3 className="text-md font-medium pt-2">Przedmiot szkody</h3>
+        <h3 className="text-sm font-semibold pt-2">Przedmiot szkody</h3>
         <div
           role="radiogroup"
           aria-label="Przedmiot szkody"

--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -1057,7 +1057,7 @@ export default function NewClaimPage() {
 
             {/* Repair Time */}
             <div className="space-y-4">
-              <h3 className="text-base font-semibold text-gray-700">Czas naprawy (roboczogodziny)</h3>
+              <h3 className="text-sm font-semibold text-gray-700">Czas naprawy (roboczogodziny)</h3>
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                 <div>
                   <Label htmlFor="bodyworkHours">Prace blacharskie</Label>

--- a/components/claim-form/appeals-section.tsx
+++ b/components/claim-form/appeals-section.tsx
@@ -487,7 +487,7 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
             <Shield className="h-5 w-5" />
           </div>
           <div>
-            <h2 className="text-lg font-semibold text-[#1a3a6c]">Odwołanie/Reklamacja</h2>
+            <h2 className="text-sm font-semibold text-[#1a3a6c]">Odwołanie/Reklamacja</h2>
           </div>
         </div>
 
@@ -506,7 +506,7 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
       {isFormVisible && (
         <div className="bg-white rounded-lg border border-[#d1d9e6] overflow-hidden mb-6 shadow-sm">
           <div className="p-4 bg-[#f8fafc] border-b border-[#d1d9e6]">
-            <h3 className="text-md font-semibold text-[#1a3a6c]">
+            <h3 className="text-sm font-semibold text-[#1a3a6c]">
               {isEditing ? "Edytuj odwołanie" : "Dodaj nowe odwołanie"}
             </h3>
           </div>
@@ -770,7 +770,7 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
       {!isFormVisible && (
         <div className="bg-white rounded-lg border border-[#d1d9e6] overflow-hidden shadow-sm">
           <div className="p-4 bg-[#f8fafc] border-b border-[#d1d9e6]">
-            <h3 className="text-md font-semibold text-[#1a3a6c]">Lista odwołań</h3>
+            <h3 className="text-sm font-semibold text-[#1a3a6c]">Lista odwołań</h3>
           </div>
           <div className="overflow-x-auto">
             <table className="min-w-full bg-white">

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -1290,7 +1290,7 @@ export const ClaimMainContent = ({
               <div className="w-8 h-8 bg-red-500 rounded-lg flex items-center justify-center">
                 <AlertTriangle className="h-4 w-4" />
               </div>
-              <CardTitle className="text-lg font-semibold">Sprawca</CardTitle>
+              <CardTitle className="text-sm font-semibold">Sprawca</CardTitle>
             </CardHeader>
             <CardContent className="p-6 bg-white">
               <ParticipantForm

--- a/components/claim-form/client-claims-section.tsx
+++ b/components/claim-form/client-claims-section.tsx
@@ -533,7 +533,7 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
             <FileSignature className="h-5 w-5" />
           </div>
           <div>
-            <h2 className="text-lg font-semibold text-[#1a3a6c]">Roszczenia</h2>
+            <h2 className="text-sm font-semibold text-[#1a3a6c]">Roszczenia</h2>
           </div>
         </div>
 
@@ -552,7 +552,7 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
       {isFormVisible && (
         <div className="bg-white rounded-lg border border-[#d1d9e6] overflow-hidden mb-6 shadow-sm">
           <div className="p-4 bg-[#f8fafc] border-b border-[#d1d9e6]">
-            <h3 className="text-md font-semibold text-[#1a3a6c]">
+            <h3 className="text-sm font-semibold text-[#1a3a6c]">
               {isEditing ? "Edytuj roszczenie" : "Dodaj nowe roszczenie"}
             </h3>
           </div>
@@ -854,7 +854,7 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
       {!isFormVisible && (
         <div className="bg-white rounded-lg border border-[#d1d9e6] overflow-hidden shadow-sm">
           <div className="p-4 bg-[#f8fafc] border-b border-[#d1d9e6] flex flex-row items-center justify-between">
-            <h3 className="text-md font-semibold text-[#1a3a6c]">Lista roszczeń</h3>
+            <h3 className="text-sm font-semibold text-[#1a3a6c]">Lista roszczeń</h3>
             <div className="text-sm text-gray-500">
               {Object.keys(totalsByCurrency).length > 0 ? (
                 <>

--- a/components/claim-form/communication-claim-summary.tsx
+++ b/components/claim-form/communication-claim-summary.tsx
@@ -240,7 +240,7 @@ const CommunicationClaimSummary = ({
             <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
               <div className="flex items-center space-x-2">
                 <FileText className="h-4 w-4 text-blue-600" />
-                <h3 className="text-base font-semibold text-gray-900">Dane szkody i zdarzenia</h3>
+                <h3 className="text-sm font-semibold text-gray-900">Dane szkody i zdarzenia</h3>
               </div>
             </div>
             <div className="p-4 space-y-3">

--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -524,7 +524,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
             <Gavel className="h-5 w-5" />
           </div>
           <div>
-            <h2 className="text-lg font-semibold text-[#1a3a6c]">Decyzje</h2>
+            <h2 className="text-sm font-semibold text-[#1a3a6c]">Decyzje</h2>
           </div>
         </div>
 
@@ -543,7 +543,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
       {isFormVisible && (
         <div className="bg-white rounded-lg border border-[#d1d9e6] overflow-hidden mb-6 shadow-sm">
           <div className="p-4 bg-[#f8fafc] border-b border-[#d1d9e6]">
-            <h3 className="text-md font-semibold text-[#1a3a6c]">
+            <h3 className="text-sm font-semibold text-[#1a3a6c]">
               {isEditing ? `Edytuj decyzję #${editingDecisionId}` : "Dodaj nową decyzję"}
             </h3>
           </div>
@@ -829,7 +829,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
       {!isFormVisible && (
         <div className="bg-white rounded-lg border border-[#d1d9e6] overflow-hidden shadow-sm">
           <div className="p-4 bg-[#f8fafc] border-b border-[#d1d9e6] flex flex-row items-center justify-between">
-            <h3 className="text-md font-semibold text-[#1a3a6c]">Lista decyzji</h3>
+            <h3 className="text-sm font-semibold text-[#1a3a6c]">Lista decyzji</h3>
             <div className="text-sm text-gray-500">
               {Object.keys(totalPaymentsByCurrency).length > 0 ? (
                 <div>

--- a/components/claim-form/driver-form.tsx
+++ b/components/claim-form/driver-form.tsx
@@ -24,7 +24,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center space-x-2">
             <User className="h-5 w-5 text-blue-600" />
-            <span className="text-lg font-semibold text-gray-900">Uczestnik</span>
+            <span className="text-sm font-semibold text-gray-900">Uczestnik</span>
           </div>
           {isRemovable && (
             <Button
@@ -41,7 +41,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
         <div className="space-y-4">
           {/* Dane podstawowe */}
           <div className="space-y-4">
-            <h4 className="text-base font-semibold text-gray-900 border-b pb-2">Dane podstawowe</h4>
+            <h4 className="text-sm font-semibold text-gray-900 border-b pb-2">Dane podstawowe</h4>
             
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
@@ -167,7 +167,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
 
           {/* Adres */}
           <div className="space-y-4">
-            <h4 className="text-base font-semibold text-gray-900 border-b pb-2">Adres</h4>
+            <h4 className="text-sm font-semibold text-gray-900 border-b pb-2">Adres</h4>
                         
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
@@ -274,7 +274,7 @@ export const DriverForm = ({ driverData, onDriverChange, onRemove, isRemovable }
 
           {/* Dane kontaktowe */}
           <div className="space-y-4">
-            <h4 className="text-base font-semibold text-gray-900 border-b pb-2">Dane kontaktowe</h4>
+            <h4 className="text-sm font-semibold text-gray-900 border-b pb-2">Dane kontaktowe</h4>
                         
             <div>
               <Label htmlFor={`driver-phone-${driverData.id}`} className="text-sm font-medium text-gray-700">

--- a/components/claim-form/participant-form.tsx
+++ b/components/claim-form/participant-form.tsx
@@ -114,7 +114,7 @@ export const ParticipantForm: React.FC<ParticipantFormProps> = ({
                 <Car className="w-5 h-5" />
               </div>
               <div>
-                <h2 className="text-lg font-semibold text-[#1a3a6c]">Dane pojazdu</h2>
+                <h2 className="text-sm font-semibold text-[#1a3a6c]">Dane pojazdu</h2>
               </div>
             </div>
 
@@ -242,7 +242,7 @@ export const ParticipantForm: React.FC<ParticipantFormProps> = ({
                   <Info className="w-5 h-5" />
                 </div>
                 <div>
-                  <h2 className="text-lg font-semibold text-[#1a3a6c]">Dane i kontakt do oględzin</h2>
+                  <h2 className="text-sm font-semibold text-[#1a3a6c]">Dane i kontakt do oględzin</h2>
                 </div>
               </div>
 
@@ -275,7 +275,7 @@ export const ParticipantForm: React.FC<ParticipantFormProps> = ({
                 <FileText className="w-5 h-5" />
               </div>
               <div>
-                <h2 className="text-lg font-semibold text-[#1a3a6c]">Polisa</h2>
+                <h2 className="text-sm font-semibold text-[#1a3a6c]">Polisa</h2>
               </div>
             </div>
 
@@ -378,7 +378,7 @@ export const ParticipantForm: React.FC<ParticipantFormProps> = ({
                 <User className="w-5 h-5" />
               </div>
               <div>
-                <h2 className="text-lg font-semibold text-[#1a3a6c]">Dane osobowe uczestnika</h2>
+                <h2 className="text-sm font-semibold text-[#1a3a6c]">Dane osobowe uczestnika</h2>
               </div>
             </div>
             <Button
@@ -398,7 +398,7 @@ export const ParticipantForm: React.FC<ParticipantFormProps> = ({
               {participantData.drivers && participantData.drivers.map((driver, index) => (
                 <div key={driver.id} className="border border-gray-200 rounded-lg p-4 bg-gray-50">
                   <div className="flex items-center justify-between mb-4">
-                    <h4 className="text-md font-semibold text-[#1a3a6c]">
+                    <h4 className="text-sm font-semibold text-[#1a3a6c]">
                       Osoba {index + 1}
                     </h4>
                     {participantData.drivers.length > 1 && (

--- a/components/claim-form/participants-section.tsx
+++ b/components/claim-form/participants-section.tsx
@@ -232,7 +232,7 @@ export function ParticipantsSection({
                 <div className="text-[#1a3a6c]">
                   <AlertTriangle className="h-5 w-5" />
                 </div>
-                <h2 className="text-lg font-semibold text-[#1a3a6c]">Sprawca</h2>
+                <h2 className="text-sm font-semibold text-[#1a3a6c]">Sprawca</h2>
               </div>
               <Button
                 variant="destructive"

--- a/components/claim-form/recourse-section.tsx
+++ b/components/claim-form/recourse-section.tsx
@@ -514,7 +514,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
             <DollarSign className="h-5 w-5" />
           </div>
           <div>
-            <h2 className="text-lg font-semibold text-[#1a3a6c]">Regres</h2>
+            <h2 className="text-sm font-semibold text-[#1a3a6c]">Regres</h2>
           </div>
         </div>
 
@@ -533,7 +533,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
       {isFormVisible && (
         <div className="bg-white rounded-lg border border-[#d1d9e6] overflow-hidden mb-6 shadow-sm">
           <div className="p-4 bg-[#f8fafc] border-b border-[#d1d9e6]">
-            <h3 className="text-md font-semibold text-[#1a3a6c]">
+            <h3 className="text-sm font-semibold text-[#1a3a6c]">
               {isEditing ? `Edytuj regres #${editingRecourseId}` : "Dodaj nowy regres"}
             </h3>
           </div>
@@ -838,7 +838,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
       {!isFormVisible && (
         <div className="bg-white rounded-lg border border-[#d1d9e6] overflow-hidden shadow-sm">
           <div className="p-4 bg-[#f8fafc] border-b border-[#d1d9e6] flex flex-row items-center justify-between">
-            <h3 className="text-md font-semibold text-[#1a3a6c]">Lista regresów</h3>
+            <h3 className="text-sm font-semibold text-[#1a3a6c]">Lista regresów</h3>
             <div className="text-sm text-gray-500">
               {Object.keys(totalRecourseAmounts).length > 0 ? (
                 <div>

--- a/components/claim-form/repair-details-section.tsx
+++ b/components/claim-form/repair-details-section.tsx
@@ -225,7 +225,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
             <form onSubmit={handleSubmit} className="space-y-8">
               {/* Basic information */}
               <div className="space-y-4">
-                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
                   <Car className="h-5 w-5 text-primary" />
                   Informacje podstawowe
                 </h3>
@@ -293,7 +293,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
 
               {/* Dates */}
               <div className="space-y-4">
-                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
                   <Calendar className="h-5 w-5 text-primary" /> Daty i terminy
                 </h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -346,7 +346,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
 
               {/* Damage description */}
               <div className="space-y-4">
-                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
                   <AlertTriangle className="h-5 w-5 text-accent" /> Opis uszkodzeń
                 </h3>
                 <Textarea
@@ -361,7 +361,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
 
               {/* Vehicle options */}
               <div className="space-y-4">
-                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
                   <Car className="h-5 w-5 text-primary" /> Opcje pojazdów
                 </h3>
                 <div className="space-y-4">
@@ -416,7 +416,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
 
               {/* Work hours */}
               <div className="space-y-4">
-                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
                   <Timer className="h-5 w-5 text-primary" /> Godziny pracy
                 </h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -484,7 +484,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({ even
 
               {/* Additional info */}
               <div className="space-y-4">
-                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
                   <FileText className="h-5 w-5 text-muted-foreground" /> Informacje dodatkowe
                 </h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/components/claim-form/repair-schedule-section.tsx
+++ b/components/claim-form/repair-schedule-section.tsx
@@ -457,7 +457,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
           <CardContent className="p-8">
             <div className="space-y-8 animate-slide-up">
               <div className="space-y-4">
-                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
                   <Car className="h-5 w-5 text-primary" />
                   Podstawowe informacje
                 </h3>
@@ -511,7 +511,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
               </div>
 
               <div className="space-y-4">
-                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
                   <Calendar className="h-5 w-5 text-primary" />
                   Harmonogram napraw
                 </h3>
@@ -572,7 +572,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
               </div>
 
               <div className="space-y-4">
-                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
                   <AlertTriangle className="h-5 w-5 text-accent" />
                   Status operacyjny
                 </h3>
@@ -649,7 +649,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
               </div>
 
               <div className="space-y-4">
-                <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+                <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
                   <User className="h-5 w-5 text-primary" />
                   Kontakty
                 </h3>

--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -521,7 +521,7 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
             <HandHeart className="h-5 w-5" />
           </div>
           <div>
-            <h2 className="text-lg font-semibold text-[#1a3a6c]">Ugoda</h2>
+            <h2 className="text-sm font-semibold text-[#1a3a6c]">Ugoda</h2>
           </div>
         </div>
 
@@ -540,7 +540,7 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
         {isFormVisible && (
           <div className="bg-white rounded-lg border border-[#d1d9e6] overflow-hidden mb-6">
             <div className="p-4 bg-[#f8fafc] border-b border-[#d1d9e6]">
-              <h3 className="text-md font-semibold text-[#1a3a6c]">
+              <h3 className="text-sm font-semibold text-[#1a3a6c]">
                 {isEditing ? `Edytuj ugodę #${editingSettlementId}` : "Dodaj nową ugodę"}
               </h3>
               {isEditing && (
@@ -838,7 +838,7 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
         {!isFormVisible && (
           <div className="bg-white rounded-lg border border-[#d1d9e6] overflow-hidden">
             <div className="p-4 bg-[#f8fafc] border-b border-[#d1d9e6] flex justify-between items-center">
-              <h3 className="text-md font-semibold text-[#1a3a6c]">Lista ugód</h3>
+              <h3 className="text-sm font-semibold text-[#1a3a6c]">Lista ugód</h3>
               <div className="text-sm text-gray-500">
                 {Object.keys(totalPaymentsByCurrency).length > 0 ? (
                   <>
@@ -987,7 +987,7 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
           <div className="bg-white rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] flex flex-col">
             {/* Modal header */}
             <div className="p-4 bg-[#f8fafc] border-b border-[#d1d9e6] flex justify-between items-center">
-              <h3 className="text-md font-semibold text-[#1a3a6c]">Podgląd: {previewFileName}</h3>
+              <h3 className="text-sm font-semibold text-[#1a3a6c]">Podgląd: {previewFileName}</h3>
               <Button
                 onClick={closePreview}
                 variant="ghost"

--- a/components/claim-form/transport-claim-summary.tsx
+++ b/components/claim-form/transport-claim-summary.tsx
@@ -64,7 +64,7 @@ export function TransportClaimSummary({
         <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
           <div className="flex items-center space-x-2">
             <FileText className="h-4 w-4 text-blue-600" />
-            <h3 className="text-base font-semibold text-gray-900">Dane szkody i zdarzenia</h3>
+            <h3 className="text-sm font-semibold text-gray-900">Dane szkody i zdarzenia</h3>
           </div>
         </div>
         <div className="p-4 space-y-3">


### PR DESCRIPTION
## Summary
- normalize section headers across claim forms and related pages to use small semibold style for consistency

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register')*


------
https://chatgpt.com/codex/tasks/task_e_68a7b92b7fb0832ca3ea1eafcba85d98