### PR TITLE
feat: add object type selection for risk types

### DIFF
--- a/app/settings/risk-types/page.tsx
+++ b/app/settings/risk-types/page.tsx
@@ -49,8 +49,15 @@ export default function RiskTypesPage() {
     code: "",
     name: "",
     description: "",
+    claimObjectTypeId: 1,
     isActive: true,
   })
+
+  const objectTypes = [
+    { id: 1, name: "Szkoda komunikacyjna" },
+    { id: 2, name: "Szkoda mienia" },
+    { id: 3, name: "Szkoda transportowa" },
+  ]
 
   const loadRiskTypes = async () => {
     const data = await apiService.getRiskTypes()
@@ -64,8 +71,12 @@ export default function RiskTypesPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError("")
-    if (!formData.code.trim() || !formData.name.trim()) {
-      setError("Kod i nazwa są wymagane")
+    if (
+      !formData.code.trim() ||
+      !formData.name.trim() ||
+      !formData.claimObjectTypeId
+    ) {
+      setError("Kod, nazwa i rodzaj szkody są wymagane")
       return
     }
     try {
@@ -74,7 +85,13 @@ export default function RiskTypesPage() {
       } else {
         await apiService.createRiskType(formData)
       }
-      setFormData({ code: "", name: "", description: "", isActive: true })
+      setFormData({
+        code: "",
+        name: "",
+        description: "",
+        claimObjectTypeId: 1,
+        isActive: true,
+      })
       setEditingId(null)
       loadRiskTypes()
     } catch (err: any) {
@@ -87,6 +104,7 @@ export default function RiskTypesPage() {
       code: rt.code,
       name: rt.name,
       description: rt.description ?? "",
+      claimObjectTypeId: rt.claimObjectTypeId ?? 1,
       isActive: rt.isActive,
     })
     setEditingId(rt.id)
@@ -171,6 +189,29 @@ export default function RiskTypesPage() {
             }
           />
         </div>
+        <div>
+          <Label htmlFor="claimObjectTypeId">Rodzaj szkody</Label>
+          <Select
+            value={formData.claimObjectTypeId?.toString()}
+            onValueChange={(v) =>
+              setFormData({
+                ...formData,
+                claimObjectTypeId: parseInt(v, 10),
+              })
+            }
+          >
+            <SelectTrigger id="claimObjectTypeId">
+              <SelectValue placeholder="Wybierz rodzaj szkody" />
+            </SelectTrigger>
+            <SelectContent>
+              {objectTypes.map((ot) => (
+                <SelectItem key={ot.id} value={ot.id.toString()}>
+                  {ot.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
         <div className="flex items-center space-x-2">
           <Checkbox
             id="isActive"
@@ -193,6 +234,7 @@ export default function RiskTypesPage() {
                   code: "",
                   name: "",
                   description: "",
+                  claimObjectTypeId: 1,
                   isActive: true,
                 })
               }}
@@ -246,6 +288,7 @@ export default function RiskTypesPage() {
             >
               Nazwa <ArrowUpDown className="inline h-4 w-4 ml-2" />
             </TableHead>
+            <TableHead>Rodzaj szkody</TableHead>
             <TableHead>Opis</TableHead>
             <TableHead>Status</TableHead>
             <TableHead>Akcje</TableHead>
@@ -256,6 +299,10 @@ export default function RiskTypesPage() {
             <TableRow key={rt.id}>
               <TableCell>{rt.code}</TableCell>
               <TableCell>{rt.name}</TableCell>
+              <TableCell>
+                {objectTypes.find((o) => o.id === rt.claimObjectTypeId)?.name ||
+                  "-"}
+              </TableCell>
               <TableCell>{rt.description}</TableCell>
               <TableCell>{rt.isActive ? "Aktywny" : "Nieaktywny"}</TableCell>
               <TableCell className="space-x-2">

--- a/backend/DTOs/RiskTypeDto.cs
+++ b/backend/DTOs/RiskTypeDto.cs
@@ -17,6 +17,8 @@ namespace AutomotiveClaimsApi.DTOs
         [MaxLength(500)]
         public string? Description { get; set; }
 
+        public int? ClaimObjectTypeId { get; set; }
+
         public bool IsActive { get; set; }
 
 

--- a/backend/Services/RiskTypeService.cs
+++ b/backend/Services/RiskTypeService.cs
@@ -32,6 +32,7 @@ namespace AutomotiveClaimsApi.Services
                         Code = rt.Code,
                         Name = rt.Name,
                         Description = rt.Description,
+                        ClaimObjectTypeId = rt.ClaimObjectTypeId,
                         IsActive = rt.IsActive,
                         CreatedAt = rt.CreatedAt,
                         UpdatedAt = rt.UpdatedAt
@@ -65,6 +66,7 @@ namespace AutomotiveClaimsApi.Services
                     Code = riskType.Code,
                     Name = riskType.Name,
                     Description = riskType.Description,
+                    ClaimObjectTypeId = riskType.ClaimObjectTypeId,
                     IsActive = riskType.IsActive,
                     CreatedAt = riskType.CreatedAt,
                     UpdatedAt = riskType.UpdatedAt
@@ -92,6 +94,7 @@ namespace AutomotiveClaimsApi.Services
                     Code = dto.Code,
                     Name = dto.Name,
                     Description = dto.Description,
+                    ClaimObjectTypeId = dto.ClaimObjectTypeId,
                     IsActive = dto.IsActive,
                     CreatedAt = DateTime.UtcNow,
                     UpdatedAt = DateTime.UtcNow
@@ -106,6 +109,7 @@ namespace AutomotiveClaimsApi.Services
                     Code = riskType.Code,
                     Name = riskType.Name,
                     Description = riskType.Description,
+                    ClaimObjectTypeId = riskType.ClaimObjectTypeId,
                     IsActive = riskType.IsActive,
                     CreatedAt = riskType.CreatedAt,
                     UpdatedAt = riskType.UpdatedAt
@@ -137,6 +141,7 @@ namespace AutomotiveClaimsApi.Services
                 riskType.Code = dto.Code;
                 riskType.Name = dto.Name;
                 riskType.Description = dto.Description;
+                riskType.ClaimObjectTypeId = dto.ClaimObjectTypeId;
                 riskType.IsActive = dto.IsActive;
                 riskType.UpdatedAt = DateTime.UtcNow;
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -293,6 +293,7 @@ export interface RiskTypeDto {
   code: string
   name: string
   description?: string
+  claimObjectTypeId?: number
   isActive: boolean
 }
 
@@ -340,6 +341,7 @@ export interface CreateRiskTypeDto {
   code: string
   name: string
   description?: string
+  claimObjectTypeId?: number
   isActive?: boolean
 }
 
@@ -347,6 +349,7 @@ export interface UpdateRiskTypeDto {
   code?: string
   name?: string
   description?: string
+  claimObjectTypeId?: number
   isActive?: boolean
 }
 


### PR DESCRIPTION
## Summary
- add claim object type to risk type DTOs and service layer
- support object type selection when creating or editing risk types
- expose claim object type id in client API types

## Testing
- `pnpm test` (fails: test failed)
- `pnpm lint` (fails: command failed with exit code 1)

------
https://chatgpt.com/codex/tasks/task_e_68ab9d45be70832ca0b1a9e94a224997