### PR TITLE
Forward auth cookies for email API calls

### DIFF
--- a/app/api/emails/[id]/read/route.ts
+++ b/app/api/emails/[id]/read/route.ts
@@ -3,14 +3,17 @@ import { type NextRequest, NextResponse } from "next/server"
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: { id: string } },
 ) {
   try {
     const emailId = params.id
+    const cookie = request.headers.get("cookie") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails/${emailId}/read`, {
       method: "POST",
+      credentials: "include",
+      headers: { Cookie: cookie },
     })
 
     if (!response.ok) {

--- a/app/api/emails/[id]/route.ts
+++ b/app/api/emails/[id]/route.ts
@@ -3,14 +3,17 @@ import { type NextRequest, NextResponse } from "next/server"
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: { id: string } },
 ) {
   try {
     const emailId = params.id
+    const cookie = request.headers.get("cookie") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails/${emailId}`, {
       cache: "no-store",
+      credentials: "include",
+      headers: { Cookie: cookie },
     })
 
     if (!response.ok) {
@@ -30,14 +33,17 @@ export async function GET(
 }
 
 export async function DELETE(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: { id: string } },
 ) {
   try {
     const emailId = params.id
+    const cookie = request.headers.get("cookie") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails/${emailId}`, {
       method: "DELETE",
+      credentials: "include",
+      headers: { Cookie: cookie },
     })
 
     if (!response.ok) {

--- a/app/api/emails/assign-to-claim/route.ts
+++ b/app/api/emails/assign-to-claim/route.ts
@@ -5,11 +5,13 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 export async function POST(request: NextRequest) {
   try {
     const { emailId, claimId } = await request.json()
+    const cookie = request.headers.get("cookie") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails/assign-to-claim`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Cookie: cookie },
       body: JSON.stringify({ emailId, claimId }),
+      credentials: "include",
     })
 
     if (!response.ok) {

--- a/app/api/emails/attachment/[id]/route.ts
+++ b/app/api/emails/attachment/[id]/route.ts
@@ -2,11 +2,15 @@ import { type NextRequest, NextResponse } from "next/server"
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
-export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const attachmentId = params.id
+    const cookie = request.headers.get("cookie") ?? ""
 
-    const response = await fetch(`${API_BASE_URL}/emails/attachment/${attachmentId}`)
+    const response = await fetch(`${API_BASE_URL}/emails/attachment/${attachmentId}`, {
+      credentials: "include",
+      headers: { Cookie: cookie },
+    })
 
     if (!response.ok) {
       const errorBody = await response.text()

--- a/app/api/emails/folder/[folder]/route.ts
+++ b/app/api/emails/folder/[folder]/route.ts
@@ -3,14 +3,17 @@ import { type NextRequest, NextResponse } from "next/server"
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: { folder: string } },
 ) {
   try {
     const folder = params.folder
+    const cookie = request.headers.get("cookie") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails/folder/${folder}`, {
       cache: "no-store",
+      credentials: "include",
+      headers: { Cookie: cookie },
     })
 
     if (!response.ok) {

--- a/app/api/emails/route.ts
+++ b/app/api/emails/route.ts
@@ -2,9 +2,14 @@ import { type NextRequest, NextResponse } from "next/server"
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
-export async function GET(_request: NextRequest) {
+export async function GET(request: NextRequest) {
   try {
-    const response = await fetch(`${API_BASE_URL}/emails`, { cache: "no-store" })
+    const cookie = request.headers.get("cookie") ?? ""
+    const response = await fetch(`${API_BASE_URL}/emails`, {
+      cache: "no-store",
+      credentials: "include",
+      headers: { Cookie: cookie },
+    })
 
     if (!response.ok) {
       const errorText = await response.text()
@@ -25,10 +30,13 @@ export async function GET(_request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData()
+    const cookie = request.headers.get("cookie") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails`, {
       method: "POST",
       body: formData,
+      credentials: "include",
+      headers: { Cookie: cookie },
     })
 
     if (!response.ok) {

--- a/app/api/emails/unassigned/route.ts
+++ b/app/api/emails/unassigned/route.ts
@@ -2,10 +2,13 @@ import { type NextRequest, NextResponse } from "next/server"
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
 
-export async function GET(_request: NextRequest) {
+export async function GET(request: NextRequest) {
   try {
+    const cookie = request.headers.get("cookie") ?? ""
     const response = await fetch(`${API_BASE_URL}/emails/unassigned`, {
       cache: "no-store",
+      credentials: "include",
+      headers: { Cookie: cookie },
     })
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- forward cookies and credentials to backend in email API routes to support authenticated requests

## Testing
- `pnpm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa60d4c578832cac9ed014cc35bba1