### PR TITLE
feat: add admin panel link and auth api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+.env
+.env.*
+dist
+out
+coverage
+

--- a/app/api/admin/[...path]/route.ts
+++ b/app/api/admin/[...path]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api";
+
+async function handler(req: NextRequest, { params }: { params: { path?: string[] } }) {
+  const path = params.path?.join("/") ?? "";
+  const url = `${API_BASE_URL}/Admin/${path}`;
+
+  const init: RequestInit = {
+    method: req.method,
+    headers: {
+      ...(req.headers.get("content-type") ? { "Content-Type": req.headers.get("content-type") as string } : {}),
+      cookie: req.headers.get("cookie") || "",
+    },
+    credentials: "include",
+    body: req.method === "GET" || req.method === "HEAD" ? undefined : await req.arrayBuffer(),
+  };
+
+  const res = await fetch(url, init);
+  const buffer = await res.arrayBuffer();
+  const response = new NextResponse(buffer, {
+    status: res.status,
+  });
+
+  res.headers.forEach((value, key) => {
+    if (key.toLowerCase() === "set-cookie") {
+      response.headers.set("set-cookie", value);
+    } else {
+      response.headers.set(key, value);
+    }
+  });
+
+  return response;
+}
+
+export { handler as GET, handler as POST, handler as PUT, handler as DELETE, handler as PATCH, handler as OPTIONS };

--- a/app/api/auth/[...path]/route.ts
+++ b/app/api/auth/[...path]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5000/api";
+
+async function handler(req: NextRequest, { params }: { params: { path?: string[] } }) {
+  const path = params.path?.join("/") ?? "";
+  const url = `${API_BASE_URL}/Auth/${path}`;
+
+  const init: RequestInit = {
+    method: req.method,
+    headers: {
+      ...(req.headers.get("content-type") ? { "Content-Type": req.headers.get("content-type") as string } : {}),
+      cookie: req.headers.get("cookie") || "",
+    },
+    credentials: "include",
+    body: req.method === "GET" || req.method === "HEAD" ? undefined : await req.arrayBuffer(),
+  };
+
+  const res = await fetch(url, init);
+  const buffer = await res.arrayBuffer();
+  const response = new NextResponse(buffer, {
+    status: res.status,
+  });
+
+  res.headers.forEach((value, key) => {
+    if (key.toLowerCase() === "set-cookie") {
+      response.headers.set("set-cookie", value);
+    } else {
+      response.headers.set(key, value);
+    }
+  });
+
+  return response;
+}
+
+export { handler as GET, handler as POST, handler as PUT, handler as DELETE, handler as PATCH, handler as OPTIONS };

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -99,9 +99,13 @@ export function Header({ onMenuClick, user, onLogout }: HeaderProps) {
                   <span>Profil</span>
                 </DropdownMenuItem>
                 {user?.roles?.some((r) => r.toLowerCase() === 'admin') && (
-                  <DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => {
+                      window.location.href = '/admin'
+                    }}
+                  >
                     <Settings className="mr-2 h-4 w-4" />
-                    <span>Ustawienia</span>
+                    <span>Panel administratora</span>
                   </DropdownMenuItem>
                 )}
                 <DropdownMenuSeparator />

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,7 +2,7 @@
 export const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/+$/, "") ||
   process.env.NEXT_PUBLIC_API_URL?.replace(/\/+$/, "") ||
-  "http://localhost:5200/api"
+  "/api"
 
 export async function getJson<T>(
   path: string,


### PR DESCRIPTION
## Summary
- expose Next.js API route that proxies AuthController login and user info endpoints
- link to the admin panel from the user dropdown when an admin is logged in
- proxy Auth and Admin backend endpoints through Next.js API and default client requests to use this proxy

## Testing
- `pnpm test` *(fails: tests 1, fail 1)*
- `pnpm lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f3e497f4832caf1d0a5a53fc50f9