### PR TITLE
Use API_BASE_URL for damage type queries

### DIFF
--- a/components/claim-form/damage-basic-info-section.tsx
+++ b/components/claim-form/damage-basic-info-section.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { DependentSelect } from "@/components/ui/dependent-select"
+import { API_BASE_URL } from "@/lib/api"
 import type { Claim } from "@/types"
 
 interface DamageBasicInfoSectionProps {
@@ -85,7 +86,7 @@ export function DamageBasicInfoSection({
           value={claimFormData.damageType || ""}
           onValueChange={(value) => handleFormChange("damageType", value)}
           placeholder="Wybierz rodzaj szkody..."
-          apiUrl="/api/damage-types"
+          apiUrl={`${API_BASE_URL}/damage-types`}
           riskTypeId={claimFormData.riskType}
           disabled={!claimFormData.riskType}
         />

--- a/components/claim-form/damage-data-section.tsx
+++ b/components/claim-form/damage-data-section.tsx
@@ -11,6 +11,7 @@ import ClientDropdown from "@/components/client-dropdown"
 import HandlerDropdown from "@/components/handler-dropdown"
 import InsuranceDropdown from "@/components/insurance-dropdown"
 import LeasingDropdown from "@/components/leasing-dropdown"
+import { API_BASE_URL } from "@/lib/api"
 import { FileText } from "lucide-react"
 import type { Claim } from "@/types"
 import type { ClientSelectionEvent } from "@/types/client"
@@ -202,7 +203,7 @@ export function DamageDataSection({
                 value={claimFormData.damageType || ""}
                 onValueChange={(value) => handleFormChange("damageType", value)}
                 placeholder="Wybierz rodzaj szkody..."
-                apiUrl="/api/damage-types"
+                apiUrl={`${API_BASE_URL}/damage-types`}
                 riskTypeId={claimFormData.riskType}
                 disabled={!claimFormData.riskType}
               />

--- a/components/claim-form/property-damage-section.tsx
+++ b/components/claim-form/property-damage-section.tsx
@@ -13,6 +13,7 @@ import InsuranceDropdown from "@/components/insurance-dropdown"
 import LeasingDropdown from "@/components/leasing-dropdown"
 import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
+import { API_BASE_URL } from "@/lib/api"
 import { FileText } from "lucide-react"
 import type { Claim } from "@/types"
 import type { ClientSelectionEvent } from "@/types/client"
@@ -218,7 +219,7 @@ export function PropertyDamageSection({
                 value={claimFormData.damageType || ""}
                 onValueChange={(value) => handleFormChange("damageType", value)}
                 placeholder="Wybierz rodzaj szkody..."
-                apiUrl="/api/damage-types"
+                apiUrl={`${API_BASE_URL}/damage-types`}
                 riskTypeId={claimFormData.riskType}
                 disabled={!claimFormData.riskType}
               />

--- a/components/new-claim-dialog.tsx
+++ b/components/new-claim-dialog.tsx
@@ -69,9 +69,12 @@ export function NewClaimDialog({ open, onOpenChange }: NewClaimDialogProps) {
   } = useQuery<DamageType[]>({
     queryKey: ["damage-types", riskTypeId],
     queryFn: async () => {
-      const res = await fetch(`/api/damage-types?riskTypeId=${riskTypeId}`, {
-        credentials: "include",
-      })
+      const res = await fetch(
+        `${API_BASE_URL}/damage-types?riskTypeId=${riskTypeId}`,
+        {
+          credentials: "include",
+        },
+      )
       return res.json()
     },
     enabled: !!riskTypeId,


### PR DESCRIPTION
## Summary
- fetch damage types directly from backend using API_BASE_URL
- update claim form components to pass API_BASE_URL to DependentSelect

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5c2c8014832c92d35f23dcefd902