### PR TITLE
Add sort order for vehicle types and revert to GUID IDs

### DIFF
--- a/backend/Controllers/DictionariesController.cs
+++ b/backend/Controllers/DictionariesController.cs
@@ -164,13 +164,14 @@ namespace AutomotiveClaimsApi.Controllers
             {
                 var vehicleTypes = await _context.VehicleTypes
                     .Where(v => v.IsActive)
-                    .OrderBy(v => v.Name)
+                    .OrderBy(v => v.SortOrder)
                     .Select(v => new DictionaryItemDto
                     {
                         Id = v.Id.ToString(),
                         Name = v.Name,
                         Code = v.Code,
-                        IsActive = v.IsActive
+                        IsActive = v.IsActive,
+                        SortOrder = v.SortOrder
                     })
                     .ToListAsync();
 

--- a/backend/Migrations/20240130000008_CreateDictionaryTables.cs
+++ b/backend/Migrations/20240130000008_CreateDictionaryTables.cs
@@ -170,6 +170,8 @@ namespace AutomotiveClaimsApi.Migrations
                     Code = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
                     Name = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     Description = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: true),
+                    SortOrder = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
                     IsActive = table.Column<bool>(type: "bit", nullable: false),
                     CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
                     UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
@@ -315,6 +317,11 @@ namespace AutomotiveClaimsApi.Migrations
                 name: "IX_VehicleTypes_IsActive",
                 table: "VehicleTypes",
                 column: "IsActive");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VehicleTypes_SortOrder",
+                table: "VehicleTypes",
+                column: "SortOrder");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Priorities_Code",

--- a/backend/Models/Dictionary/VehicleType.cs
+++ b/backend/Models/Dictionary/VehicleType.cs
@@ -18,7 +18,9 @@ namespace AutomotiveClaimsApi.Models.Dictionary
         public string? Description { get; set; }
         
         public bool IsActive { get; set; } = true;
-        
+
+        public int? SortOrder { get; set; }
+
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
     }

--- a/lib/vehicle-types.ts
+++ b/lib/vehicle-types.ts
@@ -46,6 +46,7 @@ export const vehicleTypeService = {
           label: type.label ?? type.name,
           value: type.value ?? type.code,
           isActive: type.isActive,
+          sortOrder: type.sortOrder,
         }))
     } catch (error) {
       console.error("Error fetching vehicle types:", error)
@@ -75,6 +76,7 @@ export const vehicleTypeService = {
           label: item.label ?? item.name,
           value: item.value ?? item.code,
           isActive: item.isActive,
+          sortOrder: item.sortOrder,
         }
       }
 

--- a/scripts/015_create_dictionary_tables.sql
+++ b/scripts/015_create_dictionary_tables.sql
@@ -99,10 +99,13 @@ CREATE TABLE VehicleTypes (
     Code NVARCHAR(50) NOT NULL UNIQUE,
     Name NVARCHAR(255) NOT NULL,
     Description NVARCHAR(1000),
+    SortOrder INT IDENTITY(1,1) NOT NULL,
     IsActive BIT NOT NULL DEFAULT 1,
     CreatedAt DATETIME2 NOT NULL DEFAULT GETUTCDATE(),
     UpdatedAt DATETIME2 NOT NULL DEFAULT GETUTCDATE()
 );
+
+CREATE INDEX IX_VehicleTypes_SortOrder ON VehicleTypes(SortOrder);
 
 -- Priorities table
 CREATE TABLE Priorities (

--- a/scripts/018_create_complete_dictionary_tables.sql
+++ b/scripts/018_create_complete_dictionary_tables.sql
@@ -130,12 +130,14 @@ CREATE TABLE IF NOT EXISTS VehicleTypes (
     Code VARCHAR(50) NOT NULL UNIQUE,
     Name VARCHAR(200) NOT NULL,
     Description VARCHAR(500),
+    SortOrder SERIAL NOT NULL,
     IsActive BOOLEAN NOT NULL DEFAULT TRUE,
     CreatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     UpdatedAt TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_vehicle_types_code ON VehicleTypes(Code);
 CREATE INDEX IF NOT EXISTS idx_vehicle_types_is_active ON VehicleTypes(IsActive);
+CREATE INDEX IF NOT EXISTS idx_vehicle_types_sort_order ON VehicleTypes(SortOrder);
 
 -- Priorities table
 CREATE TABLE IF NOT EXISTS Priorities (

--- a/types/vehicle-type.ts
+++ b/types/vehicle-type.ts
@@ -5,6 +5,7 @@ export interface VehicleType {
   label: string
   value: string
   isActive: boolean
+  sortOrder?: number
 }
 
 export interface VehicleTypeSelectionEvent {


### PR DESCRIPTION
## Summary
- add SortOrder column to VehicleTypes tables and scripts
- order VehicleTypes dictionary results by SortOrder
- revert frontend and types to use string IDs for vehicle types

## Testing
- `npm test` (fails: ModuleLoader.importSyncForRequire)
- `dotnet test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68aca87edbcc832caa5a92a0cad71aad