### PR TITLE
Fix risk type ternary in claims list

### DIFF
--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -756,9 +756,8 @@ export function ClaimsList({
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       {claim.riskType
-
                         ? riskTypeMap[claim.riskType.toLowerCase()] || "-"
-                      }
+                        : "-"}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <Badge className={`text-xs border ${getStatusColor(claim.status ?? "")}`}>


### PR DESCRIPTION
## Summary
- fix missing colon in risk type display causing build failure

## Testing
- `pnpm test` *(fails: tests 1 fail)*
- `pnpm build` *(fails: Can't resolve '@/components/admin/role-form-dialog')*


------
https://chatgpt.com/codex/tasks/task_e_68ab8bbe51f0832c8b50819d3c176dc3