### PR TITLE
Send auth token with client API requests

### DIFF
--- a/components/claim-form/appeals-section.tsx
+++ b/components/claim-form/appeals-section.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/lib/api/appeals"
 import { API_BASE_URL, DocumentDto } from "@/lib/api"
 import { deleteDocument } from "@/lib/api/documents"
+import { authFetch } from "@/lib/auth-fetch"
 
 interface AppealsSectionProps {
   claimId: string
@@ -357,10 +358,7 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
       const url = doc
         ? `${API_BASE_URL}/appeals/${appeal.id}/documents/${doc.id}/download`
         : `${API_BASE_URL}/appeals/${appeal.id}/download`
-      const response = await fetch(url, {
-        method: "GET",
-        credentials: "omit",
-      })
+      const response = await authFetch(url, { method: "GET" })
       if (!response.ok) {
         throw new Error("Failed to download file")
       }
@@ -389,10 +387,7 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
       const url = doc
         ? `${API_BASE_URL}/appeals/${appeal.id}/documents/${doc.id}/preview`
         : `${API_BASE_URL}/appeals/${appeal.id}/preview`
-      const response = await fetch(url, {
-        method: "GET",
-        credentials: "omit",
-      })
+      const response = await authFetch(url, { method: "GET" })
       if (!response.ok) {
         throw new Error("Failed to preview file")
       }

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -46,6 +46,7 @@ import { TransportDamageSection } from "./transport-damage-section"
 import { PropertyParticipantsSection } from "./property-participants-section"
 import InjuredPartySection from "./injured-party-section"
 import SubcontractorSection from "./subcontractor-section"
+import { authFetch } from "@/lib/auth-fetch"
 
 import { PropertyClaimSummary } from "./property-claim-summary"
 import { TransportClaimSummary } from "./transport-claim-summary"
@@ -212,17 +213,9 @@ export const ClaimMainContent = ({
     const loadRepairDetails = async () => {
       if (!eventId) return
       try {
-        const token =
-          typeof window !== "undefined" ? localStorage.getItem("token") : null
-        const response = await fetch(
+        const response = await authFetch(
           `${process.env.NEXT_PUBLIC_API_URL}/repair-details?eventId=${eventId}`,
-          {
-            method: "GET",
-            credentials: "omit",
-
-            headers: token ? { Authorization: `Bearer ${token}` } : {},
-          },
-
+          { method: "GET" },
         )
         if (response.ok) {
           const data = await response.json()

--- a/components/claim-form/client-claims-section.tsx
+++ b/components/claim-form/client-claims-section.tsx
@@ -34,6 +34,7 @@ import {
 import type { ClientClaim, ClaimStatus } from "@/types"
 import type { DocumentDto } from "@/lib/api"
 import { API_BASE_URL } from "@/lib/api"
+import { authFetch } from "@/lib/auth-fetch"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -415,7 +416,7 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
   const loadPreview = async (claim: ClientClaim, doc: DocumentDto) => {
     const fileName = doc.originalFileName || doc.fileName || "document"
     const urlPath = `${API_BASE_URL}/clientclaims/${claim.id}/documents/${doc.id}/preview`
-    const response = await fetch(urlPath, { method: "GET", credentials: "omit" })
+    const response = await authFetch(urlPath, { method: "GET" })
     if (!response.ok) throw new Error("Failed to preview")
     const blob = await response.blob()
     const objectUrl = URL.createObjectURL(blob)
@@ -449,7 +450,7 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
       }
       try {
         const urlPath = `${API_BASE_URL}/clientclaims/${claim.id}/preview`
-        const response = await fetch(urlPath, { method: "GET", credentials: "omit" })
+        const response = await authFetch(urlPath, { method: "GET" })
         if (!response.ok) throw new Error("Failed to preview")
         const blob = await response.blob()
         const objectUrl = URL.createObjectURL(blob)
@@ -523,7 +524,7 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
       const urlPath = doc
         ? `${API_BASE_URL}/clientclaims/${claim.id}/documents/${doc.id}/download`
         : `${API_BASE_URL}/clientclaims/${claim.id}/download`
-      const response = await fetch(urlPath, { method: "GET", credentials: "omit" })
+      const response = await authFetch(urlPath, { method: "GET" })
       if (!response.ok) throw new Error("Failed to download")
       const blob = await response.blob()
       const url = URL.createObjectURL(blob)

--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -20,6 +20,7 @@ import {
   deleteDecision as apiDeleteDecision,
 } from "@/lib/api/decisions"
 import { API_BASE_URL } from "@/lib/api"
+import { authFetch } from "@/lib/auth-fetch"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -332,10 +333,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
           ? `${API_BASE_URL}/documents/${doc.id}/download`
           : `${API_BASE_URL}/claims/${claimId}/decisions/${decision.id}/download`)
 
-      const response = await fetch(url, {
-        method: "GET",
-        credentials: "omit",
-      })
+      const response = await authFetch(url, { method: "GET" })
       if (response.ok) {
         const blob = await response.blob()
         const objectUrl = window.URL.createObjectURL(blob)
@@ -362,7 +360,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
   const loadPreview = async (decision: Decision, doc: DocumentDto) => {
     if (!claimId) return
     const url = doc.previewUrl ?? `${API_BASE_URL}/documents/${doc.id}/preview`
-    const response = await fetch(url, { method: "GET", credentials: "omit" })
+    const response = await authFetch(url, { method: "GET" })
     if (!response.ok) throw new Error("Failed to preview file")
     const blob = await response.blob()
     const objectUrl = window.URL.createObjectURL(blob)
@@ -388,7 +386,7 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
       // fallback for single file
       try {
         const url = `${API_BASE_URL}/claims/${claimId}/decisions/${decision.id}/preview`
-        const response = await fetch(url, { method: "GET", credentials: "omit" })
+        const response = await authFetch(url, { method: "GET" })
         if (!response.ok) throw new Error("Failed to preview file")
         const blob = await response.blob()
         const objectUrl = window.URL.createObjectURL(blob)

--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -19,6 +19,7 @@ import { useToast } from '@/hooks/use-toast'
 import { useUnsavedChangesWarning, UNSAVED_CHANGES_MESSAGE } from '@/hooks/use-unsaved-changes-warning'
 import type { Claim, ParticipantInfo, UploadedFile, RequiredDocument } from '@/types'
 import { getRequiredDocumentsByObjectType } from '@/lib/required-documents'
+import { authFetch } from '@/lib/auth-fetch'
 
 interface ClaimFormProps {
   initialData?: Claim
@@ -192,11 +193,10 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
               formDataFile.append('eventId', saved!.id.toString())
               formDataFile.append('category', file.categoryCode || mapCategoryNameToCode(file.category || 'Inne dokumenty'))
               formDataFile.append('uploadedBy', 'Current User')
-              await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents/upload`, {
-                method: 'POST',
-                credentials: 'omit',
-                body: formDataFile,
-              })
+              await authFetch(
+                `${process.env.NEXT_PUBLIC_API_URL}/documents/upload`,
+                { method: 'POST', body: formDataFile },
+              )
             })
           )
         }

--- a/components/claim-form/recourse-section.tsx
+++ b/components/claim-form/recourse-section.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/lib/api/recourses"
 import { API_BASE_URL } from "@/lib/api"
 import type { DocumentDto } from "@/lib/api"
+import { authFetch } from "@/lib/auth-fetch"
 
 interface RecourseSectionProps {
   eventId: string
@@ -343,7 +344,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
       : `${API_BASE_URL}/recourses/${recourse.id}/download`
 
     try {
-      const response = await fetch(url, { method: "GET", credentials: "omit" })
+      const response = await authFetch(url, { method: "GET" })
       if (!response.ok) throw new Error("Failed to download")
       const blob = await response.blob()
       const objectUrl = window.URL.createObjectURL(blob)
@@ -362,7 +363,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
 
   const loadPreview = async (recourse: Recourse, doc: DocumentDto) => {
     const url = `${API_BASE_URL}/recourses/${recourse.id}/documents/${doc.id}/preview`
-    const response = await fetch(url, { method: "GET", credentials: "omit" })
+    const response = await authFetch(url, { method: "GET" })
     if (!response.ok) throw new Error("Failed to preview")
     const blob = await response.blob()
     const objectUrl = window.URL.createObjectURL(blob)
@@ -385,7 +386,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
       // single file fallback
       const url = `${API_BASE_URL}/recourses/${recourse.id}/preview`
       try {
-        const response = await fetch(url, { method: "GET", credentials: "omit" })
+        const response = await authFetch(url, { method: "GET" })
         if (!response.ok) throw new Error("Failed to preview")
         const blob = await response.blob()
         const objectUrl = window.URL.createObjectURL(blob)

--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -12,6 +12,7 @@ import { useToast } from "@/hooks/use-toast"
 import { HandHeart, Plus, Minus, Edit, Trash2, Download, Eye, X, Upload, FileText, Info, Loader2, ChevronLeft, ChevronRight } from "lucide-react"
 import { getSettlements, createSettlement, updateSettlement, deleteSettlement } from "@/lib/api/settlements"
 import { API_BASE_URL } from "@/lib/api"
+import { authFetch } from "@/lib/auth-fetch"
 import type { Settlement } from "@/lib/api/settlements"
 import type { DocumentDto } from "@/lib/api"
 
@@ -333,7 +334,7 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
 
   const loadPreview = async (settlement: Settlement, doc: DocumentDto) => {
     const url = `${API_BASE_URL}/settlements/${settlement.id}/documents/${doc.id}/preview`
-    const response = await fetch(url, { method: "GET", credentials: "omit" })
+    const response = await authFetch(url, { method: "GET" })
     if (!response.ok) throw new Error("Failed to preview file")
     const blob = await response.blob()
     const objectUrl = window.URL.createObjectURL(blob)
@@ -378,7 +379,7 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
       if (docs.length === 0) {
         try {
           const url = `${API_BASE_URL}/settlements/${settlement.id}/preview`
-          const response = await fetch(url, { method: "GET", credentials: "omit" })
+          const response = await authFetch(url, { method: "GET" })
           if (!response.ok) throw new Error("Failed to preview file")
           const blob = await response.blob()
           const objectUrl = window.URL.createObjectURL(blob)
@@ -484,10 +485,7 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
           ? `${API_BASE_URL}/settlements/${settlement.id}/documents/${doc.id}/download`
           : `${API_BASE_URL}/settlements/${settlement.id}/download`
 
-        const response = await fetch(downloadUrl, {
-          method: "GET",
-          credentials: "omit",
-        })
+        const response = await authFetch(downloadUrl, { method: "GET" })
         if (!response.ok) {
           throw new Error("Failed to download file")
         }

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Checkbox } from "@/components/ui/checkbox"
 import { renameDocument } from "@/lib/api/documents"
+import { authFetch } from "@/lib/auth-fetch"
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -161,11 +162,8 @@ export const DocumentsSection = React.forwardRef<
     ) {
       const load = async () => {
         try {
-          const response = await fetch(
+          const response = await authFetch(
             previewDocument.previewUrl || previewDocument.downloadUrl,
-            {
-              credentials: "omit",
-            },
           )
           if (!response.ok) {
             throw new Error(`HTTP ${response.status}`)
@@ -293,10 +291,9 @@ export const DocumentsSection = React.forwardRef<
     setLoading(true)
     try {
       const params = new URLSearchParams({ eventId })
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents?${params.toString()}`, {
-        method: "GET",
-        credentials: "omit",
-      })
+      const response = await authFetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/documents?${params.toString()}`,
+      )
 
       if (response.status === 404) {
         setDocuments([])
@@ -454,11 +451,13 @@ export const DocumentsSection = React.forwardRef<
       formData.append("uploadedBy", "Current User")
 
       try {
-        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents/upload`, {
-          method: "POST",
-          credentials: "omit",
-          body: formData,
-        })
+        const response = await authFetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/documents/upload`,
+          {
+            method: "POST",
+            body: formData,
+          },
+        )
 
         if (response.ok) {
           const documentDto = await response.json()
@@ -637,10 +636,10 @@ export const DocumentsSection = React.forwardRef<
     }
 
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents/${documentId}`, {
-        method: "DELETE",
-        credentials: "omit",
-      })
+      const response = await authFetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/documents/${documentId}`,
+        { method: "DELETE" },
+      )
 
       if (response.ok) {
         setDocuments((prev) => prev.filter((doc) => doc.id !== documentId))
@@ -753,14 +752,14 @@ export const DocumentsSection = React.forwardRef<
     )
 
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents/${documentId}`, {
-        method: "PUT",
-        credentials: "omit",
-        headers: {
-          "Content-Type": "application/json",
+      const response = await authFetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/documents/${documentId}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ description }),
         },
-        body: JSON.stringify({ description }),
-      })
+      )
 
       if (response.ok) {
         const updatedDocument = await response.json()
@@ -793,10 +792,10 @@ export const DocumentsSection = React.forwardRef<
         description: `Rozpoczęto generowanie opisu dla pliku: ${doc.originalFileName}`,
       })
 
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents/${documentId}/generate-description`, {
-        method: "POST",
-        credentials: "omit",
-      })
+      const response = await authFetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/documents/${documentId}/generate-description`,
+        { method: "POST" },
+      )
 
       if (response.ok) {
         const updatedDocument = await response.json()
@@ -903,10 +902,7 @@ export const DocumentsSection = React.forwardRef<
       const zip = new JSZip()
 
       for (const doc of documentsForCategory) {
-        const response = await fetch(doc.downloadUrl, {
-          method: "GET",
-          credentials: "omit",
-        })
+        const response = await authFetch(doc.downloadUrl, { method: "GET" })
         const blob = await response.blob()
         zip.file(doc.originalFileName, blob)
       }
@@ -972,10 +968,7 @@ export const DocumentsSection = React.forwardRef<
       const zip = new JSZip()
 
       for (const doc of documentsForCategory) {
-        const response = await fetch(doc.downloadUrl, {
-          method: "GET",
-          credentials: "omit",
-        })
+        const response = await authFetch(doc.downloadUrl, { method: "GET" })
         const blob = await response.blob()
         zip.file(doc.originalFileName, blob)
       }
@@ -1037,12 +1030,14 @@ export const DocumentsSection = React.forwardRef<
 
       if (isGuid(documentId) && eventId) {
         try {
-          await fetch(`${process.env.NEXT_PUBLIC_API_URL}/documents/${documentId}`, {
-            method: "PUT",
-            credentials: "omit",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ documentType: targetCode }),
-          })
+          await authFetch(
+            `${process.env.NEXT_PUBLIC_API_URL}/documents/${documentId}`,
+            {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ documentType: targetCode }),
+            },
+          )
         } catch (error) {
           console.error("Error moving document:", error)
           toast({

--- a/components/email/email-compose.tsx
+++ b/components/email/email-compose.tsx
@@ -32,6 +32,7 @@ import {
 import { emailTemplates } from "@/lib/email-data"
 import type { EmailCompose, EmailAttachment } from "@/types/email"
 import type { UploadedFile } from "@/types"
+import { authFetch } from "@/lib/auth-fetch"
 
 interface EmailComposeProps {
   onSend: (email: EmailCompose) => void
@@ -113,7 +114,7 @@ export const EmailComposeComponent = ({
     try {
       let file = doc.file
       if (!file) {
-        const response = await fetch(doc.url)
+        const response = await authFetch(doc.url)
         const blob = await response.blob()
         file = new File([blob], doc.name, { type: blob.type || 'application/octet-stream' })
       }

--- a/components/email/email-section-compact.tsx
+++ b/components/email/email-section-compact.tsx
@@ -12,6 +12,7 @@ import { EmailView } from "./email-view"
 import { cn } from "@/lib/utils"
 import { emailService, type EmailDto } from "@/lib/email-service"
 import { API_BASE_URL } from "@/lib/api"
+import { authFetch } from "@/lib/auth-fetch"
 import {
   Mail,
   MailOpen,
@@ -151,9 +152,8 @@ export const EmailSection = ({
 
   const handleStarEmail = async (emailId: string) => {
     try {
-      await fetch(`${API_BASE_URL}/emails/${emailId}/starred`, {
+      await authFetch(`${API_BASE_URL}/emails/${emailId}/starred`, {
         method: "PUT",
-        credentials: "omit",
       })
     } catch (error) {
       console.error("Error toggling star:", error)

--- a/components/new-claim-dialog.tsx
+++ b/components/new-claim-dialog.tsx
@@ -11,6 +11,7 @@ import ClientDropdown from "@/components/client-dropdown"
 import { Button } from "@/components/ui/button"
 import type { ClientSelectionEvent } from "@/types/client"
 import { API_BASE_URL } from "@/lib/api"
+import { authFetch } from "@/lib/auth-fetch"
 
 interface RiskType {
   value: string
@@ -51,11 +52,8 @@ export function NewClaimDialog({ open, onOpenChange }: NewClaimDialogProps) {
   } = useQuery<RiskType[]>({
     queryKey: ["risk-types", claimObjectTypeId],
     queryFn: async () => {
-      const res = await fetch(
+      const res = await authFetch(
         `${API_BASE_URL}/dictionaries/risk-types?claimObjectTypeId=${claimObjectTypeId}`,
-        {
-          credentials: "omit",
-        },
       )
       const data = await res.json()
       return (data.items || []).map((item: any) => ({ value: String(item.id), label: item.name }))
@@ -69,11 +67,8 @@ export function NewClaimDialog({ open, onOpenChange }: NewClaimDialogProps) {
   } = useQuery<DamageType[]>({
     queryKey: ["damage-types", riskTypeId],
     queryFn: async () => {
-      const res = await fetch(
+      const res = await authFetch(
         `${API_BASE_URL}/damage-types?riskTypeId=${riskTypeId}`,
-        {
-          credentials: "omit",
-        },
       )
       return res.json()
     },

--- a/components/ui/dependent-select.tsx
+++ b/components/ui/dependent-select.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Loader2, AlertCircle } from "lucide-react"
+import { authFetch } from "@/lib/auth-fetch"
 
 interface Option {
   id: string
@@ -57,10 +58,7 @@ export function DependentSelect({
       url += `?${query}`
     }
 
-    const response = await fetch(url, {
-      method: "GET",
-      credentials: "omit",
-    })
+    const response = await authFetch(url, { method: "GET" })
 
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`)

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { authFetch } from "@/lib/auth-fetch"
 
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   apiEndpoint?: string
@@ -35,10 +36,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             url.searchParams.set("sortable", "true")
           }
 
-          const response = await fetch(url.toString(), {
-            method: "GET",
-            credentials: "omit",
-          })
+          const response = await authFetch(url.toString(), { method: "GET" })
           if (response.ok) {
             const data = await response.json()
             let fetchedOptions = Array.isArray(data) ? data : data.options || []

--- a/components/ui/searchable-select.tsx
+++ b/components/ui/searchable-select.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { authFetch } from "@/lib/auth-fetch"
 
 interface Option {
   value: string
@@ -39,10 +40,7 @@ export function SearchableSelect({
     const fetchOptions = async () => {
       setLoading(true)
       try {
-        const response = await fetch(apiEndpoint, {
-          method: "GET",
-          credentials: "omit",
-        })
+        const response = await authFetch(apiEndpoint, { method: "GET" })
         if (response.ok) {
           const data = await response.json()
           // Handle both array format and object format with options property

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -5,6 +5,7 @@ import * as SelectPrimitive from "@radix-ui/react-select"
 import { Check, ChevronDown, ChevronUp } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { authFetch } from "@/lib/auth-fetch"
 
 const Select = SelectPrimitive.Root
 
@@ -165,10 +166,7 @@ const DependentSelect = React.forwardRef<React.ElementRef<typeof SelectPrimitive
             url += `?${dependsOnParam}=${encodeURIComponent(dependsOn)}`
           }
 
-          const response = await fetch(url, {
-            method: "GET",
-            credentials: "omit",
-          })
+          const response = await authFetch(url, { method: "GET" })
 
           if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`)

--- a/hooks/use-damages.ts
+++ b/hooks/use-damages.ts
@@ -2,6 +2,7 @@
 
 import { useCallback } from "react"
 import { API_ENDPOINTS } from "@/lib/constants"
+import { authFetch } from "@/lib/auth-fetch"
 
 export interface Damage {
   id?: string
@@ -29,9 +30,8 @@ export function createDamageDraft(params: Partial<Damage> = {}): Damage {
 
 export function useDamages(eventId?: string) {
   const initDamage = useCallback(async (): Promise<DamageInit> => {
-    const response = await fetch(API_ENDPOINTS.DAMAGES_INIT, {
+    const response = await authFetch(API_ENDPOINTS.DAMAGES_INIT, {
       method: "POST",
-      credentials: "omit",
     })
 
     if (!response.ok) {
@@ -49,9 +49,9 @@ export function useDamages(eventId?: string) {
         throw new Error("Brak identyfikatora zdarzenia")
       }
 
-      const response = await fetch(
+      const response = await authFetch(
         `${API_ENDPOINTS.DAMAGES}/event/${targetId}`,
-        { method: "GET", credentials: "omit" },
+        { method: "GET" },
       )
 
       if (!response.ok) {
@@ -70,9 +70,8 @@ export function useDamages(eventId?: string) {
         throw new Error("Brak identyfikatora zdarzenia")
       }
 
-      const response = await fetch(API_ENDPOINTS.DAMAGES, {
+      const response = await authFetch(API_ENDPOINTS.DAMAGES, {
         method: "POST",
-        credentials: "omit",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...damage,
@@ -92,9 +91,8 @@ export function useDamages(eventId?: string) {
 
   const updateDamage = useCallback(
     async (id: string, damage: Partial<Damage>): Promise<void> => {
-      const response = await fetch(`${API_ENDPOINTS.DAMAGES}/${id}`, {
+      const response = await authFetch(`${API_ENDPOINTS.DAMAGES}/${id}`, {
         method: "PUT",
-        credentials: "omit",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ ...damage, eventId }),
       })
@@ -108,9 +106,8 @@ export function useDamages(eventId?: string) {
   )
 
   const deleteDamage = useCallback(async (id: string): Promise<void> => {
-    const response = await fetch(`${API_ENDPOINTS.DAMAGES}/${id}`, {
+    const response = await authFetch(`${API_ENDPOINTS.DAMAGES}/${id}`, {
       method: "DELETE",
-      credentials: "omit",
     })
 
     if (!response.ok) {

--- a/lib/api/appeals.ts
+++ b/lib/api/appeals.ts
@@ -1,4 +1,5 @@
 import { AppealDto, API_BASE_URL, DocumentDto } from "../api";
+import { authFetch } from "../auth-fetch";
 
 export interface Appeal {
   id: string;
@@ -58,9 +59,8 @@ function buildFormData(data: AppealUpsert, documents: File[] = []) {
 }
 
 export async function getAppeals(claimId: string): Promise<Appeal[]> {
-  const response = await fetch(`${APPEALS_URL}/event/${claimId}`, {
+  const response = await authFetch(`${APPEALS_URL}/event/${claimId}`, {
     method: "GET",
-    credentials: "omit",
   });
   if (!response.ok) {
     throw new Error("Failed to fetch appeals");
@@ -74,9 +74,8 @@ export async function createAppeal(
   documents: File[] = [],
 ): Promise<Appeal> {
   const body = buildFormData(data, documents);
-  const response = await fetch(APPEALS_URL, {
+  const response = await authFetch(APPEALS_URL, {
     method: "POST",
-    credentials: "omit",
     body,
   });
   if (!response.ok) {
@@ -92,9 +91,8 @@ export async function updateAppeal(
   documents: File[] = [],
 ): Promise<Appeal> {
   const body = buildFormData(data, documents);
-  const response = await fetch(`${APPEALS_URL}/${id}`, {
+  const response = await authFetch(`${APPEALS_URL}/${id}`, {
     method: "PUT",
-    credentials: "omit",
     body,
   });
   if (!response.ok) {
@@ -105,9 +103,8 @@ export async function updateAppeal(
 }
 
 export async function deleteAppeal(id: string): Promise<void> {
-  const response = await fetch(`${APPEALS_URL}/${id}`, {
+  const response = await authFetch(`${APPEALS_URL}/${id}`, {
     method: "DELETE",
-    credentials: "omit",
   });
   if (!response.ok) {
     throw new Error("Failed to delete appeal");

--- a/lib/api/clientclaims.ts
+++ b/lib/api/clientclaims.ts
@@ -1,5 +1,6 @@
 import { API_BASE_URL, ClientClaimDto } from "../api"
 import type { ClientClaim, ClaimStatus } from "@/types"
+import { authFetch } from "../auth-fetch"
 
 export interface ClientClaimUpsert {
   eventId?: string
@@ -59,9 +60,8 @@ export async function createClientClaim(
   documents: File[] = [],
 ): Promise<ClientClaim> {
   const body = buildFormData(data, documents)
-  const response = await fetch(CLIENT_CLAIMS_URL, {
+  const response = await authFetch(CLIENT_CLAIMS_URL, {
     method: "POST",
-    credentials: "omit",
     body,
   })
   if (!response.ok) {
@@ -78,9 +78,8 @@ export async function updateClientClaim(
   documents: File[] = [],
 ): Promise<ClientClaim> {
   const body = buildFormData(data, documents)
-  const response = await fetch(`${CLIENT_CLAIMS_URL}/${id}`, {
+  const response = await authFetch(`${CLIENT_CLAIMS_URL}/${id}`, {
     method: "PUT",
-    credentials: "omit",
     body,
   })
   if (!response.ok) {
@@ -92,9 +91,8 @@ export async function updateClientClaim(
 }
 
 export async function deleteClientClaim(id: string): Promise<void> {
-  const response = await fetch(`${CLIENT_CLAIMS_URL}/${id}`, {
+  const response = await authFetch(`${CLIENT_CLAIMS_URL}/${id}`, {
     method: "DELETE",
-    credentials: "omit",
   })
   if (!response.ok) {
     const text = await response.text()
@@ -103,9 +101,8 @@ export async function deleteClientClaim(id: string): Promise<void> {
 }
 
 export async function downloadClientClaimDocument(id: string): Promise<Blob> {
-  const response = await fetch(`${CLIENT_CLAIMS_URL}/${id}/download`, {
+  const response = await authFetch(`${CLIENT_CLAIMS_URL}/${id}/download`, {
     method: "GET",
-    credentials: "omit",
   })
   if (!response.ok) {
     throw new Error("Failed to download document")
@@ -114,9 +111,8 @@ export async function downloadClientClaimDocument(id: string): Promise<Blob> {
 }
 
 export async function previewClientClaimDocument(id: string): Promise<Blob> {
-  const response = await fetch(`${CLIENT_CLAIMS_URL}/${id}/preview`, {
+  const response = await authFetch(`${CLIENT_CLAIMS_URL}/${id}/preview`, {
     method: "GET",
-    credentials: "omit",
   })
   if (!response.ok) {
     throw new Error("Failed to preview document")

--- a/lib/api/decisions.ts
+++ b/lib/api/decisions.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { API_BASE_URL } from "../api";
+import { authFetch } from "../auth-fetch";
 
 const documentSchema = z.object({
   id: z.string(),
@@ -40,10 +41,7 @@ export const decisionUpsertSchema = decisionSchema.pick({
 export type DecisionUpsert = z.infer<typeof decisionUpsertSchema>;
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
-    credentials: "omit",
-    ...options,
-  });
+  const response = await authFetch(`${API_BASE_URL}${url}`, options);
   const text = await response.text();
   const data = text ? JSON.parse(text) : undefined;
   if (!response.ok) {

--- a/lib/api/documents.ts
+++ b/lib/api/documents.ts
@@ -1,10 +1,10 @@
 import { API_BASE_URL } from "../api";
 import type { DocumentDto } from "../api";
+import { authFetch } from "../auth-fetch";
 
 export async function deleteDocument(id: string): Promise<void> {
-  const res = await fetch(`${API_BASE_URL}/documents/${id}`, {
+  const res = await authFetch(`${API_BASE_URL}/documents/${id}`, {
     method: "DELETE",
-    credentials: "omit",
   });
   if (!res.ok) {
     const text = await res.text();
@@ -16,9 +16,8 @@ export async function renameDocument(
   id: string,
   originalFileName: string,
 ): Promise<DocumentDto> {
-  const res = await fetch(`${API_BASE_URL}/documents/${id}`, {
+  const res = await authFetch(`${API_BASE_URL}/documents/${id}`, {
     method: "PUT",
-    credentials: "omit",
     headers: {
       "Content-Type": "application/json",
     },

--- a/lib/api/recourses.ts
+++ b/lib/api/recourses.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import { API_BASE_URL } from "../api"
+import { authFetch } from "../auth-fetch"
 
 const documentSchema = z.object({
   id: z.string(),
@@ -39,10 +40,7 @@ export type Recourse = z.infer<typeof recourseSchema>
 export type RecourseUpsert = z.infer<typeof recourseUpsertSchema>
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
-    credentials: "omit",
-    ...options,
-  })
+  const response = await authFetch(`${API_BASE_URL}${url}`, options)
   const text = await response.text()
   const data = text ? JSON.parse(text) : undefined
   if (!response.ok) {
@@ -93,9 +91,8 @@ export async function deleteRecourse(id: string): Promise<void> {
 }
 
 export async function downloadRecourseDocument(id: string): Promise<Blob> {
-  const response = await fetch(`${API_BASE_URL}/recourses/${id}/download`, {
+  const response = await authFetch(`${API_BASE_URL}/recourses/${id}/download`, {
     method: "GET",
-    credentials: "omit",
   })
   if (!response.ok) {
     throw new Error("Failed to download document")
@@ -104,9 +101,8 @@ export async function downloadRecourseDocument(id: string): Promise<Blob> {
 }
 
 export async function previewRecourseDocument(id: string): Promise<Blob> {
-  const response = await fetch(`${API_BASE_URL}/recourses/${id}/preview`, {
+  const response = await authFetch(`${API_BASE_URL}/recourses/${id}/preview`, {
     method: "GET",
-    credentials: "omit",
   })
   if (!response.ok) {
     throw new Error("Failed to preview document")

--- a/lib/api/repair-details.ts
+++ b/lib/api/repair-details.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { API_BASE_URL } from "../api";
+import { authFetch } from "../auth-fetch";
 
 const repairDetailSchema = z.object({
   id: z.string(),
@@ -38,8 +39,7 @@ export type RepairDetail = z.infer<typeof repairDetailSchema>;
 export type RepairDetailUpsert = z.infer<typeof repairDetailUpsertSchema>;
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
-    credentials: "omit",
+  const response = await authFetch(`${API_BASE_URL}${url}`, {
     headers: { "Content-Type": "application/json" },
     ...options,
   });

--- a/lib/api/repair-schedules.ts
+++ b/lib/api/repair-schedules.ts
@@ -22,6 +22,7 @@ function ensureRequired(data: { vehicleFleetNumber?: string }) {
 }
 
 import { API_BASE_URL } from "../api";
+import { authFetch } from "../auth-fetch";
 
 const REPAIR_SCHEDULES_URL = `${API_BASE_URL}/repair-schedules`;
 
@@ -29,9 +30,8 @@ export async function getRepairSchedules(eventId: string) {
   const url = eventId
     ? `${REPAIR_SCHEDULES_URL}?eventId=${eventId}`
     : REPAIR_SCHEDULES_URL
-  const response = await fetch(url, {
+  const response = await authFetch(url, {
     method: 'GET',
-    credentials: 'omit',
     cache: 'no-store',
   })
   if (!response.ok) {
@@ -42,9 +42,8 @@ export async function getRepairSchedules(eventId: string) {
 
 export async function createRepairSchedule(data: RepairSchedulePayload) {
   ensureRequired(data)
-  const response = await fetch(REPAIR_SCHEDULES_URL, {
+  const response = await authFetch(REPAIR_SCHEDULES_URL, {
     method: 'POST',
-    credentials: 'omit',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   })
@@ -58,9 +57,8 @@ export async function updateRepairSchedule(id: string, data: Partial<RepairSched
   if ('vehicleFleetNumber' in data && !data.vehicleFleetNumber) {
     throw new Error('vehicleFleetNumber is required')
   }
-  const response = await fetch(`${REPAIR_SCHEDULES_URL}/${id}`, {
+  const response = await authFetch(`${REPAIR_SCHEDULES_URL}/${id}`, {
     method: 'PUT',
-    credentials: 'omit',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   })
@@ -71,9 +69,8 @@ export async function updateRepairSchedule(id: string, data: Partial<RepairSched
 }
 
 export async function deleteRepairSchedule(id: string) {
-  const response = await fetch(`${REPAIR_SCHEDULES_URL}/${id}`, {
+  const response = await authFetch(`${REPAIR_SCHEDULES_URL}/${id}`, {
     method: 'DELETE',
-    credentials: 'omit',
   })
   if (!response.ok) {
     throw new Error('Failed to delete repair schedule')

--- a/lib/api/reports.ts
+++ b/lib/api/reports.ts
@@ -1,4 +1,5 @@
 import { API_BASE_URL } from "../api";
+import { authFetch } from "../auth-fetch";
 
 export interface ReportMetadata {
   [entity: string]: string[];
@@ -13,9 +14,7 @@ export interface ReportRequest {
 }
 
 export async function getReportMetadata(): Promise<ReportMetadata> {
-  const res = await fetch(`${API_BASE_URL}/report/metadata`, {
-    credentials: "omit",
-  });
+  const res = await authFetch(`${API_BASE_URL}/report/metadata`);
   if (!res.ok) {
     throw new Error("Failed to fetch report metadata");
   }
@@ -23,9 +22,8 @@ export async function getReportMetadata(): Promise<ReportMetadata> {
 }
 
 export async function exportReport(request: ReportRequest): Promise<Blob> {
-  const res = await fetch(`${API_BASE_URL}/report/export`, {
+  const res = await authFetch(`${API_BASE_URL}/report/export`, {
     method: "POST",
-    credentials: "omit",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(request),
   });
@@ -39,11 +37,10 @@ export async function getFilterValues(
   entity: string,
   field: string,
 ): Promise<string[]> {
-  const res = await fetch(
+  const res = await authFetch(
     `${API_BASE_URL}/report/values?entity=${encodeURIComponent(
       entity,
     )}&field=${encodeURIComponent(field)}`,
-    { credentials: "omit" },
   );
   if (!res.ok) {
     throw new Error("Failed to fetch filter values");

--- a/lib/api/settlements.ts
+++ b/lib/api/settlements.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { API_BASE_URL } from "../api";
+import { authFetch } from "../auth-fetch";
 
 const documentSchema = z.object({
   id: z.string(),
@@ -53,10 +54,7 @@ export type Settlement = z.infer<typeof settlementSchema>;
 export type SettlementUpsert = z.infer<typeof settlementUpsertSchema>;
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${url}`, {
-    credentials: "omit",
-    ...options,
-  });
+  const response = await authFetch(`${API_BASE_URL}${url}`, options);
   const text = await response.text();
   let data: unknown;
   try {

--- a/lib/auth-fetch.ts
+++ b/lib/auth-fetch.ts
@@ -1,0 +1,24 @@
+import { API_BASE_URL } from "./api"
+
+function getToken(): string | null {
+  if (typeof window !== "undefined") {
+    return localStorage.getItem("token")
+  }
+  return null
+}
+
+export async function authFetch(
+  input: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const token = getToken()
+  const headers = new Headers(init.headers)
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`)
+  }
+  return fetch(input.startsWith("http") ? input : `${API_BASE_URL}${input}`, {
+    ...init,
+    credentials: "omit",
+    headers,
+  })
+}

--- a/lib/dictionary-service.ts
+++ b/lib/dictionary-service.ts
@@ -1,3 +1,5 @@
+import { authFetch } from "./auth-fetch"
+
 interface DictionaryItemDto {
   id: string | number
   code?: string
@@ -24,24 +26,10 @@ class DictionaryService {
   private cache = new Map<string, { data: DictionaryResponseDto; timestamp: number }>()
   private readonly CACHE_DURATION = 5 * 60 * 1000 // 5 minutes
 
-  private getToken(): string | null {
-    if (typeof window !== "undefined") {
-      return localStorage.getItem("token")
-    }
-    return null
-  }
-
   private async fetchFromAPI(endpoint: string): Promise<DictionaryResponseDto> {
-    const token = this.getToken()
-    const response = await fetch(
+    const response = await authFetch(
       `${process.env.NEXT_PUBLIC_API_URL}/dictionaries/${endpoint}`,
-      {
-        method: "GET",
-        credentials: "omit",
-
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-
-      },
+      { method: "GET" },
     )
     const text = await response.text()
     if (!response.ok) {

--- a/lib/email-service.ts
+++ b/lib/email-service.ts
@@ -1,5 +1,6 @@
 import { EmailFolder } from "@/types/email"
 import { API_BASE_URL } from "./api"
+import { authFetch } from "./auth-fetch"
 
 export interface AttachmentDto {
   id: string
@@ -60,9 +61,8 @@ class EmailService {
 
   async getAllEmails(): Promise<EmailDto[]> {
     try {
-      const response = await fetch(this.apiUrl, {
+      const response = await authFetch(this.apiUrl, {
         method: "GET",
-        credentials: "omit",
       })
       if (!response.ok) throw new Error("Failed to fetch emails")
       const data = await response.json()
@@ -97,9 +97,8 @@ class EmailService {
   async getEmailById(id: string): Promise<EmailDto | undefined> {
     if (!this.isValidGuid(id)) return undefined
     try {
-      const response = await fetch(`${this.apiUrl}/${id}`, {
+      const response = await authFetch(`${this.apiUrl}/${id}`, {
         method: "GET",
-        credentials: "omit",
       })
       if (!response.ok) throw new Error("Failed to fetch email")
       const e = await response.json()
@@ -134,9 +133,8 @@ class EmailService {
   async deleteEmail(emailId: string): Promise<boolean> {
     if (!this.isValidGuid(emailId)) return false
     try {
-      const response = await fetch(`${this.apiUrl}/${emailId}`, {
+      const response = await authFetch(`${this.apiUrl}/${emailId}`, {
         method: "DELETE",
-        credentials: "omit",
       })
       return response.ok
     } catch (error) {
@@ -188,9 +186,8 @@ class EmailService {
   async getEmailsByEventId(eventId: string): Promise<EmailDto[]> {
     if (!this.isValidGuid(eventId)) return []
     try {
-      const response = await fetch(`${this.apiUrl}/event/${eventId}`, {
+      const response = await authFetch(`${this.apiUrl}/event/${eventId}`, {
         method: "GET",
-        credentials: "omit",
       })
       if (!response.ok) throw new Error("Failed to fetch emails by event")
       const data = await response.json()
@@ -225,9 +222,8 @@ class EmailService {
   async markAsRead(emailId: string): Promise<boolean> {
     if (!this.isValidGuid(emailId)) return false
     try {
-      const response = await fetch(`${this.apiUrl}/${emailId}/read`, {
+      const response = await authFetch(`${this.apiUrl}/${emailId}/read`, {
         method: "PUT",
-        credentials: "omit",
       })
       return response.ok
     } catch (error) {
@@ -249,9 +245,8 @@ class EmailService {
       if (sendRequest.eventId) formData.append("eventId", sendRequest.eventId)
       sendRequest.attachments?.forEach((file) => formData.append("attachments", file))
 
-      const response = await fetch(this.apiUrl, {
+      const response = await authFetch(this.apiUrl, {
         method: "POST",
-        credentials: "omit",
         body: formData,
       })
       return response.ok
@@ -275,9 +270,8 @@ class EmailService {
       if (sendRequest.eventId) formData.append("eventId", sendRequest.eventId)
       sendRequest.attachments?.forEach((file) => formData.append("attachments", file))
 
-      const response = await fetch(`${this.apiUrl}/draft`, {
+      const response = await authFetch(`${this.apiUrl}/draft`, {
         method: "POST",
-        credentials: "omit",
         body: formData,
       })
       return response.ok
@@ -290,9 +284,8 @@ class EmailService {
   async downloadAttachment(attachmentId: string): Promise<Blob | undefined> {
     if (!this.isValidGuid(attachmentId)) return undefined
     try {
-      const response = await fetch(`${this.apiUrl}/attachment/${attachmentId}`, {
+      const response = await authFetch(`${this.apiUrl}/attachment/${attachmentId}`, {
         method: "GET",
-        credentials: "omit",
       })
       if (!response.ok) throw new Error("Failed to download attachment")
       return await response.blob()
@@ -310,9 +303,8 @@ class EmailService {
     try {
       const formData = new FormData()
       formData.append("file", file)
-      const response = await fetch(`${this.apiUrl}/${emailId}/attachments`, {
+      const response = await authFetch(`${this.apiUrl}/${emailId}/attachments`, {
         method: "POST",
-        credentials: "omit",
         body: formData,
       })
       if (!response.ok) throw new Error("Failed to upload attachment")
@@ -326,9 +318,8 @@ class EmailService {
   async deleteAttachment(attachmentId: string): Promise<boolean> {
     if (!this.isValidGuid(attachmentId)) return false
     try {
-      const response = await fetch(`${this.apiUrl}/attachment/${attachmentId}`, {
+      const response = await authFetch(`${this.apiUrl}/attachment/${attachmentId}`, {
         method: "DELETE",
-        credentials: "omit",
       })
       return response.ok
     } catch (error) {
@@ -339,9 +330,8 @@ class EmailService {
 
   async assignEmailToClaim(emailId: string, claimIds: string[]): Promise<boolean> {
     try {
-      const response = await fetch(`${this.apiUrl}/assign-to-claim`, {
+      const response = await authFetch(`${this.apiUrl}/assign-to-claim`, {
         method: "POST",
-        credentials: "omit",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ emailId, claimIds }),
       })

--- a/lib/vehicle-types.ts
+++ b/lib/vehicle-types.ts
@@ -1,5 +1,6 @@
 import type { VehicleType } from "@/types/vehicle-type"
 import { API_BASE_URL } from "./api"
+import { authFetch } from "./auth-fetch"
 
 const VEHICLE_TYPES_URL = `${API_BASE_URL}/dictionaries/vehicle-types`
 
@@ -16,9 +17,8 @@ export const vehicleTypeService = {
       }`
       console.log("Fetching vehicle types from:", url)
 
-      const response = await fetch(url, {
+      const response = await authFetch(url, {
         method: "GET",
-        credentials: "omit",
       })
 
       if (!response.ok) {
@@ -53,9 +53,8 @@ export const vehicleTypeService = {
 
   async getVehicleTypeById(id: string): Promise<VehicleType | null> {
     try {
-      const response = await fetch(`${VEHICLE_TYPES_URL}/${id}`, {
+      const response = await authFetch(`${VEHICLE_TYPES_URL}/${id}`, {
         method: "GET",
-        credentials: "omit",
       })
 
       if (!response.ok) {

--- a/public/passengercar.svg
+++ b/public/passengercar.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+  <rect width="100" height="50" fill="#e5e7eb"/>
+  <text x="50" y="25" font-size="10" text-anchor="middle" fill="#6b7280">passengercar</text>
+</svg>

--- a/public/suv.svg
+++ b/public/suv.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+  <rect width="100" height="50" fill="#e5e7eb"/>
+  <text x="50" y="25" font-size="10" text-anchor="middle" fill="#6b7280">suv</text>
+</svg>

--- a/public/tractor.svg
+++ b/public/tractor.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+  <rect width="100" height="50" fill="#e5e7eb"/>
+  <text x="50" y="25" font-size="10" text-anchor="middle" fill="#6b7280">tractor</text>
+</svg>

--- a/public/trailer.svg
+++ b/public/trailer.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+  <rect width="100" height="50" fill="#e5e7eb"/>
+  <text x="50" y="25" font-size="10" text-anchor="middle" fill="#6b7280">trailer</text>
+</svg>

--- a/public/truck.svg
+++ b/public/truck.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50">
+  <rect width="100" height="50" fill="#e5e7eb"/>
+  <text x="50" y="25" font-size="10" text-anchor="middle" fill="#6b7280">truck</text>
+</svg>


### PR DESCRIPTION
## Summary
- apply `authFetch` across claim form sections, document handling, email tools, and shared selects to include auth tokens on API calls
- ensure repair schedule API service uses `authFetch`

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(interactive ESLint configuration required)*

------
https://chatgpt.com/codex/tasks/task_e_68ac578659c8832cb15b7a7afe7cd5f6