### PR TITLE
Send auth token with client API requests

### DIFF
--- a/hooks/use-damages.ts
+++ b/hooks/use-damages.ts
@@ -2,6 +2,7 @@
 
 import { useCallback } from "react"
 import { API_ENDPOINTS } from "@/lib/constants"
+import { authFetch } from "@/lib/auth-fetch"
 
 export interface Damage {
   id?: string
@@ -29,9 +30,8 @@ export function createDamageDraft(params: Partial<Damage> = {}): Damage {
 
 export function useDamages(eventId?: string) {
   const initDamage = useCallback(async (): Promise<DamageInit> => {
-    const response = await fetch(API_ENDPOINTS.DAMAGES_INIT, {
+    const response = await authFetch(API_ENDPOINTS.DAMAGES_INIT, {
       method: "POST",
-      credentials: "omit",
     })
 
     if (!response.ok) {
@@ -49,9 +49,9 @@ export function useDamages(eventId?: string) {
         throw new Error("Brak identyfikatora zdarzenia")
       }
 
-      const response = await fetch(
+      const response = await authFetch(
         `${API_ENDPOINTS.DAMAGES}/event/${targetId}`,
-        { method: "GET", credentials: "omit" },
+        { method: "GET" },
       )
 
       if (!response.ok) {
@@ -70,9 +70,8 @@ export function useDamages(eventId?: string) {
         throw new Error("Brak identyfikatora zdarzenia")
       }
 
-      const response = await fetch(API_ENDPOINTS.DAMAGES, {
+      const response = await authFetch(API_ENDPOINTS.DAMAGES, {
         method: "POST",
-        credentials: "omit",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...damage,
@@ -92,9 +91,8 @@ export function useDamages(eventId?: string) {
 
   const updateDamage = useCallback(
     async (id: string, damage: Partial<Damage>): Promise<void> => {
-      const response = await fetch(`${API_ENDPOINTS.DAMAGES}/${id}`, {
+      const response = await authFetch(`${API_ENDPOINTS.DAMAGES}/${id}`, {
         method: "PUT",
-        credentials: "omit",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ ...damage, eventId }),
       })
@@ -108,9 +106,8 @@ export function useDamages(eventId?: string) {
   )
 
   const deleteDamage = useCallback(async (id: string): Promise<void> => {
-    const response = await fetch(`${API_ENDPOINTS.DAMAGES}/${id}`, {
+    const response = await authFetch(`${API_ENDPOINTS.DAMAGES}/${id}`, {
       method: "DELETE",
-      credentials: "omit",
     })
 
     if (!response.ok) {

--- a/lib/api/appeals.ts
+++ b/lib/api/appeals.ts
@@ -1,4 +1,5 @@
 import { AppealDto, API_BASE_URL, DocumentDto } from "../api";
+import { authFetch } from "../auth-fetch";
 
 export interface Appeal {
   id: string;
@@ -58,9 +59,8 @@ function buildFormData(data: AppealUpsert, documents: File[] = []) {
 }
 
 export async function getAppeals(claimId: string): Promise<Appeal[]> {
-  const response = await fetch(`${APPEALS_URL}/event/${claimId}`, {
+  const response = await authFetch(`${APPEALS_URL}/event/${claimId}`, {
     method: "GET",
-    credentials: "omit",
   });
   if (!response.ok) {
     throw new Error("Failed to fetch appeals");
@@ -74,9 +74,8 @@ export async function createAppeal(
   documents: File[] = [],
 ): Promise<Appeal> {
   const body = buildFormData(data, documents);
-  const response = await fetch(APPEALS_URL, {
+  const response = await authFetch(APPEALS_URL, {
     method: "POST",
-    credentials: "omit",
     body,
   });
   if (!response.ok) {
@@ -92,9 +91,8 @@ export async function updateAppeal(
   documents: File[] = [],
 ): Promise<Appeal> {
   const body = buildFormData(data, documents);
-  const response = await fetch(`${APPEALS_URL}/${id}`, {
+  const response = await authFetch(`${APPEALS_URL}/${id}`, {
     method: "PUT",
-    credentials: "omit",
     body,
   });
   if (!response.ok) {
@@ -105,9 +103,8 @@ export async function updateAppeal(
 }
 
 export async function deleteAppeal(id: string): Promise<void> {
-  const response = await fetch(`${APPEALS_URL}/${id}`, {
+  const response = await authFetch(`${APPEALS_URL}/${id}`, {
     method: "DELETE",
-    credentials: "omit",
   });
   if (!response.ok) {
     throw new Error("Failed to delete appeal");

--- a/lib/api/clientclaims.ts
+++ b/lib/api/clientclaims.ts
@@ -1,5 +1,6 @@
 import { API_BASE_URL, ClientClaimDto } from "../api"
 import type { ClientClaim, ClaimStatus } from "@/types"
+import { authFetch } from "../auth-fetch"
 
 export interface ClientClaimUpsert {
   eventId?: string
@@ -59,9 +60,8 @@ export async function createClientClaim(
   documents: File[] = [],
 ): Promise<ClientClaim> {
   const body = buildFormData(data, documents)
-  const response = await fetch(CLIENT_CLAIMS_URL, {
+  const response = await authFetch(CLIENT_CLAIMS_URL, {
     method: "POST",
-    credentials: "omit",
     body,
   })
   if (!response.ok) {
@@ -78,9 +78,8 @@ export async function updateClientClaim(
   documents: File[] = [],
 ): Promise<ClientClaim> {
   const body = buildFormData(data, documents)
-  const response = await fetch(`${CLIENT_CLAIMS_URL}/${id}`, {
+  const response = await authFetch(`${CLIENT_CLAIMS_URL}/${id}`, {
     method: "PUT",
-    credentials: "omit",
     body,
   })
   if (!response.ok) {
@@ -92,9 +91,8 @@ export async function updateClientClaim(
 }
 
 export async function deleteClientClaim(id: string): Promise<void> {
-  const response = await fetch(`${CLIENT_CLAIMS_URL}/${id}`, {
+  const response = await authFetch(`${CLIENT_CLAIMS_URL}/${id}`, {
     method: "DELETE",
-    credentials: "omit",
   })
   if (!response.ok) {
     const text = await response.text()
@@ -103,9 +101,8 @@ export async function deleteClientClaim(id: string): Promise<void> {
 }
 
 export async function downloadClientClaimDocument(id: string): Promise<Blob> {
-  const response = await fetch(`${CLIENT_CLAIMS_URL}/${id}/download`, {
+  const response = await authFetch(`${CLIENT_CLAIMS_URL}/${id}/download`, {
     method: "GET",
-    credentials: "omit",
   })
   if (!response.ok) {
     throw new Error("Failed to download document")
@@ -114,9 +111,8 @@ export async function downloadClientClaimDocument(id: string): Promise<Blob> {
 }
 
 export async function previewClientClaimDocument(id: string): Promise<Blob> {
-  const response = await fetch(`${CLIENT_CLAIMS_URL}/${id}/preview`, {
+  const response = await authFetch(`${CLIENT_CLAIMS_URL}/${id}/preview`, {
     method: "GET",
-    credentials: "omit",
   })
   if (!response.ok) {
     throw new Error("Failed to preview document")

--- a/lib/api/decisions.ts
+++ b/lib/api/decisions.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { API_BASE_URL } from "../api";
+import { authFetch } from "../auth-fetch";
 
 const documentSchema = z.object({
   id: z.string(),
@@ -40,10 +41,7 @@ export const decisionUpsertSchema = decisionSchema.pick({
 export type DecisionUpsert = z.infer<typeof decisionUpsertSchema>;
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
-    credentials: "omit",
-    ...options,
-  });
+  const response = await authFetch(`${API_BASE_URL}${url}`, options);
   const text = await response.text();
   const data = text ? JSON.parse(text) : undefined;
   if (!response.ok) {

--- a/lib/api/documents.ts
+++ b/lib/api/documents.ts
@@ -1,10 +1,10 @@
 import { API_BASE_URL } from "../api";
 import type { DocumentDto } from "../api";
+import { authFetch } from "../auth-fetch";
 
 export async function deleteDocument(id: string): Promise<void> {
-  const res = await fetch(`${API_BASE_URL}/documents/${id}`, {
+  const res = await authFetch(`${API_BASE_URL}/documents/${id}`, {
     method: "DELETE",
-    credentials: "omit",
   });
   if (!res.ok) {
     const text = await res.text();
@@ -16,9 +16,8 @@ export async function renameDocument(
   id: string,
   originalFileName: string,
 ): Promise<DocumentDto> {
-  const res = await fetch(`${API_BASE_URL}/documents/${id}`, {
+  const res = await authFetch(`${API_BASE_URL}/documents/${id}`, {
     method: "PUT",
-    credentials: "omit",
     headers: {
       "Content-Type": "application/json",
     },

--- a/lib/api/recourses.ts
+++ b/lib/api/recourses.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import { API_BASE_URL } from "../api"
+import { authFetch } from "../auth-fetch"
 
 const documentSchema = z.object({
   id: z.string(),
@@ -39,10 +40,7 @@ export type Recourse = z.infer<typeof recourseSchema>
 export type RecourseUpsert = z.infer<typeof recourseUpsertSchema>
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
-    credentials: "omit",
-    ...options,
-  })
+  const response = await authFetch(`${API_BASE_URL}${url}`, options)
   const text = await response.text()
   const data = text ? JSON.parse(text) : undefined
   if (!response.ok) {
@@ -93,9 +91,8 @@ export async function deleteRecourse(id: string): Promise<void> {
 }
 
 export async function downloadRecourseDocument(id: string): Promise<Blob> {
-  const response = await fetch(`${API_BASE_URL}/recourses/${id}/download`, {
+  const response = await authFetch(`${API_BASE_URL}/recourses/${id}/download`, {
     method: "GET",
-    credentials: "omit",
   })
   if (!response.ok) {
     throw new Error("Failed to download document")
@@ -104,9 +101,8 @@ export async function downloadRecourseDocument(id: string): Promise<Blob> {
 }
 
 export async function previewRecourseDocument(id: string): Promise<Blob> {
-  const response = await fetch(`${API_BASE_URL}/recourses/${id}/preview`, {
+  const response = await authFetch(`${API_BASE_URL}/recourses/${id}/preview`, {
     method: "GET",
-    credentials: "omit",
   })
   if (!response.ok) {
     throw new Error("Failed to preview document")

--- a/lib/api/repair-details.ts
+++ b/lib/api/repair-details.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { API_BASE_URL } from "../api";
+import { authFetch } from "../auth-fetch";
 
 const repairDetailSchema = z.object({
   id: z.string(),
@@ -38,8 +39,7 @@ export type RepairDetail = z.infer<typeof repairDetailSchema>;
 export type RepairDetailUpsert = z.infer<typeof repairDetailUpsertSchema>;
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
-    credentials: "omit",
+  const response = await authFetch(`${API_BASE_URL}${url}`, {
     headers: { "Content-Type": "application/json" },
     ...options,
   });

--- a/lib/api/reports.ts
+++ b/lib/api/reports.ts
@@ -1,4 +1,5 @@
 import { API_BASE_URL } from "../api";
+import { authFetch } from "../auth-fetch";
 
 export interface ReportMetadata {
   [entity: string]: string[];
@@ -13,9 +14,7 @@ export interface ReportRequest {
 }
 
 export async function getReportMetadata(): Promise<ReportMetadata> {
-  const res = await fetch(`${API_BASE_URL}/report/metadata`, {
-    credentials: "omit",
-  });
+  const res = await authFetch(`${API_BASE_URL}/report/metadata`);
   if (!res.ok) {
     throw new Error("Failed to fetch report metadata");
   }
@@ -23,9 +22,8 @@ export async function getReportMetadata(): Promise<ReportMetadata> {
 }
 
 export async function exportReport(request: ReportRequest): Promise<Blob> {
-  const res = await fetch(`${API_BASE_URL}/report/export`, {
+  const res = await authFetch(`${API_BASE_URL}/report/export`, {
     method: "POST",
-    credentials: "omit",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(request),
   });
@@ -39,11 +37,10 @@ export async function getFilterValues(
   entity: string,
   field: string,
 ): Promise<string[]> {
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE_URL}/report/values?entity=${encodeURIComponent(
       entity,
     )}&field=${encodeURIComponent(field)}`,
-    { credentials: "omit" },
   );
   if (!res.ok) {
     throw new Error("Failed to fetch filter values");

--- a/lib/api/settlements.ts
+++ b/lib/api/settlements.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { API_BASE_URL } from "../api";
+import { authFetch } from "../auth-fetch";
 
 const documentSchema = z.object({
   id: z.string(),
@@ -53,10 +54,7 @@ export type Settlement = z.infer<typeof settlementSchema>;
 export type SettlementUpsert = z.infer<typeof settlementUpsertSchema>;
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
-    credentials: "omit",
-    ...options,
-  });
+  const response = await authFetch(`${API_BASE_URL}${url}`, options);
   const text = await response.text();
   let data: unknown;
   try {

--- a/lib/auth-fetch.ts
+++ b/lib/auth-fetch.ts
@@ -1,0 +1,24 @@
+import { API_BASE_URL } from "./api"
+
+function getToken(): string | null {
+  if (typeof window !== "undefined") {
+    return localStorage.getItem("token")
+  }
+  return null
+}
+
+export async function authFetch(
+  input: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const token = getToken()
+  const headers = new Headers(init.headers)
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`)
+  }
+  return fetch(input.startsWith("http") ? input : `${API_BASE_URL}${input}`, {
+    ...init,
+    credentials: "omit",
+    headers,
+  })
+}

--- a/lib/dictionary-service.ts
+++ b/lib/dictionary-service.ts
@@ -1,3 +1,5 @@
+import { authFetch } from "./auth-fetch"
+
 interface DictionaryItemDto {
   id: string | number
   code?: string
@@ -24,24 +26,10 @@ class DictionaryService {
   private cache = new Map<string, { data: DictionaryResponseDto; timestamp: number }>()
   private readonly CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
 
-  private getToken(): string | null {
-    if (typeof window !== "undefined") {
-      return localStorage.getItem("token")
-    }
-    return null
-  }
-
   private async fetchFromAPI(endpoint: string): Promise<DictionaryResponseDto> {
-    const token = this.getToken()
-    const response = await fetch(
+    const response = await authFetch(
       `${process.env.NEXT_PUBLIC_API_URL}/dictionaries/${endpoint}`,
-      {
-        method: "GET",
-        credentials: "omit",
-
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-
-      },
+      { method: "GET" },
     )
     const text = await response.text()
     if (!response.ok) {

--- a/lib/email-service.ts
+++ b/lib/email-service.ts
@@ -1,5 +1,6 @@
 import { EmailFolder } from "@/types/email"
 import { API_BASE_URL } from "./api"
+import { authFetch } from "./auth-fetch"
 
 export interface AttachmentDto {
   id: string
@@ -60,9 +61,8 @@ class EmailService {
 
   async getAllEmails(): Promise<EmailDto[]> {
     try {
-      const response = await fetch(this.apiUrl, {
+      const response = await authFetch(this.apiUrl, {
         method: "GET",
-        credentials: "omit",
       })
       if (!response.ok) throw new Error("Failed to fetch emails")
       const data = await response.json()
@@ -97,9 +97,8 @@ class EmailService {
   async getEmailById(id: string): Promise<EmailDto | undefined> {
     if (!this.isValidGuid(id)) return undefined
     try {
-      const response = await fetch(`${this.apiUrl}/${id}`, {
+      const response = await authFetch(`${this.apiUrl}/${id}`, {
         method: "GET",
-        credentials: "omit",
       })
       if (!response.ok) throw new Error("Failed to fetch email")
       const e = await response.json()
@@ -134,9 +133,8 @@ class EmailService {
   async deleteEmail(emailId: string): Promise<boolean> {
     if (!this.isValidGuid(emailId)) return false
     try {
-      const response = await fetch(`${this.apiUrl}/${emailId}`, {
+      const response = await authFetch(`${this.apiUrl}/${emailId}`, {
         method: "DELETE",
-        credentials: "omit",
       })
       return response.ok
     } catch (error) {
@@ -188,9 +186,8 @@ class EmailService {
   async getEmailsByEventId(eventId: string): Promise<EmailDto[]> {
     if (!this.isValidGuid(eventId)) return []
     try {
-      const response = await fetch(`${this.apiUrl}/event/${eventId}`, {
+      const response = await authFetch(`${this.apiUrl}/event/${eventId}`, {
         method: "GET",
-        credentials: "omit",
       })
       if (!response.ok) throw new Error("Failed to fetch emails by event")
       const data = await response.json()
@@ -225,9 +222,8 @@ class EmailService {
   async markAsRead(emailId: string): Promise<boolean> {
     if (!this.isValidGuid(emailId)) return false
     try {
-      const response = await fetch(`${this.apiUrl}/${emailId}/read`, {
+      const response = await authFetch(`${this.apiUrl}/${emailId}/read`, {
         method: "PUT",
-        credentials: "omit",
       })
       return response.ok
     } catch (error) {
@@ -249,9 +245,8 @@ class EmailService {
       if (sendRequest.eventId) formData.append("eventId", sendRequest.eventId)
       sendRequest.attachments?.forEach((file) => formData.append("attachments", file))
 
-      const response = await fetch(this.apiUrl, {
+      const response = await authFetch(this.apiUrl, {
         method: "POST",
-        credentials: "omit",
         body: formData,
       })
       return response.ok
@@ -275,9 +270,8 @@ class EmailService {
       if (sendRequest.eventId) formData.append("eventId", sendRequest.eventId)
       sendRequest.attachments?.forEach((file) => formData.append("attachments", file))
 
-      const response = await fetch(`${this.apiUrl}/draft`, {
+      const response = await authFetch(`${this.apiUrl}/draft`, {
         method: "POST",
-        credentials: "omit",
         body: formData,
       })
       return response.ok
@@ -290,9 +284,8 @@ class EmailService {
   async downloadAttachment(attachmentId: string): Promise<Blob | undefined> {
     if (!this.isValidGuid(attachmentId)) return undefined
     try {
-      const response = await fetch(`${this.apiUrl}/attachment/${attachmentId}`, {
+      const response = await authFetch(`${this.apiUrl}/attachment/${attachmentId}`, {
         method: "GET",
-        credentials: "omit",
       })
       if (!response.ok) throw new Error("Failed to download attachment")
       return await response.blob()
@@ -310,9 +303,8 @@ class EmailService {
     try {
       const formData = new FormData()
       formData.append("file", file)
-      const response = await fetch(`${this.apiUrl}/${emailId}/attachments`, {
+      const response = await authFetch(`${this.apiUrl}/${emailId}/attachments`, {
         method: "POST",
-        credentials: "omit",
         body: formData,
       })
       if (!response.ok) throw new Error("Failed to upload attachment")
@@ -326,9 +318,8 @@ class EmailService {
   async deleteAttachment(attachmentId: string): Promise<boolean> {
     if (!this.isValidGuid(attachmentId)) return false
     try {
-      const response = await fetch(`${this.apiUrl}/attachment/${attachmentId}`, {
+      const response = await authFetch(`${this.apiUrl}/attachment/${attachmentId}`, {
         method: "DELETE",
-        credentials: "omit",
       })
       return response.ok
     } catch (error) {
@@ -339,9 +330,8 @@ class EmailService {
 
   async assignEmailToClaim(emailId: string, claimIds: string[]): Promise<boolean> {
     try {
-      const response = await fetch(`${this.apiUrl}/assign-to-claim`, {
+      const response = await authFetch(`${this.apiUrl}/assign-to-claim`, {
         method: "POST",
-        credentials: "omit",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ emailId, claimIds }),
       })

--- a/lib/vehicle-types.ts
+++ b/lib/vehicle-types.ts
@@ -1,5 +1,6 @@
 import type { VehicleType } from "@/types/vehicle-type"
 import { API_BASE_URL } from "./api"
+import { authFetch } from "./auth-fetch"
 
 const VEHICLE_TYPES_URL = `${API_BASE_URL}/dictionaries/vehicle-types`
 
@@ -16,9 +17,8 @@ export const vehicleTypeService = {
       }`
       console.log("Fetching vehicle types from:", url)
 
-      const response = await fetch(url, {
+      const response = await authFetch(url, {
         method: "GET",
-        credentials: "omit",
       })
 
       if (!response.ok) {
@@ -53,9 +53,8 @@ export const vehicleTypeService = {
 
   async getVehicleTypeById(id: string): Promise<VehicleType | null> {
     try {
-      const response = await fetch(`${VEHICLE_TYPES_URL}/${id}`, {
+      const response = await authFetch(`${VEHICLE_TYPES_URL}/${id}`, {
         method: "GET",
-        credentials: "omit",
       })
 
       if (!response.ok) {

--- a/public/passengercar.svg
+++ b/public/passengercar.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+  <rect width="100" height="50" fill="#e5e7eb"/>
+  <text x="50" y="25" font-size="10" text-anchor="middle" fill="#6b7280">passengercar</text>
+</svg>

--- a/public/suv.svg
+++ b/public/suv.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+  <rect width="100" height="50" fill="#e5e7eb"/>
+  <text x="50" y="25" font-size="10" text-anchor="middle" fill="#6b7280">suv</text>
+</svg>

--- a/public/tractor.svg
+++ b/public/tractor.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+  <rect width="100" height="50" fill="#e5e7eb"/>
+  <text x="50" y="25" font-size="10" text-anchor="middle" fill="#6b7280">tractor</text>
+</svg>

--- a/public/trailer.svg
+++ b/public/trailer.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+  <rect width="100" height="50" fill="#e5e7eb"/>
+  <text x="50" y="25" font-size="10" text-anchor="middle" fill="#6b7280">trailer</text>
+</svg>

--- a/public/truck.svg
+++ b/public/truck.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+  <rect width="100" height="50" fill="#e5e7eb"/>
+  <text x="50" y="25" font-size="10" text-anchor="middle" fill="#6b7280">truck</text>
+</svg>


### PR DESCRIPTION
## Summary
- add `authFetch` helper to attach stored token to API calls
- update client API modules and hooks to use `authFetch`
- provide placeholder vehicle SVGs to avoid missing asset errors

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ac578659c8832cb15b7a7afe7cd5f6