### PR TITLE
Fix ServicesCalled array deserialization

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -1018,7 +1018,7 @@ namespace AutomotiveClaimsApi.Controllers
             entity.WereInjured = dto.WereInjured;
             entity.StatementWithPerpetrator = dto.StatementWithPerpetrator;
             entity.PerpetratorFined = dto.PerpetratorFined;
-            entity.ServicesCalled = dto.ServicesCalled;
+            entity.ServicesCalled = dto.ServicesCalled != null ? string.Join(",", dto.ServicesCalled) : null;
             entity.PoliceUnitDetails = dto.PoliceUnitDetails;
             entity.PropertyDamageSubject = dto.PropertyDamageSubject;
             entity.DamageListing = dto.DamageListing;
@@ -1040,7 +1040,7 @@ namespace AutomotiveClaimsApi.Controllers
             entity.ComplaintResponse = dto.ComplaintResponse;
             entity.ComplaintResponseDate = dto.ComplaintResponseDate;
             entity.CargoDescription = dto.CargoDescription;
-            entity.Losses = dto.Losses;
+            entity.Losses = dto.Losses != null ? string.Join(",", dto.Losses) : null;
             entity.Carrier = dto.Carrier;
             entity.CarrierPolicyNumber = dto.CarrierPolicyNumber;
             entity.InspectionContactName = dto.InspectionContactName;

--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -128,8 +128,8 @@ namespace AutomotiveClaimsApi.DTOs
 
         public bool? PerpetratorFined { get; set; }
 
-        [StringLength(500)]
-        public string? ServicesCalled { get; set; }
+        [MaxLength(500)]
+        public string[]? ServicesCalled { get; set; }
 
         [StringLength(500)]
         public string? PoliceUnitDetails { get; set; }
@@ -188,8 +188,8 @@ namespace AutomotiveClaimsApi.DTOs
         [StringLength(2000)]
         public string? CargoDescription { get; set; }
 
-        [StringLength(500)]
-        public string? Losses { get; set; }
+        [MaxLength(500)]
+        public string[]? Losses { get; set; }
 
         [StringLength(200)]
         public string? Carrier { get; set; }


### PR DESCRIPTION
## Summary
- Accept lists for ServicesCalled and Losses on claim updates
- Normalize these lists to comma separated strings when persisting

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9ba8e124832cbaa0812f855f2374