### PR TITLE
feat: expose roles endpoint for admin panel

### DIFF
--- a/backend/Controllers/RolesController.cs
+++ b/backend/Controllers/RolesController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AutomotiveClaimsApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class RolesController : ControllerBase
+    {
+        private readonly RoleManager<IdentityRole> _roleManager;
+
+        public RolesController(RoleManager<IdentityRole> roleManager)
+        {
+            _roleManager = roleManager;
+        }
+
+        [HttpGet]
+        [Authorize]
+        public async Task<IActionResult> GetRoles()
+        {
+            var roles = await _roleManager.Roles
+                .Select(r => new { value = r.Name, label = r.Name })
+                .ToListAsync();
+            return Ok(roles);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add API endpoint to list user roles for admin UI

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca76b5044832cb06a5c7308a942cd