### PR TITLE
feat: enable excel document preview

### DIFF
--- a/components/claim-form/recourse-section.tsx
+++ b/components/claim-form/recourse-section.tsx
@@ -366,10 +366,16 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
     if (!response.ok) throw new Error("Failed to preview")
     const blob = await response.blob()
     const objectUrl = window.URL.createObjectURL(blob)
-    setPreviewUrl(objectUrl)
     const name = doc.originalFileName || doc.fileName || ""
+    const fileType = getFileType(name)
     setPreviewFileName(name)
-    setPreviewFileType(getFileType(name))
+    setPreviewFileType(fileType)
+    if (fileType === "excel") {
+      setPreviewUrl(url)
+      window.URL.revokeObjectURL(objectUrl)
+    } else {
+      setPreviewUrl(objectUrl)
+    }
     setPreviewDoc(doc)
   }
 
@@ -384,10 +390,16 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
         const blob = await response.blob()
         const objectUrl = window.URL.createObjectURL(blob)
         const name = recourse.documentName || ""
+        const fileType = getFileType(name)
         setPreviewDocs([])
-        setPreviewUrl(objectUrl)
         setPreviewFileName(name)
-        setPreviewFileType(getFileType(name))
+        setPreviewFileType(fileType)
+        if (fileType === "excel") {
+          setPreviewUrl(url)
+          window.URL.revokeObjectURL(objectUrl)
+        } else {
+          setPreviewUrl(objectUrl)
+        }
         setPreviewRecourse(recourse)
         setPreviewDoc(null)
         setIsPreviewVisible(true)
@@ -440,7 +452,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
     setPreviewRecourse(null)
     setPreviewDoc(null)
     setPreviewDocs([])
-    if (previewUrl) {
+    if (previewUrl && previewUrl.startsWith("blob:")) {
       window.URL.revokeObjectURL(previewUrl)
     }
   }
@@ -480,7 +492,17 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
   const isPreviewable = (fileName?: string) => {
     if (!fileName) return false
     const ext = fileName.split(".").pop()?.toLowerCase()
-    return ["pdf", "jpg", "jpeg", "png", "gif", "bmp"].includes(ext || "")
+    return [
+      "pdf",
+      "jpg",
+      "jpeg",
+      "png",
+      "gif",
+      "bmp",
+      "docx",
+      "xls",
+      "xlsx",
+    ].includes(ext || "")
   }
 
   const getFileNameFromPath = (path: string): string => {
@@ -492,6 +514,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
     const ext = fileName.split(".").pop()?.toLowerCase()
     if (ext === "pdf") return "pdf"
     if (["jpg", "jpeg", "png", "gif", "bmp"].includes(ext || "")) return "image"
+    if (ext === "xls" || ext === "xlsx") return "excel"
     return "other"
   }
 
@@ -1010,6 +1033,14 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
                 src={previewUrl || "/placeholder.svg"}
                 className="max-w-full max-h-[70vh] object-contain"
                 alt="Preview"
+              />
+            )}
+
+            {previewFileType === "excel" && previewUrl && (
+              <iframe
+                src={`https://view.officeapps.live.com/op/embed.aspx?src=${encodeURIComponent(previewUrl)}`}
+                className="w-full h-[70vh] border-0"
+                title="Excel Preview"
               />
             )}
 

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -472,7 +472,10 @@ export const DocumentsSection = React.forwardRef<
                documentDto.contentType?.startsWith("video/") ||
                documentDto.contentType ===
                  "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
-               documentDto.contentType === "application/msword"),
+               documentDto.contentType === "application/msword" ||
+               documentDto.contentType === "application/vnd.ms-excel" ||
+               documentDto.contentType ===
+                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
            previewUrl:
              documentDto.cloudUrl ||
              `${apiUrl}/documents/${documentDto.id}/preview`,
@@ -536,7 +539,11 @@ export const DocumentsSection = React.forwardRef<
               ? "image"
               : doc.contentType.includes("pdf")
               ? "pdf"
-              : doc.contentType.includes("msword") || doc.contentType.includes("wordprocessingml")
+              : doc.contentType.includes("msword") ||
+                doc.contentType.includes("wordprocessingml") ||
+                doc.contentType.includes("ms-excel") ||
+                doc.contentType.includes("spreadsheetml") ||
+                doc.contentType.includes("excel")
               ? "doc"
               : "other",
             uploadedAt: doc.createdAt,


### PR DESCRIPTION
## Summary
- support Excel file type in settlement previews
- allow Excel preview for client claims
- handle Excel files in recourse preview dialog
- enable Excel preview in general documents section

## Testing
- `pnpm lint` *(fails: next: not found)*
- `pnpm test` *(fails: Cannot find module 'tsconfig-paths/register`)*

------
https://chatgpt.com/codex/tasks/task_e_68a87ce084d4832c82023c2158587783