### PR TITLE
Add Microsoft.Extensions.Hosting reference

### DIFF
--- a/emailservice/EmailService.csproj
+++ b/emailservice/EmailService.csproj
@@ -13,5 +13,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- include Microsoft.Extensions.Hosting package to allow using Host builder in EmailService

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68abb19a30d8832caa1d2fe126a806f4