### PR TITLE
Fix EF Core translation error in EmailService

### DIFF
--- a/backend/Services/EmailService.cs
+++ b/backend/Services/EmailService.cs
@@ -142,11 +142,11 @@ namespace AutomotiveClaimsApi.Services
             var emails = await _context.Emails
                 .Where(e => e.EventId == eventId)
                 .Include(e => e.EmailClaims)
-                .Select(e => MapEmailToDto(e))
+                .Include(e => e.Attachments)
                 .OrderByDescending(e => e.CreatedAt)
                 .ToListAsync();
 
-            return emails;
+            return emails.Select(MapEmailToDto);
         }
 
         public async Task<EmailDto?> GetEmailByIdAsync(Guid id)
@@ -154,10 +154,10 @@ namespace AutomotiveClaimsApi.Services
             var email = await _context.Emails
                 .Where(e => e.Id == id)
                 .Include(e => e.EmailClaims)
-                .Select(e => MapEmailToDto(e))
+                .Include(e => e.Attachments)
                 .FirstOrDefaultAsync();
 
-            return email;
+            return email != null ? MapEmailToDto(email) : null;
         }
         
         private static EmailDto MapEmailToDto(Email email) =>


### PR DESCRIPTION
## Summary
- defer Email DTO mapping until after EF Core queries materialize results to avoid translation errors
- load attachments for email queries and order by creation date before mapping

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abac117a44832c8449c0826314f0eb