### PR TITLE
feat: persist claim status via id

### DIFF
--- a/app/api/claim-statuses/route.ts
+++ b/app/api/claim-statuses/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
 
     // Transform the data to match frontend expectations
     const transformedData = data.map((item: any) => ({
-      id: Number(item.id),
+      id: item.id,
       code: item.code,
       name: item.name,
       label: item.name,

--- a/app/api/dictionaries/claim-statuses/route.ts
+++ b/app/api/dictionaries/claim-statuses/route.ts
@@ -16,10 +16,7 @@ export async function GET(request: NextRequest) {
     }
 
     const data = await response.json()
-    const items = (data.items ?? []).map((item: any) => ({
-      ...item,
-      id: Number(item.id),
-    }))
+    const items = (data.items ?? [])
     return NextResponse.json({ ...data, items })
   } catch (error) {
     console.error('Error fetching claim statuses:', error)

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -58,7 +58,7 @@ interface RiskType {
 }
 
 interface ClaimStatus {
-  id: number
+  id: string
   name: string
   description: string
 }
@@ -353,9 +353,7 @@ export const ClaimMainContent = ({
       )
       if (response.ok) {
         const data = await response.json()
-        setClaimStatuses(
-          (data.items ?? []).map((item: any) => ({ ...item, id: Number(item.id) })),
-        )
+        setClaimStatuses((data.items ?? []) as ClaimStatus[])
       } else {
         throw new Error(`HTTP error! status: ${response.status}`)
       }
@@ -606,9 +604,9 @@ export const ClaimMainContent = ({
   }
 
   // Get status label from code
-  const getStatusLabel = (statusId?: number) => {
+  const getStatusLabel = (statusId?: string) => {
     const status = claimStatuses.find((s) => s.id === statusId)
-    return status ? status.name : statusId?.toString() || "Nie wybrano"
+    return status ? status.name : statusId || "Nie wybrano"
   }
 
   // Get risk type label from code

--- a/components/claim-form/communication-claim-summary.tsx
+++ b/components/claim-form/communication-claim-summary.tsx
@@ -24,7 +24,7 @@ import type {
 } from "@/types"
 
 interface ClaimStatus {
-  id: number
+  id: string
   name: string
   description: string
 }
@@ -132,9 +132,9 @@ const CommunicationClaimSummary = ({
 }: CommunicationClaimSummaryProps) => {
   const visibleNotes = notes.filter((note) => !note.type || note.type === "note")
 
-  const getStatusLabel = (statusId?: number) => {
+  const getStatusLabel = (statusId?: string) => {
     const status = claimStatuses.find((s) => s.id === statusId)
-    return status ? status.name : statusId?.toString() || "Nie wybrano"
+    return status ? status.name : statusId || "Nie wybrano"
   }
 
   const getRiskTypeLabel = (riskTypeCode?: string) => {
@@ -250,7 +250,7 @@ const CommunicationClaimSummary = ({
               </div>
 
               <div className="grid grid-cols-2 gap-3">
-                <InfoCard label="Status" value={getStatusLabel(claimFormData.status)} />
+                <InfoCard label="Status" value={getStatusLabel(claimFormData.claimStatusId)} />
                 <InfoCard label="Szkodę zarejestrował" value={claimFormData.handler} />
               </div>
 

--- a/components/claim-form/damage-data-section.tsx
+++ b/components/claim-form/damage-data-section.tsx
@@ -25,7 +25,7 @@ interface RiskType {
 }
 
 interface ClaimStatus {
-  id: number
+  id: string
   name: string
   description: string
 }
@@ -124,8 +124,8 @@ export function DamageDataSection({
                 Status szkody
               </Label>
               <Select
-                value={claimFormData.status?.toString() || ""}
-                onValueChange={(value) => handleFormChange("status", Number(value))}
+                value={claimFormData.claimStatusId || ""}
+                onValueChange={(value) => handleFormChange("claimStatusId", value)}
                 disabled={loadingStatuses}
               >
                 <SelectTrigger className="mt-0.5">
@@ -133,7 +133,7 @@ export function DamageDataSection({
                 </SelectTrigger>
                 <SelectContent>
                   {claimStatuses.map((status) => (
-                    <SelectItem key={status.id} value={status.id.toString()}>
+                    <SelectItem key={status.id} value={status.id}>
                       {status.name}
                     </SelectItem>
                   ))}

--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -36,6 +36,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
     claimNumber: '',
     insurerClaimNumber: '',
     status: 'Nowa',
+    claimStatusId: '',
     riskType: '',
     damageType: '',
     damageDate: '',

--- a/components/claim-form/property-claim-form.tsx
+++ b/components/claim-form/property-claim-form.tsx
@@ -17,7 +17,7 @@ interface RiskType {
 }
 
 interface ClaimStatus {
-  id: number
+  id: string
   name: string
   description: string
 }

--- a/components/claim-form/property-claim-summary.tsx
+++ b/components/claim-form/property-claim-summary.tsx
@@ -5,7 +5,7 @@ import { DocumentsSection } from "../documents-section"
 import type { Claim, Note, UploadedFile } from "@/types"
 
 interface ClaimStatus {
-  id: number
+  id: string
   name: string
   description: string
 }
@@ -46,9 +46,9 @@ export function PropertyClaimSummary({
 }: PropertyClaimSummaryProps) {
   const visibleNotes = notes.filter((note) => !note.type || note.type === "note")
 
-  const getStatusLabel = (statusId?: number) => {
+  const getStatusLabel = (statusId?: string) => {
     const status = claimStatuses.find((s) => s.id === statusId)
-    return status ? status.name : statusId?.toString() || "Nie wybrano"
+    return status ? status.name : statusId || "Nie wybrano"
   }
 
   const getRiskTypeLabel = (riskTypeCode?: string) => {
@@ -71,7 +71,7 @@ export function PropertyClaimSummary({
             <InfoCard label="Nr szkody TU" value={claimFormData.insurerClaimNumber} />
           </div>
           <div className="grid grid-cols-2 gap-3">
-            <InfoCard label="Status" value={getStatusLabel(claimFormData.status)} />
+            <InfoCard label="Status" value={getStatusLabel(claimFormData.claimStatusId)} />
             <InfoCard label="Szkodę zarejestrował" value={claimFormData.handler} />
           </div>
           {(claimFormData.handlerEmail || claimFormData.handlerPhone) && (

--- a/components/claim-form/property-damage-section.tsx
+++ b/components/claim-form/property-damage-section.tsx
@@ -27,7 +27,7 @@ interface RiskType {
 }
 
 interface ClaimStatus {
-  id: number
+  id: string
   name: string
   description: string
 }
@@ -136,8 +136,8 @@ export function PropertyDamageSection({
                 Status szkody
               </Label>
               <Select
-                value={claimFormData.status?.toString() || ""}
-                onValueChange={(value) => handleFormChange("status", Number(value))}
+                value={claimFormData.claimStatusId || ""}
+                onValueChange={(value) => handleFormChange("claimStatusId", value)}
                 disabled={loadingStatuses}
               >
                 <SelectTrigger className="mt-0.5">
@@ -147,7 +147,7 @@ export function PropertyDamageSection({
                 </SelectTrigger>
                 <SelectContent>
                   {claimStatuses.map((status) => (
-                    <SelectItem key={status.id} value={status.id.toString()}>
+                    <SelectItem key={status.id} value={status.id}>
                       {status.name}
                     </SelectItem>
                   ))}

--- a/components/claim-form/transport-claim-form.tsx
+++ b/components/claim-form/transport-claim-form.tsx
@@ -18,7 +18,7 @@ interface RiskType {
 }
 
 interface ClaimStatus {
-  id: number
+  id: string
   name: string
   description: string
 }

--- a/components/claim-form/transport-claim-summary.tsx
+++ b/components/claim-form/transport-claim-summary.tsx
@@ -5,7 +5,7 @@ import { DocumentsSection } from "../documents-section"
 import type { Claim, Note, UploadedFile } from "@/types"
 
 interface ClaimStatus {
-  id: number
+  id: string
   name: string
   description: string
 }
@@ -46,9 +46,9 @@ export function TransportClaimSummary({
 }: TransportClaimSummaryProps) {
   const visibleNotes = notes.filter((note) => !note.type || note.type === "note")
 
-  const getStatusLabel = (statusId?: number) => {
+  const getStatusLabel = (statusId?: string) => {
     const status = claimStatuses.find((s) => s.id === statusId)
-    return status ? status.name : statusId?.toString() || "Nie wybrano"
+    return status ? status.name : statusId || "Nie wybrano"
   }
 
   const getRiskTypeLabel = (riskTypeCode?: string) => {
@@ -73,7 +73,7 @@ export function TransportClaimSummary({
             <InfoCard label="Nr szkody TU" value={claimFormData.insurerClaimNumber} />
           </div>
           <div className="grid grid-cols-2 gap-3">
-            <InfoCard label="Status" value={getStatusLabel(claimFormData.status)} />
+            <InfoCard label="Status" value={getStatusLabel(claimFormData.claimStatusId)} />
             <InfoCard label="Szkodę zarejestrował" value={claimFormData.handler} />
           </div>
           {(claimFormData.handlerEmail || claimFormData.handlerPhone) && (

--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -216,7 +216,7 @@ export function ClaimsList({
     () =>
       claims.filter((claim: any) => {
         const matchesFilter =
-          filterStatus === "all" || claim.claimStatusId?.toString() === filterStatus
+          filterStatus === "all" || claim.claimStatusId === filterStatus
         const matchesRegistration =
           !filterRegistration ||
           claim.victimRegistrationNumber?.toLowerCase().includes(filterRegistration.toLowerCase())

--- a/hooks/use-dictionaries.ts
+++ b/hooks/use-dictionaries.ts
@@ -14,10 +14,7 @@ export function useDictionary(type: string) {
       setLoading(true)
       setError(null)
       const result = await dictionaryService.getDictionary(type)
-      const items =
-        type === 'claim-statuses'
-          ? result.items.map((item) => ({ ...item, id: Number(item.id) }))
-          : result.items
+      const items = result.items
       setData(items)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error')

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -40,7 +40,7 @@ export interface EventListItemDto {
   liquidator?: string
   brand?: string
   status?: string
-  claimStatusId?: number
+  claimStatusId?: string
   damageDate?: string
   totalClaim?: number
   payout?: number
@@ -157,7 +157,7 @@ export interface EventUpsertDto {
   liquidator?: string
   brand?: string
   status?: string
-  claimStatusId?: number
+  claimStatusId?: string
   riskType?: string
   damageType?: string
   objectTypeId?: number


### PR DESCRIPTION
## Summary
- update claim form to store claimStatusId instead of numeric status
- load claim statuses as string identifiers and use them across summaries and lists
- simplify dictionary hook to avoid coercing ids

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68ab62ab0ee8832cbc45613c13a4c11d