### PR TITLE
Remove bulk selection actions from documents section

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -14,7 +14,7 @@ import {
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu"
 import { useToast } from "@/hooks/use-toast"
-import { File, Search, Eye, Download, Upload, X, Trash2, Grid, List, Wand, Plus, FileText, Paperclip, ZoomIn, ZoomOut, ChevronLeft, ChevronRight, RotateCw, Maximize2, Minimize2, Pencil, Save, Move } from 'lucide-react'
+import { File, Search, Eye, Download, Upload, X, Trash2, Grid, List, Wand, Plus, FileText, Paperclip, ZoomIn, ZoomOut, ChevronLeft, ChevronRight, RotateCw, Maximize2, Minimize2, Pencil, Save } from 'lucide-react'
 import type { DocumentsSectionProps, UploadedFile, DocumentsSectionRef } from "@/types"
 import JSZip from "jszip"
 import { saveAs } from "file-saver"
@@ -1074,17 +1074,6 @@ export const DocumentsSection = React.forwardRef<
     )
   }
 
-  const handleMoveSelected = (targetCategory: string, fromCategory?: string) => {
-    const idsToMove = selectedDocumentIds.filter((id) => {
-      const doc = visibleDocuments.find((d) => d.id === id)
-      return doc && (!fromCategory || doc.documentType === fromCategory)
-    })
-
-    idsToMove.forEach((id) => moveDocument(id, targetCategory))
-
-    setSelectedDocumentIds((prev) => prev.filter((id) => !idsToMove.includes(id)))
-  }
-
   const handleDrop = (e: React.DragEvent, category: string) => {
     e.preventDefault()
     e.stopPropagation()
@@ -1396,40 +1385,11 @@ export const DocumentsSection = React.forwardRef<
           >
             <Download className="mr-2 h-4 w-4" /> Pobierz wszystkie
           </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => handleDownloadSelected()}
-            disabled={selectedDocumentIds.length === 0}
-          >
-            <Download className="mr-2 h-4 w-4" /> Pobierz zaznaczone
-          </Button>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={selectedDocumentIds.length === 0}
-              >
-                <Move className="mr-2 h-4 w-4" /> Przenieś zaznaczone
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {documentCategories.map((c) => (
-                <DropdownMenuItem key={c} onClick={() => handleMoveSelected(c)}>
-                  {c}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
         </div>
 
         {documentCategories.map((category) => {
           const documentsForCategory = visibleDocuments.filter((d) => d.documentType === category)
           const isCategoryOpen = openCategories[category] ?? false
-          const hasSelected = documentsForCategory.some((d) =>
-            selectedDocumentIds.includes(d.id),
-          )
 
           return (
             <Card
@@ -1471,42 +1431,6 @@ export const DocumentsSection = React.forwardRef<
                   )}
                 </div>
                 <div className="flex items-center gap-1.5">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      handleDownloadSelected(category)
-                    }}
-                    disabled={!hasSelected}
-                  >
-                    <Download className="mr-2 h-4 w-4" />
-                    Pobierz zaznaczone
-                  </Button>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={(e) => e.stopPropagation()}
-                        disabled={!hasSelected}
-                      >
-                        <Move className="mr-2 h-4 w-4" /> Przenieś zaznaczone
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      {documentCategories
-                        .filter((c) => c !== category)
-                        .map((c) => (
-                          <DropdownMenuItem
-                            key={c}
-                            onClick={() => handleMoveSelected(c, category)}
-                          >
-                            {c}
-                          </DropdownMenuItem>
-                        ))}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
                   <Button
                     size="sm"
                     onClick={(e) => {

--- a/docs/vacation-module.md
+++ b/docs/vacation-module.md
@@ -67,21 +67,17 @@ Status: enum (Pending, Approved, Rejected)
 <!--
 settlements
 8
-Pobierz zaznaczone
 UPLOAD
 
 recourses
 7
-Pobierz zaznaczone
 UPLOAD
 
 appeals
 11
-Pobierz zaznaczone
 UPLOAD
 
 decisions
 13
-Pobierz zaznaczone
 UPLOAD
 -->


### PR DESCRIPTION
## Summary
- remove bulk download and move buttons from documents section UI
- drop unused move-selected handler and doc references

## Testing
- `pnpm lint` *(fails: next not found, node_modules missing)*
- `pnpm install` *(fails: registry 403 authentication error)*
- `pnpm test` *(fails: missing tsconfig-paths/register)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e36692e4832cbaa6509af5487665