### PR TITLE
fix: use local dashboard api route

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -75,13 +75,20 @@ function HomePage({ user, onLogout }: PageProps) {
   useEffect(() => {
     async function loadStats() {
       try {
-        const res = await fetch(`${API_BASE_URL}/dashboard/user`);
-        if (!res.ok) throw new Error("Failed to fetch dashboard stats");
+        const res = await fetch("/api/dashboard");
+        if (!res.ok) {
+          console.warn(
+            "Failed to fetch dashboard stats:",
+            res.status,
+            res.statusText,
+          );
+          return;
+        }
         const data = await res.json();
         setStats([
           { ...initialStats[0], value: data.totalClaims?.toString() },
           { ...initialStats[1], value: data.activeClaims?.toString() },
-          { ...initialStats[2], value: data.closedClaims?.toString() }
+          { ...initialStats[2], value: data.closedClaims?.toString() },
         ]);
       } catch (err) {
         console.error("Error fetching dashboard stats:", err);


### PR DESCRIPTION
## Summary
- use app API route for dashboard stats fetch
- log a warning instead of throwing when stats endpoint is unavailable

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)*

------
https://chatgpt.com/codex/tasks/task_e_68acf73fa830832cb127b22991754229