### PR TITLE
Ensure Google Cloud Storage bucket exists before operations

### DIFF
--- a/backend/AutomotiveClaimsApi.Tests/GoogleCloudStorageServiceTests.cs
+++ b/backend/AutomotiveClaimsApi.Tests/GoogleCloudStorageServiceTests.cs
@@ -45,6 +45,16 @@ namespace AutomotiveClaimsApi.Tests
                 _storage.Remove(objectName);
                 return Task.CompletedTask;
             }
+
+            public override Task<Bucket> GetBucketAsync(string bucket, GetBucketOptions options = null, CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(new Bucket { Name = bucket });
+            }
+
+            public override Task<Bucket> CreateBucketAsync(string projectId, Bucket bucket, CreateBucketOptions options = null, CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(bucket);
+            }
         }
 
         [Fact]
@@ -53,7 +63,8 @@ namespace AutomotiveClaimsApi.Tests
             var settings = Options.Create(new GoogleCloudStorageSettings
             {
                 Enabled = true,
-                BucketName = "test-bucket"
+                BucketName = "test-bucket",
+                ProjectId = "test-project"
             });
             var client = new FakeStorageClient();
             var service = new GoogleCloudStorageService(settings, NullLogger<GoogleCloudStorageService>.Instance, client);


### PR DESCRIPTION
## Summary
- add `EnsureBucketExistsAsync` to create bucket when missing
- reset stream before upload and verify bucket for upload, download, delete
- extend fake storage client and tests with bucket/project settings

## Testing
- `dotnet test` *(fails: command not found)*
- `sudo apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68acceda23c8832c9bfa74146c3f5608