### PR TITLE
Schedule email service to process messages every minute

### DIFF
--- a/emailservice/EmailBackgroundService.cs
+++ b/emailservice/EmailBackgroundService.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace EmailService;
+
+public class EmailBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<EmailBackgroundService> _logger;
+
+    public EmailBackgroundService(
+        IServiceProvider serviceProvider,
+        ILogger<EmailBackgroundService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var scope = _serviceProvider.CreateScope();
+                var client = scope.ServiceProvider.GetRequiredService<EmailClient>();
+
+                var fetched = await client.FetchUnreadEmailsAsync();
+                _logger.LogInformation("Fetched {Count} unread emails.", fetched.Count);
+
+                var sent = await client.SendPendingEmailsAsync();
+                _logger.LogInformation("Sent {Count} pending emails.", sent);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error processing emails");
+            }
+
+            await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+        }
+    }
+}
+

--- a/emailservice/Program.cs
+++ b/emailservice/Program.cs
@@ -5,6 +5,7 @@ using Google.Cloud.Storage.V1;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 var builder = Host.CreateApplicationBuilder(args);
 
@@ -31,12 +32,9 @@ builder.Services.AddTransient<EmailClient>(sp =>
     );
 });
 
+builder.Services.AddHostedService<EmailBackgroundService>();
+
 using var host = builder.Build();
 
-var client = host.Services.GetRequiredService<EmailClient>();
-var fetched = await client.FetchUnreadEmailsAsync();
-Console.WriteLine($"Fetched {fetched.Count} unread emails.");
-
-var sent = await client.SendPendingEmailsAsync();
-Console.WriteLine($"Sent {sent} pending emails.");
+await host.RunAsync();
 


### PR DESCRIPTION
## Summary
- run email worker as hosted service and start host
- add background service to fetch and send emails every minute

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abb283245c832c96a00adf6b6ae0c9