### PR TITLE
Switch RiskType identifiers from GUID to integer

### DIFF
--- a/app/settings/damage-types/page.tsx
+++ b/app/settings/damage-types/page.tsx
@@ -51,7 +51,7 @@ export default function DamageTypesPage() {
     code: "",
     name: "",
     description: "",
-    riskTypeId: "",
+    riskTypeId: 0,
     isActive: true,
   })
 
@@ -87,7 +87,7 @@ export default function DamageTypesPage() {
         code: "",
         name: "",
         description: "",
-        riskTypeId: "",
+        riskTypeId: 0,
         isActive: true,
       })
       setEditingId(null)
@@ -186,15 +186,15 @@ export default function DamageTypesPage() {
         <div>
           <Label htmlFor="riskType">Typ ryzyka</Label>
           <Select
-            value={formData.riskTypeId}
-            onValueChange={(v) => setFormData({ ...formData, riskTypeId: v })}
+            value={formData.riskTypeId ? formData.riskTypeId.toString() : ""}
+            onValueChange={(v) => setFormData({ ...formData, riskTypeId: Number(v) })}
           >
             <SelectTrigger id="riskType" className="w-full">
               <SelectValue placeholder="Wybierz" />
             </SelectTrigger>
             <SelectContent>
               {riskTypes.map((rt) => (
-                <SelectItem key={rt.id} value={rt.id}>
+                <SelectItem key={rt.id} value={rt.id.toString()}>
                   {rt.name}
                 </SelectItem>
               ))}
@@ -223,7 +223,7 @@ export default function DamageTypesPage() {
                   code: "",
                   name: "",
                   description: "",
-                  riskTypeId: "",
+                  riskTypeId: 0,
                   isActive: true,
                 })
               }}

--- a/app/settings/risk-types/page.tsx
+++ b/app/settings/risk-types/page.tsx
@@ -43,7 +43,7 @@ export default function RiskTypesPage() {
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc")
   const [page, setPage] = useState(1)
   const pageSize = 10
-  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<number | null>(null)
   const [error, setError] = useState("")
   const [formData, setFormData] = useState<CreateRiskTypeDto>({
     code: "",
@@ -92,7 +92,7 @@ export default function RiskTypesPage() {
     setEditingId(rt.id)
   }
 
-  const handleDelete = async (id: string) => {
+  const handleDelete = async (id: number) => {
     setError("")
     try {
       await apiService.deleteRiskType(id)

--- a/backend/Controllers/DamageTypesController.cs
+++ b/backend/Controllers/DamageTypesController.cs
@@ -17,7 +17,7 @@ namespace AutomotiveClaimsApi.Controllers
 
         [HttpGet]
 
-        public async Task<IActionResult> GetDamageTypes([FromQuery] Guid? riskTypeId = null)
+        public async Task<IActionResult> GetDamageTypes([FromQuery] int? riskTypeId = null)
 
         {
             var result = await _service.GetDamageTypesAsync(riskTypeId);

--- a/backend/Controllers/RiskTypesController.cs
+++ b/backend/Controllers/RiskTypesController.cs
@@ -41,7 +41,7 @@ namespace AutomotiveClaimsApi.Controllers
         }
 
         [HttpGet("{id}")]
-        public async Task<IActionResult> GetRiskType(Guid id)
+        public async Task<IActionResult> GetRiskType(int id)
         {
             var result = await _service.GetRiskTypeAsync(id);
         
@@ -63,7 +63,7 @@ namespace AutomotiveClaimsApi.Controllers
         }
 
         [HttpPut("{id}")]
-        public async Task<IActionResult> UpdateRiskType(Guid id, RiskTypeDto dto)
+        public async Task<IActionResult> UpdateRiskType(int id, RiskTypeDto dto)
         {
 
             var result = await _service.UpdateRiskTypeAsync(id, dto);
@@ -77,7 +77,7 @@ namespace AutomotiveClaimsApi.Controllers
         }
 
         [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteRiskType(Guid id)
+        public async Task<IActionResult> DeleteRiskType(int id)
         {
 
             var result = await _service.DeleteRiskTypeAsync(id);

--- a/backend/DTOs/DamageTypeDto.cs
+++ b/backend/DTOs/DamageTypeDto.cs
@@ -19,7 +19,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Description { get; set; }
         
         [Required]
-        public Guid RiskTypeId { get; set; }
+        public int RiskTypeId { get; set; }
         
         public string? RiskTypeName { get; set; }
         public bool IsActive { get; set; }

--- a/backend/DTOs/RiskTypeDto.cs
+++ b/backend/DTOs/RiskTypeDto.cs
@@ -4,7 +4,7 @@ namespace AutomotiveClaimsApi.DTOs
 {
     public class RiskTypeDto
     {
-        public Guid Id { get; set; }
+        public int Id { get; set; }
         
         [Required]
         [MaxLength(20)]

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -251,10 +251,10 @@ namespace AutomotiveClaimsApi.Migrations
 
             modelBuilder.Entity("AutomotiveClaimsApi.Models.Appeal", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid")
-                        .HasDefaultValueSql("gen_random_uuid()");
+                        .HasColumnType("integer")
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
                     b.Property<decimal?>("AppealAmount")
                         .HasColumnType("decimal(18,2)");
@@ -578,10 +578,10 @@ namespace AutomotiveClaimsApi.Migrations
 
             modelBuilder.Entity("AutomotiveClaimsApi.Models.RiskType", b =>
                 {
-                    b.Property<Guid>("Id")
+                    b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid")
-                        .HasDefaultValueSql("gen_random_uuid()");
+                        .HasColumnType("integer")
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
                     b.Property<string>("Code")
                         .IsRequired()

--- a/backend/Models/DamageType.cs
+++ b/backend/Models/DamageType.cs
@@ -18,7 +18,7 @@ namespace AutomotiveClaimsApi.Models
         public string? Description { get; set; }
         
         [Required]
-        public Guid RiskTypeId { get; set; }
+        public int RiskTypeId { get; set; }
         
         public bool IsActive { get; set; } = true;
         

--- a/backend/Models/RiskType.cs
+++ b/backend/Models/RiskType.cs
@@ -4,7 +4,7 @@ namespace AutomotiveClaimsApi.Models
 {
     public class RiskType
     {
-        public Guid Id { get; set; }
+        public int Id { get; set; }
         
         [Required]
         [MaxLength(20)]

--- a/backend/Services/DamageTypeService.cs
+++ b/backend/Services/DamageTypeService.cs
@@ -13,7 +13,7 @@ namespace AutomotiveClaimsApi.Services
             _context = context;
         }
 
-        public async Task<ServiceResult<IEnumerable<DamageTypeDto>>> GetDamageTypesAsync(Guid? riskTypeId)
+        public async Task<ServiceResult<IEnumerable<DamageTypeDto>>> GetDamageTypesAsync(int? riskTypeId)
         {
             try
             {

--- a/backend/Services/IDamageTypeService.cs
+++ b/backend/Services/IDamageTypeService.cs
@@ -4,7 +4,7 @@ namespace AutomotiveClaimsApi.Services
 {
     public interface IDamageTypeService
     {
-        Task<ServiceResult<IEnumerable<DamageTypeDto>>> GetDamageTypesAsync(Guid? riskTypeId);
+        Task<ServiceResult<IEnumerable<DamageTypeDto>>> GetDamageTypesAsync(int? riskTypeId);
         Task<ServiceResult<DamageTypeDto>> GetDamageTypeAsync(Guid id);
         Task<ServiceResult<DamageTypeDto>> CreateDamageTypeAsync(DamageTypeDto dto);
         Task<ServiceResult> UpdateDamageTypeAsync(Guid id, DamageTypeDto dto);

--- a/backend/Services/IRiskTypeService.cs
+++ b/backend/Services/IRiskTypeService.cs
@@ -5,10 +5,10 @@ namespace AutomotiveClaimsApi.Services
     public interface IRiskTypeService
     {
         Task<ServiceResult<IEnumerable<RiskTypeDto>>> GetRiskTypesAsync(int? claimObjectTypeId);
-        Task<ServiceResult<RiskTypeDto>> GetRiskTypeAsync(Guid id);
+        Task<ServiceResult<RiskTypeDto>> GetRiskTypeAsync(int id);
         Task<ServiceResult<RiskTypeDto>> CreateRiskTypeAsync(RiskTypeDto dto);
-        Task<ServiceResult> UpdateRiskTypeAsync(Guid id, RiskTypeDto dto);
-        Task<ServiceResult> DeleteRiskTypeAsync(Guid id);
+        Task<ServiceResult> UpdateRiskTypeAsync(int id, RiskTypeDto dto);
+        Task<ServiceResult> DeleteRiskTypeAsync(int id);
     }
 }
 

--- a/backend/Services/RiskTypeService.cs
+++ b/backend/Services/RiskTypeService.cs
@@ -46,7 +46,7 @@ namespace AutomotiveClaimsApi.Services
             }
         }
 
-        public async Task<ServiceResult<RiskTypeDto>> GetRiskTypeAsync(Guid id)
+        public async Task<ServiceResult<RiskTypeDto>> GetRiskTypeAsync(int id)
         {
             try
             {
@@ -89,7 +89,6 @@ namespace AutomotiveClaimsApi.Services
 
                 var riskType = new Models.RiskType
                 {
-                    Id = Guid.NewGuid(),
                     Code = dto.Code,
                     Name = dto.Name,
                     Description = dto.Description,
@@ -120,7 +119,7 @@ namespace AutomotiveClaimsApi.Services
             }
         }
 
-        public async Task<ServiceResult> UpdateRiskTypeAsync(Guid id, RiskTypeDto dto)
+        public async Task<ServiceResult> UpdateRiskTypeAsync(int id, RiskTypeDto dto)
         {
             try
             {
@@ -150,7 +149,7 @@ namespace AutomotiveClaimsApi.Services
             }
         }
 
-        public async Task<ServiceResult> DeleteRiskTypeAsync(Guid id)
+        public async Task<ServiceResult> DeleteRiskTypeAsync(int id)
         {
             try
             {

--- a/components/claim-form/damage-basic-info-section.tsx
+++ b/components/claim-form/damage-basic-info-section.tsx
@@ -87,7 +87,7 @@ export function DamageBasicInfoSection({
           onValueChange={(value) => handleFormChange("damageType", value)}
           placeholder="Wybierz rodzaj szkody..."
           apiUrl={`${API_BASE_URL}/damage-types`}
-          riskTypeId={claimFormData.riskType}
+          riskTypeId={claimFormData.riskType ? Number(claimFormData.riskType) : undefined}
           disabled={!claimFormData.riskType}
         />
       </div>

--- a/components/claim-form/damage-data-section.tsx
+++ b/components/claim-form/damage-data-section.tsx
@@ -204,7 +204,7 @@ export function DamageDataSection({
                 onValueChange={(value) => handleFormChange("damageType", value)}
                 placeholder="Wybierz rodzaj szkody..."
                 apiUrl={`${API_BASE_URL}/damage-types`}
-                riskTypeId={claimFormData.riskType}
+                riskTypeId={claimFormData.riskType ? Number(claimFormData.riskType) : undefined}
                 disabled={!claimFormData.riskType}
               />
             </div>

--- a/components/claim-form/property-damage-section.tsx
+++ b/components/claim-form/property-damage-section.tsx
@@ -220,7 +220,7 @@ export function PropertyDamageSection({
                 onValueChange={(value) => handleFormChange("damageType", value)}
                 placeholder="Wybierz rodzaj szkody..."
                 apiUrl={`${API_BASE_URL}/damage-types`}
-                riskTypeId={claimFormData.riskType}
+                riskTypeId={claimFormData.riskType ? Number(claimFormData.riskType) : undefined}
                 disabled={!claimFormData.riskType}
               />
             </div>

--- a/components/ui/dependent-select.tsx
+++ b/components/ui/dependent-select.tsx
@@ -25,7 +25,7 @@ interface DependentSelectProps {
   onValueChange?: (value: string) => void
   placeholder?: string
   apiUrl: string
-  riskTypeId?: string
+  riskTypeId?: number
   disabled?: boolean
   className?: string
 }
@@ -46,8 +46,8 @@ export function DependentSelect({
   const fetchOptions = async (): Promise<Option[]> => {
     let url = apiUrl
     const params = new URLSearchParams()
-    if (riskTypeId) {
-      params.set("riskTypeId", riskTypeId)
+    if (riskTypeId !== undefined) {
+      params.set("riskTypeId", String(riskTypeId))
     }
     if (debouncedSearch) {
       params.set("search", debouncedSearch)
@@ -87,7 +87,7 @@ export function DependentSelect({
   } = useQuery({
     queryKey: ["dependent-select", apiUrl, riskTypeId, debouncedSearch],
     queryFn: fetchOptions,
-    enabled: !!riskTypeId && (open || !!value),
+    enabled: riskTypeId !== undefined && (open || !!value),
   })
 
   useEffect(() => {
@@ -98,7 +98,7 @@ export function DependentSelect({
     <Select
       value={value}
       onValueChange={onValueChange}
-      disabled={disabled || !riskTypeId}
+      disabled={disabled || riskTypeId === undefined}
       open={open}
       onOpenChange={setOpen}
     >

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -289,7 +289,7 @@ export interface UpdateClientDto {
 }
 
 export interface RiskTypeDto {
-  id: string
+  id: number
   code: string
   name: string
   description?: string
@@ -301,7 +301,7 @@ export interface DamageTypeDto {
   code: string
   name: string
   description?: string
-  riskTypeId: string
+  riskTypeId: number
   riskTypeName?: string
   isActive: boolean
   createdAt: string
@@ -354,7 +354,7 @@ export interface CreateDamageTypeDto {
   code: string
   name: string
   description?: string
-  riskTypeId: string
+  riskTypeId: number
   isActive?: boolean
 }
 
@@ -1150,14 +1150,14 @@ class ApiService {
     })
   }
 
-  async updateRiskType(id: string, data: UpdateRiskTypeDto): Promise<void> {
+  async updateRiskType(id: number, data: UpdateRiskTypeDto): Promise<void> {
     await this.request<void>(`/RiskTypes/${id}`, {
       method: 'PUT',
       body: JSON.stringify(data),
     })
   }
 
-  async deleteRiskType(id: string): Promise<void> {
+  async deleteRiskType(id: number): Promise<void> {
     const token = this.getToken()
     const response = await fetch(`${API_BASE_URL}/RiskTypes/${id}`, {
       method: 'DELETE',
@@ -1176,7 +1176,7 @@ class ApiService {
   }
 
   // Damage Types API
-  async getDamageTypes(params: { riskTypeId?: string; isActive?: boolean } = {}): Promise<DamageTypeDto[]> {
+  async getDamageTypes(params: { riskTypeId?: number; isActive?: boolean } = {}): Promise<DamageTypeDto[]> {
     const searchParams = new URLSearchParams()
     Object.entries(params).forEach(([key, value]) => {
       if (value !== undefined) {

--- a/scripts/001_create_complete_database_schema.sql
+++ b/scripts/001_create_complete_database_schema.sql
@@ -37,7 +37,7 @@ CREATE TABLE dbo.Clients (
 
 -- Create RiskTypes table
 CREATE TABLE dbo.RiskTypes (
-    Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
+    Id INT IDENTITY(1,1) PRIMARY KEY,
     Code NVARCHAR(20) NOT NULL UNIQUE,
     Name NVARCHAR(200) NOT NULL,
     Description NVARCHAR(500),
@@ -52,7 +52,7 @@ CREATE TABLE dbo.DamageTypes (
     Code NVARCHAR(20) NOT NULL,
     Name NVARCHAR(200) NOT NULL,
     Description NVARCHAR(500),
-    RiskTypeId UNIQUEIDENTIFIER NOT NULL,
+    RiskTypeId INT NOT NULL,
     IsActive BIT NOT NULL DEFAULT 1,
     CreatedAt DATETIME2 NOT NULL DEFAULT GETUTCDATE(),
     UpdatedAt DATETIME2 NOT NULL DEFAULT GETUTCDATE(),
@@ -389,7 +389,7 @@ INSERT INTO dbo.RiskTypes (Id, Code, Name, Description) VALUES
 (NEWID(), 'NNWP', 'NNWP', 'Następstwa nieszczęśliwych wypadków przy pracy');
 
 -- Insert sample damage types
-DECLARE @RiskTypeId UNIQUEIDENTIFIER;
+DECLARE @RiskTypeId INT;
 
 -- OC DZIAŁALNOŚCI damage types
 SELECT @RiskTypeId = Id FROM dbo.RiskTypes WHERE Code = 'OC_DZIAL';

--- a/scripts/001_create_database_schema.sql
+++ b/scripts/001_create_database_schema.sql
@@ -37,7 +37,7 @@ CREATE TABLE dbo.Clients (
 
 -- Create RiskTypes table
 CREATE TABLE dbo.RiskTypes (
-    Id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
+    Id INT IDENTITY(1,1) PRIMARY KEY,
     Code NVARCHAR(20) NOT NULL,
     Name NVARCHAR(200) NOT NULL,
     Description NVARCHAR(500),
@@ -52,7 +52,7 @@ CREATE TABLE dbo.DamageTypes (
     Code NVARCHAR(20) NOT NULL,
     Name NVARCHAR(200) NOT NULL,
     Description NVARCHAR(500),
-    RiskTypeId UNIQUEIDENTIFIER NOT NULL,
+    RiskTypeId INT NOT NULL,
     IsActive BIT NOT NULL DEFAULT 1,
     CreatedAt DATETIME2 NOT NULL DEFAULT GETUTCDATE(),
     UpdatedAt DATETIME2 NOT NULL DEFAULT GETUTCDATE(),
@@ -76,7 +76,7 @@ CREATE TABLE dbo.Events (
     WitnessName NVARCHAR(100),
     WitnessPhone NVARCHAR(20),
     WitnessEmail NVARCHAR(100),
-    RiskTypeId UNIQUEIDENTIFIER,
+    RiskTypeId INT,
     DamageTypeId UNIQUEIDENTIFIER,
     Status NVARCHAR(50) DEFAULT 'Open',
     Priority NVARCHAR(20) DEFAULT 'Medium',

--- a/scripts/003_seed_risk_and_damage_types.sql
+++ b/scripts/003_seed_risk_and_damage_types.sql
@@ -6,20 +6,20 @@ DELETE FROM dbo.DamageTypes;
 DELETE FROM dbo.RiskTypes;
 
 -- Insert Risk Types
-INSERT INTO dbo.RiskTypes (Id, Code, Name, Description, IsActive) VALUES
-(NEWID(), 'OC_DZIAL', 'OC DZIAŁALNOŚCI', 'Odpowiedzialność cywilna z tytułu prowadzenia działalności gospodarczej', 1),
-(NEWID(), 'OC_SPRAWCY', 'OC SPRAWCY', 'Odpowiedzialność cywilna sprawcy szkody', 1),
-(NEWID(), 'MAJATKOWE', 'MAJĄTKOWE', 'Ubezpieczenie majątkowe', 1),
-(NEWID(), 'KOMUNIKACYJNE', 'KOMUNIKACYJNE', 'Ubezpieczenie komunikacyjne', 1),
-(NEWID(), 'BUDOWLANE', 'BUDOWLANE', 'Ubezpieczenie budowlane', 1),
-(NEWID(), 'CARGO', 'CARGO', 'Ubezpieczenie ładunku', 1),
-(NEWID(), 'CASCO', 'CASCO', 'Ubezpieczenie autocasco', 1),
-(NEWID(), 'NNWP', 'NNWP', 'Następstwa nieszczęśliwych wypadków przy pracy', 1),
-(NEWID(), 'CYBER', 'CYBER', 'Ubezpieczenie cyber ryzyk', 1),
-(NEWID(), 'D_O', 'D&O', 'Ubezpieczenie odpowiedzialności cywilnej członków organów zarządzających', 1);
+INSERT INTO dbo.RiskTypes (Code, Name, Description, IsActive) VALUES
+('OC_DZIAL', 'OC DZIAŁALNOŚCI', 'Odpowiedzialność cywilna z tytułu prowadzenia działalności gospodarczej', 1),
+('OC_SPRAWCY', 'OC SPRAWCY', 'Odpowiedzialność cywilna sprawcy szkody', 1),
+('MAJATKOWE', 'MAJĄTKOWE', 'Ubezpieczenie majątkowe', 1),
+('KOMUNIKACYJNE', 'KOMUNIKACYJNE', 'Ubezpieczenie komunikacyjne', 1),
+('BUDOWLANE', 'BUDOWLANE', 'Ubezpieczenie budowlane', 1),
+('CARGO', 'CARGO', 'Ubezpieczenie ładunku', 1),
+('CASCO', 'CASCO', 'Ubezpieczenie autocasco', 1),
+('NNWP', 'NNWP', 'Następstwa nieszczęśliwych wypadków przy pracy', 1),
+('CYBER', 'CYBER', 'Ubezpieczenie cyber ryzyk', 1),
+('D_O', 'D&O', 'Ubezpieczenie odpowiedzialności cywilnej członków organów zarządzających', 1);
 
 -- Insert Damage Types for each Risk Type
-DECLARE @RiskTypeId UNIQUEIDENTIFIER;
+DECLARE @RiskTypeId INT;
 
 -- OC DZIAŁALNOŚCI damage types
 SELECT @RiskTypeId = Id FROM dbo.RiskTypes WHERE Code = 'OC_DZIAL';


### PR DESCRIPTION
## Summary
- change RiskType Id type from Guid to int across backend models, DTOs, services, and controllers
- adjust frontend API types and pages to use numeric RiskType ids
- update SQL schema and seed scripts for integer RiskType ids

## Testing
- `dotnet build backend` *(fails: command not found)*
- `pnpm install`
- `pnpm test` *(fails: Cannot require() ES Module in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8cb61b80832cbe7f45c88450c53e