### PR TITLE
Remove border from repair schedule empty state icon

### DIFF
--- a/components/claim-form/repair-schedule-section.tsx
+++ b/components/claim-form/repair-schedule-section.tsx
@@ -743,7 +743,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
           <Card className="col-span-full w-full border-2 border-dashed border-border bg-muted/20 rounded-2xl animate-fade-in">
             <CardContent className="text-center py-16">
               <div className="space-y-4">
-                <div className="p-6 bg-primary/10 rounded-2xl w-fit mx-auto border border-border">
+                <div className="p-6 bg-primary/10 rounded-2xl w-fit mx-auto">
                   <Calendar className="h-16 w-16 text-primary" />
                 </div>
                 <div className="space-y-2">


### PR DESCRIPTION
## Summary
- remove unnecessary border from empty repair schedule calendar icon

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_e_68aca477368c832cba35baaad8d2ee27