### PR TITLE
fix: align damage types route with frontend expectations

### DIFF
--- a/backend/Controllers/DamageTypesController.cs
+++ b/backend/Controllers/DamageTypesController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace AutomotiveClaimsApi.Controllers
 {
     [ApiController]
-    [Route("api/[controller]")]
+    [Route("api/damage-types")]
     public class DamageTypesController : ControllerBase
     {
         private readonly IDamageTypeService _service;


### PR DESCRIPTION
## Summary
- use kebab-case `api/damage-types` route to match frontend calls

## Testing
- `dotnet test` *(fails: command not found)*
- `pnpm test` *(fails: Cannot require() ES Module ...)*
- `pnpm lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4a12417c832ca412699ae664f163