### PR TITLE
Load risk types from database

### DIFF
--- a/app/api/dictionaries/risk-types/route.ts
+++ b/app/api/dictionaries/risk-types/route.ts
@@ -9,7 +9,7 @@ export async function GET(request: NextRequest) {
     const url = `${API_BASE_URL}/dictionaries/risk-types?claimObjectTypeId=${claimObjectTypeId}`
 
     const response = await fetch(url)
-    
+
     if (!response.ok) {
       throw new Error('Failed to fetch risk types')
     }
@@ -19,36 +19,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(data)
   } catch (error) {
     console.error('Error fetching risk types:', error)
-    
-    // Fallback data based on your database structure
-    const allRiskTypes = [
-      // claimObjectTypeId = 1 (Szkody komunikacyjne)
-      { id: 1, riskId: 4, name: "OC DZIAŁALNOŚCI", description: "OC DZIAŁALNOŚCI", claimObjectTypeId: 1 },
-      { id: 2, riskId: 2, name: "OC SPRAWCY", description: "OC SPRAWCY", claimObjectTypeId: 1 },
-      { id: 6, riskId: 6, name: "OC PPM", description: "OC PPM", claimObjectTypeId: 1 },
-      { id: 7, riskId: 7, name: "AC", description: "AC", claimObjectTypeId: 1 },
-      { id: 19, riskId: 19, name: "NAPRAWA WŁASNA", description: "NAPRAWA WŁASNA", claimObjectTypeId: 1 },
-      { id: 20, riskId: 20, name: "OC W ŻYCIU PRYWATNYM", description: "OC W ŻYCIU PRYWATNYM", claimObjectTypeId: 1 },
-      { id: 22, riskId: 22, name: "OC ROLNIKA", description: "OC ROLNIKA", claimObjectTypeId: 1 },
-      { id: 23, riskId: 1, name: "INNE", description: "INNE", claimObjectTypeId: 1 },
-      
-      // claimObjectTypeId = 2 (Szkody mienia)
-      { id: 3, riskId: 4, name: "MAJĄTKOWE", description: "MAJĄTKOWE", claimObjectTypeId: 2 },
-      { id: 8, riskId: 57, name: "NNW", description: "NNW", claimObjectTypeId: 2 },
-      { id: 9, riskId: 57, name: "CPM", description: "CPM", claimObjectTypeId: 2 },
-      { id: 10, riskId: 57, name: "CAR/EAR", description: "CAR/EAR", claimObjectTypeId: 2 },
-      { id: 11, riskId: 57, name: "BI", description: "BI", claimObjectTypeId: 2 },
-      { id: 12, riskId: 57, name: "GWARANCJIE", description: "GWARANCJIE", claimObjectTypeId: 2 },
-
-      // claimObjectTypeId = 3 (Szkody transportowe)
-      { id: 4, riskId: 4, name: "OCPD", description: "OCPD", claimObjectTypeId: 3 },
-      { id: 5, riskId: 4, name: "CARGO", description: "CARGO", claimObjectTypeId: 3 }
-    ]
-    
-    const { searchParams } = new URL(request.url)
-    const claimObjectTypeId = searchParams.get('claimObjectTypeId') || '1'
-    const filteredData = allRiskTypes.filter(item => item.claimObjectTypeId.toString() === claimObjectTypeId)
-
-    return NextResponse.json({ items: filteredData })
+    return NextResponse.json({ error: 'Failed to fetch risk types' }, { status: 500 })
   }
 }

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -330,34 +330,10 @@ export const ClaimMainContent = ({
       }
     } catch (error) {
       console.error("Error loading risk types:", error)
-      // Fallback data for communication claims (claimObjectTypeId = 1)
-      const communicationRiskTypes = [
-        { value: "4", label: "OC DZIAŁALNOŚCI" },
-        { value: "2", label: "OC SPRAWCY" },
-        { value: "6", label: "OC PPM" },
-        { value: "7", label: "AC" },
-        { value: "19", label: "NAPRAWA WŁASNA" },
-        { value: "20", label: "OC W ŻYCIU PRYWATNYM" },
-        { value: "22", label: "OC ROLNIKA" },
-        { value: "1", label: "INNE" },
-      ]
-      
-      const propertyRiskTypes = [
-        { value: "4", label: "MAJĄTKOWE" },
-        { value: "4", label: "OCPD" },
-        { value: "4", label: "CARGO" },
-        { value: "57", label: "NNW" },
-        { value: "57", label: "CPM" },
-        { value: "57", label: "CAR/EAR" },
-        { value: "57", label: "BI" },
-        { value: "57", label: "GWARANCJIE" },
-      ]
-      
-      setRiskTypes(claimObjectType === "1" ? communicationRiskTypes : propertyRiskTypes)
-      
+      setRiskTypes([])
       toast({
         title: "Uwaga",
-        description: "Nie udało się załadować danych z serwera. Używane są dane lokalne.",
+        description: "Nie udało się załadować danych z serwera.",
         variant: "destructive",
       })
     } finally {


### PR DESCRIPTION
## Summary
- Remove hardcoded risk type fallbacks and rely on API data
- Fetch allowed risk types dynamically on claims list
- Return error when backend risk type request fails

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68ab51625b3c832c9a043e312b19abe1