### PR TITLE
feat: add mobile sidebar controls and fix user creation

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -6,8 +6,7 @@ import { useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { Users, Shield, BarChart3, Menu, X, UserCheck, Lock } from "lucide-react"
+import { Users, Shield, BarChart3, Menu, X, Lock } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 const navigation = [
@@ -58,7 +57,18 @@ export default function AdminLayout({
       >
         <div className="flex h-full flex-col">
           {/* Header */}
-          
+          <div className="flex h-16 items-center justify-between border-b px-4">
+            <span className="font-semibold">Admin</span>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="lg:hidden"
+              onClick={() => setSidebarOpen(false)}
+            >
+              <X className="h-5 w-5" />
+              <span className="sr-only">Close sidebar</span>
+            </Button>
+          </div>
 
           {/* Navigation */}
           <nav className="flex-1 space-y-1 px-4 py-4">
@@ -94,7 +104,18 @@ export default function AdminLayout({
       {/* Main content */}
       <div className="lg:pl-64">
         {/* Top bar */}
-        
+        <div className="flex h-16 items-center border-b px-4 lg:px-6">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="lg:hidden"
+            onClick={() => setSidebarOpen(true)}
+          >
+            <Menu className="h-5 w-5" />
+            <span className="sr-only">Open sidebar</span>
+          </Button>
+          <h1 className="ml-2 text-lg font-semibold">Panel administratora</h1>
+        </div>
 
         {/* Page content */}
         <main className="flex-1 p-6">{children}</main>

--- a/lib/services/admin-service.ts
+++ b/lib/services/admin-service.ts
@@ -79,6 +79,20 @@ export const adminService = {
       fullAccess: data.fullAccess,
       clientIds: data.clientIds,
     });
+
+    // try to locate the newly created user and update remaining fields
+    const { items } = await apiService.getUsers({ search: data.email })
+    const created = items.find((u) => u.email === data.email)
+    if (created) {
+      await apiService.updateUser(created.id, {
+        firstName: data.firstName,
+        lastName: data.lastName,
+        roles: data.roles.map((r) => r.id),
+        status: data.status,
+        fullAccess: data.fullAccess,
+        clientIds: data.clientIds,
+      });
+    }
   },
 
   async deleteUser(id: string): Promise<void> {


### PR DESCRIPTION
## Summary
- add header and menu button to admin sidebar for mobile
- show top bar with menu toggle and title
- persist details when creating a new user in the admin panel

## Testing
- `pnpm test` *(fails: Cannot require() ES Module in a cycle)*
- `pnpm lint` *(fails: requires Next.js ESLint plugin configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68acbc8d35d8832c9d369f3d8586b7f7