### PR TITLE
Use Authorization header instead of cookies for JWT

### DIFF
--- a/app/api/appeals/[id]/documents/[docId]/preview/route.ts
+++ b/app/api/appeals/[id]/documents/[docId]/preview/route.ts
@@ -12,7 +12,7 @@ export async function GET(
       {
         method: "GET",
         headers: {
-          cookie: request.headers.get("cookie") || "",
+          authorization: request.headers.get("authorization") || "",
         },
       },
     )

--- a/app/api/appeals/[id]/preview/route.ts
+++ b/app/api/appeals/[id]/preview/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
       const response = await fetch(`${API_BASE_URL}/appeals/${id}/preview`, {
         method: "GET",
         headers: {
-          cookie: request.headers.get("cookie") || "",
+          authorization: request.headers.get("authorization") || "",
         },
       })
 

--- a/app/api/claims/[claimId]/decisions/[decisionId]/preview/route.ts
+++ b/app/api/claims/[claimId]/decisions/[decisionId]/preview/route.ts
@@ -20,7 +20,7 @@ export async function GET(
       `${API_BASE_URL}/claims/${claimId}/decisions/${decisionId}/preview`,
       {
         headers: {
-          cookie: request.headers.get("cookie") ?? "",
+          authorization: request.headers.get("authorization") ?? "",
         },
       },
     )

--- a/app/api/claims/[claimId]/route.ts
+++ b/app/api/claims/[claimId]/route.ts
@@ -13,9 +13,12 @@ export async function GET(
     const { claimId } = params
     console.log(`Fetching claim ${claimId} from backend`)
 
+    const auth = request.headers.get("authorization") ?? ""
+
     const response = await fetch(`${API_BASE_URL}/claims/${claimId}`, {
       headers: {
         "Content-Type": "application/json",
+        ...(auth ? { Authorization: auth } : {}),
       },
       cache: "no-store",
     })
@@ -49,10 +52,13 @@ export async function PUT(
     const body = await request.json()
     console.log(`Updating claim ${claimId}:`, body)
 
+    const auth = request.headers.get("authorization") ?? ""
+
     const response = await fetch(`${API_BASE_URL}/claims/${claimId}`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
+        ...(auth ? { Authorization: auth } : {}),
       },
       body: JSON.stringify(body),
     })
@@ -82,14 +88,14 @@ export async function DELETE(
   { params }: { params: { claimId: string } },
 ) {
   try {
-    const token = request.cookies.get("token")?.value
-    if (!token) {
+    const auth = request.headers.get("authorization")
+    if (!auth) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 
     const userResp = await fetch(`${API_BASE_URL}/auth/me`, {
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: auth,
       },
     })
 
@@ -111,7 +117,7 @@ export async function DELETE(
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
+        Authorization: auth,
       },
     })
 

--- a/app/api/claims/route.ts
+++ b/app/api/claims/route.ts
@@ -10,16 +10,13 @@ export async function GET(request: NextRequest) {
 
     console.log(`Fetching claims from backend: ${url}`)
 
-    // Retrieve auth token from cookies (adjust cookie name as needed)
-    const token = request.cookies.get("token")?.value
+    const auth = request.headers.get("authorization") ?? ""
 
     const response = await fetch(url, {
       headers: {
         "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...(auth ? { Authorization: auth } : {}),
       },
-      // Include cookies for session-based authentication
-      credentials: "include",
       cache: "no-store",
     })
 

--- a/app/api/dashboard/client/route.ts
+++ b/app/api/dashboard/client/route.ts
@@ -4,15 +4,14 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 
 export async function GET(request: NextRequest) {
   try {
-    const token = request.cookies.get("token")?.value;
+    const auth = request.headers.get("authorization") ?? "";
     const url = `${API_BASE_URL}/dashboard/client`;
 
     const response = await fetch(url, {
       headers: {
         "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...(auth ? { Authorization: auth } : {}),
       },
-      credentials: "include",
       cache: "no-store",
     });
 

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -4,15 +4,14 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 
 export async function GET(request: NextRequest) {
   try {
-    const token = request.cookies.get("token")?.value;
+    const auth = request.headers.get("authorization") ?? "";
     const url = `${API_BASE_URL}/dashboard/user`;
 
     const response = await fetch(url, {
       headers: {
         "Content-Type": "application/json",
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...(auth ? { Authorization: auth } : {}),
       },
-      credentials: "include",
       cache: "no-store",
     });
 

--- a/app/api/decisions/[id]/download/route.ts
+++ b/app/api/decisions/[id]/download/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
       `${API_BASE_URL}/claims/${claimId}/decisions/${id}/download`,
       {
         headers: {
-          cookie: request.headers.get("cookie") ?? "",
+          authorization: request.headers.get("authorization") ?? "",
         },
       },
     )

--- a/app/api/emails/[id]/read/route.ts
+++ b/app/api/emails/[id]/read/route.ts
@@ -8,12 +8,11 @@ export async function POST(
 ) {
   try {
     const emailId = params.id
-    const cookie = request.headers.get("cookie") ?? ""
+    const auth = request.headers.get("authorization") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails/${emailId}/read`, {
       method: "POST",
-      credentials: "include",
-      headers: { Cookie: cookie },
+      headers: { Authorization: auth },
     })
 
     if (!response.ok) {

--- a/app/api/emails/[id]/route.ts
+++ b/app/api/emails/[id]/route.ts
@@ -8,12 +8,11 @@ export async function GET(
 ) {
   try {
     const emailId = params.id
-    const cookie = request.headers.get("cookie") ?? ""
+    const auth = request.headers.get("authorization") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails/${emailId}`, {
       cache: "no-store",
-      credentials: "include",
-      headers: { Cookie: cookie },
+      headers: { Authorization: auth },
     })
 
     if (!response.ok) {
@@ -38,12 +37,11 @@ export async function DELETE(
 ) {
   try {
     const emailId = params.id
-    const cookie = request.headers.get("cookie") ?? ""
+    const auth = request.headers.get("authorization") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails/${emailId}`, {
       method: "DELETE",
-      credentials: "include",
-      headers: { Cookie: cookie },
+      headers: { Authorization: auth },
     })
 
     if (!response.ok) {

--- a/app/api/emails/assign-to-claim/route.ts
+++ b/app/api/emails/assign-to-claim/route.ts
@@ -5,13 +5,12 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 export async function POST(request: NextRequest) {
   try {
     const { emailId, claimId } = await request.json()
-    const cookie = request.headers.get("cookie") ?? ""
+    const auth = request.headers.get("authorization") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails/assign-to-claim`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", Cookie: cookie },
+      headers: { "Content-Type": "application/json", Authorization: auth },
       body: JSON.stringify({ emailId, claimId }),
-      credentials: "include",
     })
 
     if (!response.ok) {

--- a/app/api/emails/attachment/[id]/route.ts
+++ b/app/api/emails/attachment/[id]/route.ts
@@ -5,11 +5,10 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const attachmentId = params.id
-    const cookie = request.headers.get("cookie") ?? ""
+    const auth = request.headers.get("authorization") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails/attachment/${attachmentId}`, {
-      credentials: "include",
-      headers: { Cookie: cookie },
+      headers: { Authorization: auth },
     })
 
     if (!response.ok) {

--- a/app/api/emails/event/[eventId]/route.ts
+++ b/app/api/emails/event/[eventId]/route.ts
@@ -7,11 +7,10 @@ export async function GET(
   { params }: { params: { eventId: string } },
 ) {
   try {
-    const cookie = request.headers.get("cookie") ?? ""
+    const auth = request.headers.get("authorization") ?? ""
     const response = await fetch(`${API_BASE_URL}/emails/event/${params.eventId}`, {
       cache: "no-store",
-      credentials: "include",
-      headers: { Cookie: cookie },
+      headers: { Authorization: auth },
     })
 
     if (!response.ok) {

--- a/app/api/emails/folder/[folder]/route.ts
+++ b/app/api/emails/folder/[folder]/route.ts
@@ -8,12 +8,11 @@ export async function GET(
 ) {
   try {
     const folder = params.folder
-    const cookie = request.headers.get("cookie") ?? ""
+    const auth = request.headers.get("authorization") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails/folder/${folder}`, {
       cache: "no-store",
-      credentials: "include",
-      headers: { Cookie: cookie },
+      headers: { Authorization: auth },
     })
 
     if (!response.ok) {

--- a/app/api/emails/route.ts
+++ b/app/api/emails/route.ts
@@ -4,11 +4,10 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 
 export async function GET(request: NextRequest) {
   try {
-    const cookie = request.headers.get("cookie") ?? ""
+    const auth = request.headers.get("authorization") ?? ""
     const response = await fetch(`${API_BASE_URL}/emails`, {
       cache: "no-store",
-      credentials: "include",
-      headers: { Cookie: cookie },
+      headers: { Authorization: auth },
     })
 
     if (!response.ok) {
@@ -30,13 +29,12 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData()
-    const cookie = request.headers.get("cookie") ?? ""
+    const auth = request.headers.get("authorization") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails`, {
       method: "POST",
       body: formData,
-      credentials: "include",
-      headers: { Cookie: cookie },
+      headers: { Authorization: auth },
     })
 
     if (!response.ok) {

--- a/app/api/emails/unassigned/route.ts
+++ b/app/api/emails/unassigned/route.ts
@@ -4,11 +4,10 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 
 export async function GET(request: NextRequest) {
   try {
-    const cookie = request.headers.get("cookie") ?? ""
+    const auth = request.headers.get("authorization") ?? ""
     const response = await fetch(`${API_BASE_URL}/emails/unassigned`, {
       cache: "no-store",
-      credentials: "include",
-      headers: { Cookie: cookie },
+      headers: { Authorization: auth },
     })
 
     if (!response.ok) {

--- a/app/api/settlements/[id]/download/route.ts
+++ b/app/api/settlements/[id]/download/route.ts
@@ -6,7 +6,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const response = await fetch(`${API_BASE_URL}/settlements/${params.id}/download`, {
       method: "GET",
-      headers: { cookie: request.headers.get("cookie") ?? "" },
+      headers: { authorization: request.headers.get("authorization") ?? "" },
     })
 
     if (!response.ok) {

--- a/app/api/settlements/[id]/preview/route.ts
+++ b/app/api/settlements/[id]/preview/route.ts
@@ -6,7 +6,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const response = await fetch(`${API_BASE_URL}/settlements/${params.id}/preview`, {
       method: "GET",
-      headers: { cookie: request.headers.get("cookie") ?? "" },
+      headers: { authorization: request.headers.get("authorization") ?? "" },
     })
 
     if (!response.ok) {

--- a/backend/appsettings.Development.json
+++ b/backend/appsettings.Development.json
@@ -11,6 +11,9 @@
     "DefaultConnection": "Server=SBLAP54\\MSSQLSERVER02;Database=AutomotiveClaimsDb;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True",
     "PostgresConnection": "Host=localhost;Database=AutomotiveClaimsDb;Username=postgres;Password=password"
   },
+  "Jwt": {
+    "Key": "SuperSecretKey"
+  },
   "ClaimNotifications": {
     "Recipients": [
       "handler1@example.com",

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -11,6 +11,9 @@
     "DefaultConnection": "Server=SBLAP54\\MSSQLSERVER02;Database=AutomotiveClaimsDb2;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True",
     "PostgresConnection": "Host=localhost;Database=AutomotiveClaimsDb2;Username=postgres;Password=password"
   },
+  "Jwt": {
+    "Key": "SuperSecretKey"
+  },
   "SmtpSettings": {
     "Host": "smtp.gmail.com",
     "Port": 587,

--- a/lib/api-fetch.ts
+++ b/lib/api-fetch.ts
@@ -9,9 +9,9 @@ export async function apiFetch(
 ): Promise<Response> {
   const url = `${API_BASE_URL}${endpoint}`
   const headers = new Headers(init.headers)
-  const cookie = request.headers.get("cookie")
-  if (cookie) {
-    headers.set("cookie", cookie)
+  const auth = request.headers.get("authorization")
+  if (auth) {
+    headers.set("authorization", auth)
   }
   return fetch(url, {
     ...init,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -827,13 +827,14 @@ class ApiService {
     username: string,
     password: string,
   ): Promise<{ mustChangePassword: boolean }> {
-    const data = await this.request<{ mustChangePassword: boolean }>(
+    const data = await this.request<{ token: string; mustChangePassword: boolean }>(
       "/auth/login",
       {
         method: "POST",
         body: JSON.stringify({ userName: username, password }),
       },
     )
+    this.setToken(data.token)
     return { mustChangePassword: data.mustChangePassword }
   }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -729,19 +729,18 @@ export interface SettlementUpsertDto {
 // API Service
 class ApiService {
   private getToken(): string | null {
-    if (typeof document !== "undefined") {
-      const match = document.cookie.match(/(?:^|; )token=([^;]+)/)
-      return match ? decodeURIComponent(match[1]) : null
+    if (typeof window !== "undefined") {
+      return localStorage.getItem("token")
     }
     return null
   }
 
   private setToken(token: string | null) {
-    if (typeof document !== "undefined") {
+    if (typeof window !== "undefined") {
       if (token) {
-        document.cookie = `token=${token}; path=/`
+        localStorage.setItem("token", token)
       } else {
-        document.cookie = "token=; Max-Age=0; path=/"
+        localStorage.removeItem("token")
       }
     }
   }
@@ -761,7 +760,7 @@ class ApiService {
     }
 
     const response = await fetch(url, {
-      credentials: "include",
+      credentials: "omit",
       headers,
       ...options,
     })


### PR DESCRIPTION
## Summary
- store JWT in localStorage and send with Authorization header
- forward Authorization header in internal API routes
- drop cookie and credential usage for backend requests

## Testing
- `pnpm lint` *(fails: ESLint configuration prompt)*
- `pnpm test` *(fails: Cannot require() ES Module in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68ac45a176ac832ca2ff6a9c0cc78ce1