### PR TITLE
Map registration number and risk type by id

### DIFF
--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -75,7 +75,7 @@ export function ClaimsList({
   >([])
   const [filterRisk, setFilterRisk] = useState("all")
   const [riskTypes, setRiskTypes] = useState<
-    { id: string; code: string; name: string }[]
+    { id: number; code: string; name: string }[]
   >([])
   const [filterRegistration, setFilterRegistration] = useState("")
   const [filterHandler, setFilterHandler] = useState("")
@@ -140,7 +140,7 @@ export function ClaimsList({
         const data = await dictionaryService.getRiskTypes(claimObjectTypeId)
 
         setRiskTypes(
-          (data.items ?? []) as { id: string; code: string; name: string }[],
+          (data.items ?? []) as { id: number; code: string; name: string }[],
         )
       } catch (error) {
         console.error("Error loading risk types:", error)
@@ -217,7 +217,7 @@ export function ClaimsList({
   const riskTypeMap = useMemo(() => {
     const map: Record<string, string> = {}
     riskTypes.forEach((r) => {
-      map[r.code.toLowerCase()] = r.name
+      map[String(r.id)] = r.name
     })
     return map
   }, [riskTypes])
@@ -475,7 +475,7 @@ export function ClaimsList({
             >
               <option value="all">Wszystkie ryzyka</option>
               {riskTypes.map((risk) => (
-                <option key={risk.id} value={risk.code}>
+                <option key={risk.id} value={risk.id.toString()}>
                   {risk.name}
                 </option>
               ))}
@@ -674,7 +674,7 @@ export function ClaimsList({
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       {claim.riskType
-                        ? riskTypeMap[String(claim.riskType).toLowerCase()] ||
+                        ? riskTypeMap[String(claim.riskType)] ||
                           String(claim.riskType)
                         : "-"}
                     </td>

--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -7,14 +7,14 @@ import { transformFrontendClaimToApiPayload } from '../use-claims'
 
 test('includes dropdown selections in payload', () => {
   const payload = transformFrontendClaimToApiPayload({
-    riskType: 'RT',
+    riskType: '5',
     damageType: { code: 'DT', name: 'Damage' } as any,
     insuranceCompanyId: '5',
     clientId: '7',
     handlerId: '9',
   } as any)
 
-  assert.equal(payload.riskType, 'RT')
+  assert.equal(payload.riskType, '5')
   assert.equal(payload.damageType, 'DT')
   assert.equal(payload.insuranceCompanyId, 5)
   assert.equal(payload.clientId, 7)
@@ -72,6 +72,16 @@ test('participant and driver ids include only GUID strings', () => {
   assert.equal(invalidDriver?.id, undefined)
   assert.equal(perpetrator?.id, undefined)
   assert.equal(perpetrator?.drivers?.[0]?.id, guid)
+})
+
+test('maps registration numbers from participants', () => {
+  const payload = transformFrontendClaimToApiPayload({
+    injuredParty: { vehicleRegistration: 'ABC123' },
+    perpetrator: { vehicleRegistration: 'DEF456' },
+  } as any)
+
+  assert.equal(payload.victimRegistrationNumber, 'ABC123')
+  assert.equal(payload.perpetratorRegistrationNumber, 'DEF456')
 })
 
 test('settlement ids are validated and converted', () => {

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -264,6 +264,8 @@ export const transformFrontendClaimToApiPayload = (
     leasingCompanyId: leasingCompanyId ? parseInt(leasingCompanyId, 10) : undefined,
     clientId: clientId ? parseInt(clientId, 10) : undefined,
     handlerId: handlerId ? parseInt(handlerId, 10) : undefined,
+    victimRegistrationNumber: injuredParty?.vehicleRegistration,
+    perpetratorRegistrationNumber: perpetrator?.vehicleRegistration,
     riskType,
     ...(damageTypeValue ? { damageType: damageTypeValue } : {}),
     damageDate: toIso(rest.damageDate, "damageDate"),


### PR DESCRIPTION
## Summary
- Populate victim and perpetrator registration numbers from participant data when sending claim payloads
- Look up risk types by numeric id in the claims list
- Test mapping of registration numbers from participants

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68acac660578832c83466f0b3a6e7ba1