### PR TITLE
Allow all CORS

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -21,6 +21,15 @@ builder.Services.AddControllersWithViews(options =>
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+// Configure CORS to allow any origin
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowAll", policy =>
+        policy.AllowAnyOrigin()
+              .AllowAnyHeader()
+              .AllowAnyMethod());
+});
+
 // Add Entity Framework with database provider selected from configuration
 var dbProvider = builder.Configuration.GetValue<string>("DatabaseProvider")?.ToLowerInvariant();
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
@@ -103,6 +112,7 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+app.UseCors("AllowAll");
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();


### PR DESCRIPTION
## Summary
- allow any origin, method, and header via AllowAll CORS policy
- apply AllowAll CORS policy in HTTP pipeline

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `dotnet test backend` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2bc4782c832ca0abd8e6b5afbd2b