### PR TITLE
Forward authorization header for document preview

### DIFF
--- a/app/api/clientclaims/[id]/preview/route.ts
+++ b/app/api/clientclaims/[id]/preview/route.ts
@@ -6,7 +6,9 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const { id } = params
 
-    const response = await fetch(`${API_BASE_URL}/clientclaims/${id}/preview`)
+    const response = await fetch(`${API_BASE_URL}/clientclaims/${id}/preview`, {
+      headers: { authorization: request.headers.get("authorization") ?? "" },
+    })
 
     if (!response.ok) {
       const errorText = await response.text()

--- a/app/api/documents/[id]/preview/route.ts
+++ b/app/api/documents/[id]/preview/route.ts
@@ -6,6 +6,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const response = await fetch(`${API_BASE_URL}/documents/${params.id}/preview`, {
       method: "GET",
+      headers: { authorization: request.headers.get("authorization") ?? "" },
     })
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- forward incoming auth header when requesting backend document previews
- forward auth header for client claim preview

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_68acd9296268832cb9e8e4f27279cc75