### PR TITLE
fix: include auth token when fetching roles

### DIFF
--- a/lib/services/admin-service.ts
+++ b/lib/services/admin-service.ts
@@ -9,7 +9,15 @@ const ROLE_COLORS: Record<string, string> = {
 
 export const adminService = {
   async getRoles(): Promise<Role[]> {
-    const res = await fetch(`${API_BASE_URL}/roles`);
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("token") : null;
+
+    const res = await fetch(`${API_BASE_URL}/roles`, {
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
 
     // Handle cases where the response has no body or invalid JSON
     const text = await res.text();


### PR DESCRIPTION
## Summary
- include stored token in role-fetch request so admin panel can list roles

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68acf5ed7268832c988c6f552e7f8fa7