### PR TITLE
Fix duplicate API segment in document URLs

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -1785,7 +1785,8 @@ namespace AutomotiveClaimsApi.Controllers
 
         private ClaimDto MapEventToDto(Event e)
         {
-            var baseUrl = _config["App:BaseUrl"];
+            var baseUrl = (_config["App:BaseUrl"] ?? string.Empty).TrimEnd('/');
+            var apiBaseUrl = baseUrl.EndsWith("/api") ? baseUrl : $"{baseUrl}/api";
             return new ClaimDto
             {
             Id = e.Id.ToString(),
@@ -1933,8 +1934,8 @@ namespace AutomotiveClaimsApi.Controllers
                 IsActive = !d.IsDeleted,
                 CreatedAt = d.CreatedAt,
                 UpdatedAt = d.UpdatedAt,
-                DownloadUrl = $"{baseUrl}/api/documents/{d.Id}/download",
-                PreviewUrl = $"{baseUrl}/api/documents/{d.Id}/preview",
+                DownloadUrl = $"{apiBaseUrl}/documents/{d.Id}/download",
+                PreviewUrl = $"{apiBaseUrl}/documents/{d.Id}/preview",
                 CanPreview = true
 
             }).ToList(),

--- a/backend/Controllers/DecisionsController.cs
+++ b/backend/Controllers/DecisionsController.cs
@@ -295,7 +295,8 @@ namespace AutomotiveClaimsApi.Controllers
 
         private async Task<DecisionDto> MapToDto(Decision d)
         {
-            var baseUrl = _config["App:BaseUrl"] ?? string.Empty;
+            var baseUrl = (_config["App:BaseUrl"] ?? string.Empty).TrimEnd('/');
+            var apiBaseUrl = baseUrl.EndsWith("/api") ? baseUrl : $"{baseUrl}/api";
 
             var documents = await _context.Documents
                 .Where(doc => doc.RelatedEntityId == d.Id && doc.RelatedEntityType == "Decision" && !doc.IsDeleted)
@@ -305,8 +306,8 @@ namespace AutomotiveClaimsApi.Controllers
                     OriginalFileName = doc.OriginalFileName,
                     FileName = doc.FileName,
                     FilePath = doc.FilePath,
-                    DownloadUrl = $"{baseUrl}/api/documents/{doc.Id}/download",
-                    PreviewUrl = $"{baseUrl}/api/documents/{doc.Id}/preview"
+                    DownloadUrl = $"{apiBaseUrl}/documents/{doc.Id}/download",
+                    PreviewUrl = $"{apiBaseUrl}/documents/{doc.Id}/preview"
                 })
                 .ToListAsync();
 

--- a/backend/Controllers/DocumentsController.cs
+++ b/backend/Controllers/DocumentsController.cs
@@ -200,7 +200,8 @@ namespace AutomotiveClaimsApi.Controllers
         private DocumentDto MapToDto(Document doc)
 
         {
-            var baseUrl = _config["App:BaseUrl"] ?? string.Empty;
+            var baseUrl = (_config["App:BaseUrl"] ?? string.Empty).TrimEnd('/');
+            var apiBaseUrl = baseUrl.EndsWith("/api") ? baseUrl : $"{baseUrl}/api";
             return new DocumentDto
             {
                 Id = doc.Id,
@@ -218,8 +219,8 @@ namespace AutomotiveClaimsApi.Controllers
                 Status = doc.Status,
                 CreatedAt = doc.CreatedAt,
                 UpdatedAt = doc.UpdatedAt,
-                DownloadUrl = $"{baseUrl}/api/documents/{doc.Id}/download",
-                PreviewUrl = $"{baseUrl}/api/documents/{doc.Id}/preview",
+                DownloadUrl = $"{apiBaseUrl}/documents/{doc.Id}/download",
+                PreviewUrl = $"{apiBaseUrl}/documents/{doc.Id}/preview",
                 CanPreview = true // Simplified
             };
         }

--- a/backend/Services/DocumentService.cs
+++ b/backend/Services/DocumentService.cs
@@ -336,7 +336,8 @@ namespace AutomotiveClaimsApi.Services
         private DocumentDto MapToDto(Document doc)
 
         {
-            var baseUrl = _config["App:BaseUrl"] ?? string.Empty;
+            var baseUrl = (_config["App:BaseUrl"] ?? string.Empty).TrimEnd('/');
+            var apiBaseUrl = baseUrl.EndsWith("/api") ? baseUrl : $"{baseUrl}/api";
             return new DocumentDto
             {
                 Id = doc.Id,
@@ -354,8 +355,8 @@ namespace AutomotiveClaimsApi.Services
                 Status = doc.Status,
                 CreatedAt = doc.CreatedAt,
                 UpdatedAt = doc.UpdatedAt,
-                DownloadUrl = $"{baseUrl}/api/documents/{doc.Id}/download",
-                PreviewUrl = $"{baseUrl}/api/documents/{doc.Id}/preview",
+                DownloadUrl = $"{apiBaseUrl}/documents/{doc.Id}/download",
+                PreviewUrl = $"{apiBaseUrl}/documents/{doc.Id}/preview",
                 CanPreview = true
             };
         }


### PR DESCRIPTION
## Summary
- Normalize configured base URL and append `/api` only when missing
- Use sanitized API base for document preview/download links across controllers and services

## Testing
- ❌ `dotnet test backend/AutomotiveClaimsApi.Tests/AutomotiveClaimsApi.Tests.csproj` *(dotnet: command not found)*
- ⚠️ `apt-get update` *(403 errors, unable to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68aca2c90ca0832caf76a4494bea64cc