### PR TITLE
Handle missing IMAP host in email client

### DIFF
--- a/emailservice/EmailClient.cs
+++ b/emailservice/EmailClient.cs
@@ -78,6 +78,9 @@ public class EmailClient
     public async Task<IList<Email>> FetchUnreadEmailsAsync()
 
     {
+        if (string.IsNullOrWhiteSpace(_imapHost) || _imapPort <= 0)
+            return new List<Email>();
+
         using var client = new ImapClient();
         await client.ConnectAsync(_imapHost, _imapPort, SecureSocketOptions.SslOnConnect);
         await client.AuthenticateAsync(_username, _password);

--- a/emailservice/Program.cs
+++ b/emailservice/Program.cs
@@ -21,12 +21,12 @@ builder.Services.AddTransient<EmailClient>(sp =>
 {
     var cfg = builder.Configuration.GetSection("Email");
     return new EmailClient(
-        smtpHost: cfg["SmtpHost"]!,
-        smtpPort: cfg.GetValue<int>("SmtpPort"),
-        imapHost: cfg["ImapHost"]!,
-        imapPort: cfg.GetValue<int>("ImapPort"),
-        username: cfg["Username"]!,
-        password: cfg["Password"]!,
+        smtpHost: cfg["SmtpHost"] ?? string.Empty,
+        smtpPort: cfg.GetValue<int?>("SmtpPort") ?? 0,
+        imapHost: cfg["ImapHost"] ?? string.Empty,
+        imapPort: cfg.GetValue<int?>("ImapPort") ?? 0,
+        username: cfg["Username"] ?? string.Empty,
+        password: cfg["Password"] ?? string.Empty,
         db: sp.GetRequiredService<EmailDbContext>(),
         storage: sp.GetRequiredService<IAttachmentStorage>()
     );


### PR DESCRIPTION
## Summary
- avoid connecting to IMAP when host or port configuration is missing
- default email configuration values to empty/zero to prevent null issues during service registration

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68abb8b05cbc832ca228511c75796fa9