### PR TITLE
feat: apply global API base URL

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import { ProtectedRoute } from '@/components/protected-route'
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { FileText, Clock, TrendingUp, Users, Search, Filter, CheckSquare } from 'lucide-react';
+import { API_BASE_URL } from "@/lib/api";
 
 interface User {
   username: string
@@ -40,7 +41,7 @@ function HomePage({ user, onLogout }: PageProps) {
   useEffect(() => {
     async function loadTasks() {
       try {
-        const res = await fetch("/api/notes?category=task")
+        const res = await fetch(`${API_BASE_URL}/notes?category=task`)
         if (!res.ok) {
           console.warn(
             "Failed to fetch tasks:",
@@ -74,7 +75,7 @@ function HomePage({ user, onLogout }: PageProps) {
   useEffect(() => {
     async function loadStats() {
       try {
-        const res = await fetch("/api/dashboard/user");
+        const res = await fetch(`${API_BASE_URL}/dashboard/user`);
         if (!res.ok) throw new Error("Failed to fetch dashboard stats");
         const data = await res.json();
         setStats([

--- a/app/vacations/manage/page.tsx
+++ b/app/vacations/manage/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { API_BASE_URL } from "@/lib/api";
 
 interface VacationRequest {
   id: string;
@@ -16,13 +17,13 @@ export default function VacationManagePage() {
   const [requests, setRequests] = useState<VacationRequest[]>([]);
 
   useEffect(() => {
-    fetch("/api/vacations/pending")
+    fetch(`${API_BASE_URL}/vacations/pending`)
       .then((r) => r.json())
       .then((data) => setRequests(data));
   }, []);
 
   const act = async (id: string, action: "approve" | "reject") => {
-    await fetch(`/api/vacations/${id}/${action}`, { method: "PUT" });
+    await fetch(`${API_BASE_URL}/vacations/${id}/${action}`, { method: "PUT" });
     setRequests((r) => r.filter((x) => x.id !== id));
   };
 

--- a/app/vacations/page.tsx
+++ b/app/vacations/page.tsx
@@ -6,6 +6,7 @@ import HandlerDropdown from "@/components/handler-dropdown";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { HandlerSelectionEvent } from "@/types/handler";
+import { API_BASE_URL } from "@/lib/api";
 
 export default function VacationPage() {
   const { user } = useAuth();
@@ -17,7 +18,7 @@ export default function VacationPage() {
   const [managers, setManagers] = useState<{ id: string; name: string }[]>([]);
 
   const submit = async () => {
-    await fetch("/api/vacations", {
+    await fetch(`${API_BASE_URL}/vacations`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/components/email/email-section.tsx
+++ b/components/email/email-section.tsx
@@ -9,6 +9,7 @@ import { EmailComposeComponent } from "./email-compose"
 import { emailFolders, sampleEmails } from "@/lib/email-data"
 import type { Email, EmailCompose, EmailAttachment } from "@/types/email"
 import type { UploadedFile, RequiredDocument } from "@/types"
+import { API_BASE_URL } from "@/lib/api"
 
 interface EmailSectionProps {
   claimId?: string
@@ -137,7 +138,7 @@ export const EmailSection = ({
   const handleAssignAttachment = (attachment: EmailAttachment, documentId: string) => {
     const doc = reqDocuments.find((d) => d.id === documentId)
 
-    const url = attachment.url || `/api/emails/attachment/${attachment.id}`
+    const url = attachment.url || `${API_BASE_URL}/emails/attachment/${attachment.id}`
     const type = attachment.type || (attachment as any).contentType || ""
 
     const newFile: UploadedFile = {

--- a/components/email/email-view.tsx
+++ b/components/email/email-view.tsx
@@ -25,6 +25,7 @@ import {
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import type { Email } from "@/types/email"
 import type { RequiredDocument } from "@/types"
+import { API_BASE_URL } from "@/lib/api"
 
 interface EmailViewProps {
   email: Email
@@ -233,7 +234,7 @@ export const EmailView = ({
                             className="h-8 w-8 p-0"
                           >
                             <a
-                              href={attachment.url || `/api/emails/attachment/${attachment.id}`}
+                              href={attachment.url || `${API_BASE_URL}/emails/attachment/${attachment.id}`}
                               target="_blank"
                               rel="noopener noreferrer"
                             >
@@ -247,7 +248,7 @@ export const EmailView = ({
                             className="h-8 w-8 p-0"
                           >
                             <a
-                              href={attachment.url || `/api/emails/attachment/${attachment.id}`}
+                              href={attachment.url || `${API_BASE_URL}/emails/attachment/${attachment.id}`}
                               download
                             >
                               <Download className="h-4 w-4" />
@@ -275,7 +276,7 @@ export const EmailView = ({
                                             ...attachment,
                                             url:
                                               attachment.url ||
-                                              `/api/emails/attachment/${attachment.id}`,
+                                              `${API_BASE_URL}/emails/attachment/${attachment.id}`,
                                           },
                                           doc.id,
                                         )

--- a/components/email/unassigned-list.tsx
+++ b/components/email/unassigned-list.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { SearchableSelect } from "@/components/ui/searchable-select"
 import { emailService, type EmailDto } from "@/lib/email-service"
+import { API_BASE_URL } from "@/lib/api"
 
 export function UnassignedEmailList() {
   const [emails, setEmails] = useState<EmailDto[]>([])
@@ -85,7 +86,7 @@ export function UnassignedEmailList() {
           </DialogHeader>
 
           <SearchableSelect
-            apiEndpoint="/api/claims/options"
+            apiEndpoint={`${API_BASE_URL}/claims/options`}
             value={selectedClaim}
             onValueChange={setSelectedClaim}
             placeholder="Wybierz szkodę"

--- a/components/user-form.tsx
+++ b/components/user-form.tsx
@@ -11,6 +11,7 @@ import { Switch } from '@/components/ui/switch'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Badge } from '@/components/ui/badge'
 import { FormHeader } from '@/components/ui/form-header'
+import { API_BASE_URL } from '@/lib/api'
 import { User } from 'lucide-react'
 
 interface UserFormProps {
@@ -169,7 +170,7 @@ export default function UserForm({ userId }: UserFormProps) {
       <div>
         <Label htmlFor="roles">Role</Label>
         <SearchableSelect
-          apiEndpoint="/api/roles"
+          apiEndpoint={`${API_BASE_URL}/roles`}
           value={roleValue}
           onValueChange={handleRoleSelect}
           placeholder="Wybierz rolę..."

--- a/hooks/use-casehandlers.ts
+++ b/hooks/use-casehandlers.ts
@@ -3,6 +3,7 @@
 
 import useSWR from 'swr'
 import type { DictionaryResponseDto } from '@/lib/dictionary-service'
+import { getJson } from '@/lib/api'
 
 interface Handler {
   id: string
@@ -11,21 +12,8 @@ interface Handler {
   isActive: boolean
 }
 
-async function getJson<T>(url: string): Promise<T> {
-  const response = await fetch(url)
-  const text = await response.text()
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ${url}: ${response.status} ${text}`)
-  }
-  try {
-    return JSON.parse(text) as T
-  } catch {
-    throw new Error(`Invalid JSON from ${url}: ${text}`)
-  }
-}
-
 async function fetchCaseHandlers(): Promise<Handler[]> {
-  const data = await getJson<DictionaryResponseDto>('/api/dictionaries/casehandlers')
+  const data = await getJson<DictionaryResponseDto>('/dictionaries/casehandlers')
   return data.items.map(({ id, name, code, isActive }) => ({
     id,
     name,

--- a/lib/email-service.ts
+++ b/lib/email-service.ts
@@ -82,7 +82,7 @@ class EmailService {
             fileName: a.fileName,
             contentType: a.contentType,
             size: a.fileSize,
-            url: `/api/emails/attachment/${a.id}`,
+            url: `${API_BASE_URL}/emails/attachment/${a.id}`,
           })) || [],
       }))
     } catch (error) {
@@ -118,7 +118,7 @@ class EmailService {
             fileName: a.fileName,
             contentType: a.contentType,
             size: a.fileSize,
-            url: `/api/emails/attachment/${a.id}`,
+            url: `${API_BASE_URL}/emails/attachment/${a.id}`,
           })) || [],
       }
     } catch (error) {
@@ -208,7 +208,7 @@ class EmailService {
             fileName: a.fileName,
             contentType: a.contentType,
             size: a.fileSize,
-            url: `/api/emails/attachment/${a.id}`,
+            url: `${API_BASE_URL}/emails/attachment/${a.id}`,
           })) || [],
       }))
     } catch (error) {

--- a/lib/services/admin-service.ts
+++ b/lib/services/admin-service.ts
@@ -1,4 +1,4 @@
-import { apiService, type UserListItemDto } from "../api";
+import { apiService, API_BASE_URL, type UserListItemDto } from "../api";
 import type { Role, User, UserFilters, Permission } from "../types/admin";
 
 // Predefined role colors for display
@@ -9,7 +9,7 @@ const ROLE_COLORS: Record<string, string> = {
 
 export const adminService = {
   async getRoles(): Promise<Role[]> {
-    const res = await fetch("/api/roles");
+    const res = await fetch(`${API_BASE_URL}/roles`);
     const data = (await res.json()) as { value: string; label: string }[];
     return data.map((r) => ({
       id: r.value,


### PR DESCRIPTION
## Summary
- use `API_BASE_URL` for dashboard and task fetches
- update user, vacation, and email modules to use API_BASE_URL
- centralize case handler dictionary fetch with API base

## Testing
- `pnpm lint` *(fails: next lint prompted for config)*
- `pnpm test` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_68aba169bfd8832ca7420149e6a3fc2d