### PR TITLE
Default Sparta number sorting to descending

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -186,7 +186,8 @@ namespace AutomotiveClaimsApi.Controllers
 
                 if (!string.IsNullOrEmpty(sortBy))
                 {
-                    bool desc = sortOrder != null && sortOrder.ToLower() == "desc";
+                    // Treat any sort order other than an explicit "asc" as descending.
+                    bool desc = sortOrder == null || sortOrder.ToLower() != "asc";
                     query = sortBy switch
                     {
                         "spartaNumber" => desc ? query.OrderByDescending(e => e.SpartaNumber) : query.OrderBy(e => e.SpartaNumber),


### PR DESCRIPTION
## Summary
- ensure backend claims sorting treats non-`asc` requests as descending

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4d9b96dc832c839bc7ed05cb4cfc