### PR TITLE
Forward auth header for file downloads

### DIFF
--- a/app/api/appeals/[id]/documents/[docId]/download/route.ts
+++ b/app/api/appeals/[id]/documents/[docId]/download/route.ts
@@ -11,6 +11,7 @@ export async function GET(
       `${API_BASE_URL}/appeals/${params.id}/documents/${params.docId}/download`,
       {
         method: "GET",
+        headers: { authorization: request.headers.get("authorization") ?? "" },
       },
     )
 

--- a/app/api/appeals/[id]/download/route.ts
+++ b/app/api/appeals/[id]/download/route.ts
@@ -11,6 +11,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
     if (process.env.NEXT_PUBLIC_API_URL) {
       const response = await fetch(`${API_BASE_URL}/appeals/${id}/download`, {
         method: "GET",
+        headers: { authorization: request.headers.get("authorization") ?? "" },
       })
 
       if (!response.ok) {

--- a/app/api/clientclaims/[id]/download/route.ts
+++ b/app/api/clientclaims/[id]/download/route.ts
@@ -6,7 +6,9 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const { id } = params
 
-    const response = await fetch(`${API_BASE_URL}/clientclaims/${id}/download`)
+    const response = await fetch(`${API_BASE_URL}/clientclaims/${id}/download`, {
+      headers: { authorization: request.headers.get("authorization") ?? "" },
+    })
 
     if (!response.ok) {
       const errorText = await response.text()

--- a/app/api/documents/[id]/download/route.ts
+++ b/app/api/documents/[id]/download/route.ts
@@ -6,6 +6,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const response = await fetch(`${API_BASE_URL}/documents/${params.id}/download`, {
       method: "GET",
+      headers: { authorization: request.headers.get("authorization") ?? "" },
     })
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- forward authorization header to document download API
- forward authorization header to appeals download endpoints
- forward authorization header to client claim download endpoint

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*
- `pnpm test` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_68ace424cd30832cbc943eb10bbb885c