### PR TITLE
Display 50 claims per page with infinite scroll

### DIFF
--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -97,7 +97,7 @@ export function ClaimsList({
     field: string
     direction: "asc" | "desc"
   } | null>(null)
-  const pageSize = 30
+  const pageSize = 50
   const [sortBy, setSortBy] = useState<string>("spartaNumber")
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc")
   const loaderRef = useRef<HTMLDivElement | null>(null)


### PR DESCRIPTION
## Summary
- Increase page size for claim list to 50 items to load larger batches through the existing infinite scroll observer

## Testing
- `pnpm lint` *(fails: prompts to configure ESLint)*
- `pnpm test` *(fails: Test failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4d2e0138832cb0cfc484ddb8c66f