### PR TITLE
Fix user creation to include profile and role data

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -925,6 +925,10 @@ class ApiService {
     userName: string
     email?: string
     password: string
+    firstName?: string
+    lastName?: string
+    roles?: string[]
+    status?: "active" | "inactive"
     fullAccess?: boolean
     clientIds?: number[]
   }): Promise<void> {

--- a/lib/services/admin-service.ts
+++ b/lib/services/admin-service.ts
@@ -76,23 +76,13 @@ export const adminService = {
       userName: data.email,
       email: data.email,
       password: data.password,
+      firstName: data.firstName,
+      lastName: data.lastName,
+      roles: data.roles.map((r) => r.id),
+      status: data.status,
       fullAccess: data.fullAccess,
       clientIds: data.clientIds,
-    });
-
-    // try to locate the newly created user and update remaining fields
-    const { items } = await apiService.getUsers({ search: data.email })
-    const created = items.find((u) => u.email === data.email)
-    if (created) {
-      await apiService.updateUser(created.id, {
-        firstName: data.firstName,
-        lastName: data.lastName,
-        roles: data.roles.map((r) => r.id),
-        status: data.status,
-        fullAccess: data.fullAccess,
-        clientIds: data.clientIds,
-      });
-    }
+    })
   },
 
   async deleteUser(id: string): Promise<void> {


### PR DESCRIPTION
## Summary
- send full user details (names, roles, status, access) during creation
- simplify admin service by removing secondary update call

## Testing
- `pnpm test` *(fails: Module _compile etc)*

------
https://chatgpt.com/codex/tasks/task_e_68acd9c05c48832c861518bb6272adce