### PR TITLE
Load claim emails by event

### DIFF
--- a/app/api/emails/event/[eventId]/route.ts
+++ b/app/api/emails/event/[eventId]/route.ts
@@ -1,0 +1,36 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api"
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { eventId: string } },
+) {
+  try {
+    const cookie = request.headers.get("cookie") ?? ""
+    const response = await fetch(`${API_BASE_URL}/emails/event/${params.eventId}`, {
+      cache: "no-store",
+      credentials: "include",
+      headers: { Cookie: cookie },
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      return NextResponse.json({ error: errorText }, { status: response.status })
+    }
+
+    const emails = await response.json()
+    return NextResponse.json(emails)
+  } catch (error) {
+    console.error("Error fetching emails by event:", error)
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to fetch emails by event",
+      },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add API route to fetch emails for a specific event
- load emails for claim folders by event ID instead of fetching all
- compute folder counts from event-scoped emails

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)*

------
https://chatgpt.com/codex/tasks/task_e_68aba07f920c832c8c7f5819580e5f4b