### PR TITLE
Use API_BASE_URL for risk type fetches

### DIFF
--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -38,6 +38,7 @@ import { useClaims } from "@/hooks/use-claims"
 import { useToast } from "@/hooks/use-toast"
 import { useAuth } from "@/hooks/use-auth"
 import type { Claim } from "@/types"
+import { API_BASE_URL } from "@/lib/api"
 
 
 const typeLabelMap: Record<number, string> = {
@@ -176,7 +177,7 @@ export function ClaimsList({
     const loadRiskTypes = async () => {
       try {
         const res = await fetch(
-          `/api/dictionaries/risk-types?claimObjectTypeId=${claimObjectTypeId}`,
+          `${API_BASE_URL}/dictionaries/risk-types?claimObjectTypeId=${claimObjectTypeId}`,
           { credentials: "include" },
         )
         const data = await res.json()

--- a/components/new-claim-dialog.tsx
+++ b/components/new-claim-dialog.tsx
@@ -10,6 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import ClientDropdown from "@/components/client-dropdown"
 import { Button } from "@/components/ui/button"
 import type { ClientSelectionEvent } from "@/types/client"
+import { API_BASE_URL } from "@/lib/api"
 
 interface RiskType {
   value: string
@@ -50,9 +51,12 @@ export function NewClaimDialog({ open, onOpenChange }: NewClaimDialogProps) {
   } = useQuery<RiskType[]>({
     queryKey: ["risk-types", claimObjectTypeId],
     queryFn: async () => {
-      const res = await fetch(`/api/dictionaries/risk-types?claimObjectTypeId=${claimObjectTypeId}`, {
-        credentials: "include",
-      })
+      const res = await fetch(
+        `${API_BASE_URL}/dictionaries/risk-types?claimObjectTypeId=${claimObjectTypeId}`,
+        {
+          credentials: "include",
+        },
+      )
       const data = await res.json()
       return (data.items || []).map((item: any) => ({ value: String(item.id), label: item.name }))
     },


### PR DESCRIPTION
## Summary
- use API_BASE_URL for risk type lookups in new claim dialog
- use API_BASE_URL for risk type filtering in claims list

## Testing
- `pnpm lint` (fails: requires ESLint setup)
- `pnpm test` (fails: tests failing to load modules)


------
https://chatgpt.com/codex/tasks/task_e_68ab59ba8168832c9606055c77f62346