### PR TITLE
feat: show counts for claim sections

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -315,6 +315,32 @@ export default function ClaimPage() {
             activeClaimSection={activeClaimSection}
             setActiveClaimSection={setActiveClaimSection}
             claimObjectType={claim?.objectTypeId?.toString()}
+            counts={{
+              roszczenia:
+                (mode === "view"
+                  ? claim?.clientClaims?.length
+                  : claimFormData.clientClaims?.length) || 0,
+              decyzje:
+                (mode === "view"
+                  ? claim?.decisions?.length
+                  : claimFormData.decisions?.length) || 0,
+              odwolanie:
+                (mode === "view"
+                  ? claim?.appeals?.length
+                  : claimFormData.appeals?.length) || 0,
+              regres:
+                (mode === "view"
+                  ? claim?.recourses?.length
+                  : claimFormData.recourses?.length) || 0,
+              ugody:
+                (mode === "view"
+                  ? claim?.settlements?.length
+                  : claimFormData.settlements?.length) || 0,
+              notatki:
+                (mode === "view"
+                  ? claim?.notes?.length
+                  : claimFormData.notes?.length) || 0,
+            }}
           />
           <div ref={contentRef} className="flex-1 overflow-y-auto bg-gray-50">
             <div className="p-6 min-h-full">

--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -204,6 +204,14 @@ export default function EditClaimPage() {
           activeClaimSection={activeClaimSection}
           setActiveClaimSection={setActiveClaimSection}
           claimObjectType={claimFormData.objectTypeId?.toString()}
+          counts={{
+            roszczenia: claimFormData.clientClaims?.length || 0,
+            decyzje: claimFormData.decisions?.length || 0,
+            odwolanie: claimFormData.appeals?.length || 0,
+            regres: claimFormData.recourses?.length || 0,
+            ugody: claimFormData.settlements?.length || 0,
+            notatki: claimFormData.notes?.length || 0,
+          }}
         />
         <div ref={contentRef} className="flex-1 overflow-y-auto bg-gray-50">
           <div className="p-6 min-h-full">

--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -421,6 +421,14 @@ export default function NewClaimPage() {
           activeClaimSection={activeClaimSection}
           setActiveClaimSection={setActiveClaimSection}
           claimObjectType={claimObjectType}
+          counts={{
+            roszczenia: claimFormData.clientClaims?.length || 0,
+            decyzje: claimFormData.decisions?.length || 0,
+            odwolanie: claimFormData.appeals?.length || 0,
+            regres: claimFormData.recourses?.length || 0,
+            ugody: claimFormData.settlements?.length || 0,
+            notatki: claimFormData.notes?.length || 0,
+          }}
         />
 
         <div ref={contentRef} className="flex-1 overflow-y-auto bg-gray-50">

--- a/components/claim-form/claim-form-sidebar.tsx
+++ b/components/claim-form/claim-form-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
+import { Badge } from "@/components/ui/badge"
 import {
   FileText,
   AlertTriangle,
@@ -24,6 +25,7 @@ interface ClaimFormSidebarProps {
   activeClaimSection: string
   setActiveClaimSection: (section: string) => void
   claimObjectType?: string
+  counts?: Record<string, number>
 }
 
 const sidebarSections = [
@@ -122,7 +124,12 @@ const sidebarSections = [
   },
 ]
 
-function ClaimFormSidebar({ activeClaimSection, setActiveClaimSection, claimObjectType }: ClaimFormSidebarProps) {
+function ClaimFormSidebar({
+  activeClaimSection,
+  setActiveClaimSection,
+  claimObjectType,
+  counts,
+}: ClaimFormSidebarProps) {
   const sections = sidebarSections.map((section) => {
     let items = section.items
     if (claimObjectType === "3") {
@@ -149,6 +156,7 @@ function ClaimFormSidebar({ activeClaimSection, setActiveClaimSection, claimObje
                 {section.items.map((item) => {
                   const Icon = item.icon
                   const isActive = activeClaimSection === item.id
+                  const count = counts?.[item.id] ?? 0
 
                   return (
                     <Button
@@ -166,10 +174,20 @@ function ClaimFormSidebar({ activeClaimSection, setActiveClaimSection, claimObje
                         <div className={`mt-0.5 ${isActive ? "text-blue-700" : "text-gray-400"}`}>
                           <Icon className="h-4 w-4" />
                         </div>
-                        <div className="flex-1 min-w-0">
-                          <div className={`text-sm font-medium ${isActive ? "text-blue-700 font-semibold" : "text-gray-900"}`}>
+                        <div className="flex-1 min-w-0 flex items-center justify-between">
+                          <div
+                            className={`text-sm font-medium ${isActive ? "text-blue-700 font-semibold" : "text-gray-900"}`}
+                          >
                             {item.label}
                           </div>
+                          {count > 0 && (
+                            <Badge
+                              variant="secondary"
+                              className="ml-2 bg-blue-100 text-blue-800"
+                            >
+                              {count}
+                            </Badge>
+                          )}
                         </div>
                       </div>
                     </Button>


### PR DESCRIPTION
## Summary
- show badges with counts for notes, decisions, appeals, recourses, settlements and client claims in the sidebar
- pass section counts from claim form pages to sidebar

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Module._compile error)*

------
https://chatgpt.com/codex/tasks/task_e_68acad050e5c832cb9191b8d4985e821