### PR TITLE
fix: avoid HEAD method in health check

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -855,7 +855,7 @@ class ApiService {
 
   async checkHealth(): Promise<void> {
     try {
-      await fetch(API_BASE_URL, { method: "HEAD" })
+      await fetch(API_BASE_URL, { method: "GET" })
     } catch {
       throw new Error("API unavailable")
     }


### PR DESCRIPTION
## Summary
- replace HEAD request with GET in `checkHealth` to prevent 405 errors

## Testing
- ⚠️ `pnpm lint` *(fails: How would you like to configure ESLint?)*
- ❌ `pnpm test` *(fails: tests 1, fail 1)*

------
https://chatgpt.com/codex/tasks/task_e_68aba2b26044832caee4a0acab30b67b