### PR TITLE
Handle /api root requests with health check endpoint

### DIFF
--- a/backend/AutomotiveClaimsApi.Tests/AutomotiveClaimsApi.Tests.csproj
+++ b/backend/AutomotiveClaimsApi.Tests/AutomotiveClaimsApi.Tests.csproj
@@ -13,5 +13,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/backend/AutomotiveClaimsApi.Tests/RootEndpointTests.cs
+++ b/backend/AutomotiveClaimsApi.Tests/RootEndpointTests.cs
@@ -1,0 +1,24 @@
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace AutomotiveClaimsApi.Tests;
+
+public class RootEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public RootEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetApiRoot_ReturnsOk()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -119,6 +119,7 @@ app.UseCors("Frontend");
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
+app.MapGet("/api", () => Results.Ok(new { status = "Automotive Claims API is running" }));
 
 // Ensure database is created and seed default roles/users
 using (var scope = app.Services.CreateScope())
@@ -149,3 +150,5 @@ using (var scope = app.Services.CreateScope())
 }
 
 app.Run();
+
+public partial class Program { }


### PR DESCRIPTION
## Summary
- add GET /api endpoint returning a simple status message
- expose Program for tests and verify health endpoint returns OK
- include integration test package to enable WebApplicationFactory

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9ce36c18832c92f9a9bb3369ea09