### PR TITLE
Allow specifying handler by ID during claim operations

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -333,7 +333,11 @@ namespace AutomotiveClaimsApi.Controllers
                 }
 
                 CaseHandler? handler = null;
-                if (currentUser?.CaseHandlerId != null)
+                if (eventDto.HandlerId.HasValue)
+                {
+                    handler = await _context.CaseHandlers.FindAsync(eventDto.HandlerId.Value);
+                }
+                else if (currentUser?.CaseHandlerId != null)
                 {
                     handler = await _context.CaseHandlers.FindAsync(currentUser.CaseHandlerId.Value);
                 }
@@ -360,20 +364,17 @@ namespace AutomotiveClaimsApi.Controllers
                         existingEvent.RegisteredById = userId;
                     }
 
-                    if (isHandler)
+                    if (handler != null)
                     {
-                        if (handler != null)
-                        {
-                            existingEvent.HandlerId = handler.Id;
-                            existingEvent.Handler = handler.Name;
-                            existingEvent.HandlerEmail = handler.Email;
-                            existingEvent.HandlerPhone = handler.Phone;
-                        }
-                        else if (currentUser != null)
-                        {
-                            existingEvent.Handler = currentUser.UserName;
-                            existingEvent.HandlerEmail = currentUser.Email;
-                        }
+                        existingEvent.HandlerId = handler.Id;
+                        existingEvent.Handler = handler.Name;
+                        existingEvent.HandlerEmail = handler.Email;
+                        existingEvent.HandlerPhone = handler.Phone;
+                    }
+                    else if (isHandler && currentUser != null)
+                    {
+                        existingEvent.Handler = currentUser.UserName;
+                        existingEvent.HandlerEmail = currentUser.Email;
                     }
 
                     if (string.IsNullOrEmpty(existingEvent.SpartaNumber))
@@ -403,20 +404,17 @@ namespace AutomotiveClaimsApi.Controllers
 
                 await UpsertClaimAsync(eventEntity, eventDto);
 
-                if (isHandler)
+                if (handler != null)
                 {
-                    if (handler != null)
-                    {
-                        eventEntity.HandlerId = handler.Id;
-                        eventEntity.Handler = handler.Name;
-                        eventEntity.HandlerEmail = handler.Email;
-                        eventEntity.HandlerPhone = handler.Phone;
-                    }
-                    else if (currentUser != null)
-                    {
-                        eventEntity.Handler = currentUser.UserName;
-                        eventEntity.HandlerEmail = currentUser.Email;
-                    }
+                    eventEntity.HandlerId = handler.Id;
+                    eventEntity.Handler = handler.Name;
+                    eventEntity.HandlerEmail = handler.Email;
+                    eventEntity.HandlerPhone = handler.Phone;
+                }
+                else if (isHandler && currentUser != null)
+                {
+                    eventEntity.Handler = currentUser.UserName;
+                    eventEntity.HandlerEmail = currentUser.Email;
                 }
 
                 if (string.IsNullOrEmpty(eventEntity.SpartaNumber))
@@ -488,7 +486,11 @@ namespace AutomotiveClaimsApi.Controllers
                 }
 
                 CaseHandler? handler = null;
-                if (currentUser?.CaseHandlerId != null)
+                if (eventDto.HandlerId.HasValue)
+                {
+                    handler = await _context.CaseHandlers.FindAsync(eventDto.HandlerId.Value);
+                }
+                else if (currentUser?.CaseHandlerId != null)
                 {
                     handler = await _context.CaseHandlers.FindAsync(currentUser.CaseHandlerId.Value);
                 }
@@ -613,20 +615,17 @@ namespace AutomotiveClaimsApi.Controllers
 
                 await UpsertClaimAsync(existing, eventDto);
 
-                if (isHandler)
+                if (handler != null)
                 {
-                    if (handler != null)
-                    {
-                        existing.HandlerId = handler.Id;
-                        existing.Handler = handler.Name;
-                        existing.HandlerEmail = handler.Email;
-                        existing.HandlerPhone = handler.Phone;
-                    }
-                    else if (currentUser != null)
-                    {
-                        existing.Handler = currentUser.UserName;
-                        existing.HandlerEmail = currentUser.Email;
-                    }
+                    existing.HandlerId = handler.Id;
+                    existing.Handler = handler.Name;
+                    existing.HandlerEmail = handler.Email;
+                    existing.HandlerPhone = handler.Phone;
+                }
+                else if (isHandler && currentUser != null)
+                {
+                    existing.Handler = currentUser.UserName;
+                    existing.HandlerEmail = currentUser.Email;
                 }
 
                 await _context.SaveChangesAsync();


### PR DESCRIPTION
## Summary
- Resolve handler from provided `HandlerId` or the current user's handler
- Populate claim handler fields using the resolved handler when creating or updating claims

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5081daf4832ca82fcc5e84f55676