### PR TITLE
Use generateId helper instead of crypto.randomUUID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+node_modules/
 /.next/cache/webpack/client-development/0.pack.gz
 /.next/cache/webpack/client-development/1.pack.gz
 /.next/cache/webpack/client-development/2.pack.gz

--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -20,6 +20,7 @@ import { useUnsavedChangesWarning, UNSAVED_CHANGES_MESSAGE } from '@/hooks/use-u
 import type { Claim, ParticipantInfo, UploadedFile, RequiredDocument } from '@/types'
 import { getRequiredDocumentsByObjectType } from '@/lib/required-documents'
 import { authFetch } from '@/lib/auth-fetch'
+import { generateId } from '@/lib/constants'
 
 interface ClaimFormProps {
   initialData?: Claim
@@ -32,7 +33,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
   const { toast } = useToast()
   useUnsavedChangesWarning(mode !== 'view')
   const [formData, setFormData] = useState<Claim>({
-    id: initialData?.id || crypto.randomUUID(),
+    id: initialData?.id || generateId(),
     spartaNumber: '',
     claimNumber: '',
     insurerClaimNumber: '',

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Checkbox } from "@/components/ui/checkbox"
 import { renameDocument } from "@/lib/api/documents"
 import { authFetch } from "@/lib/auth-fetch"
+import { generateId } from "@/lib/constants"
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -517,7 +518,7 @@ export const DocumentsSection = React.forwardRef<
       )
       const successfulUploadsWithIds = successfulUploads.map((doc) => ({
         ...doc,
-        id: doc.id?.toString() ?? crypto.randomUUID(),
+        id: doc.id?.toString() ?? generateId(),
       }))
 
       if (successfulUploadsWithIds.length > 0) {

--- a/hooks/use-claim-form.ts
+++ b/hooks/use-claim-form.ts
@@ -7,7 +7,7 @@ import type { Claim, ParticipantInfo, DriverInfo } from "@/types"
 export function useClaimForm(initialData?: Partial<Claim>) {
   const [claimFormData, setClaimFormData] = useState<Partial<Claim>>({
     ...initialClaimFormData,
-    id: initialData?.id ?? crypto.randomUUID(),
+    id: initialData?.id ?? generateId(),
     ...initialData,
   })
 

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -9,6 +9,7 @@ import {
   type ParticipantUpsertDto,
 } from "@/lib/api"
 import type { Claim, ParticipantInfo, DriverInfo, Note } from "@/types"
+import { generateId } from "@/lib/constants"
 
 const toIso = (value?: string, field?: string): string | undefined => {
   if (!value) return undefined
@@ -450,7 +451,7 @@ export function useClaims() {
       setError(null)
       const payload = transformFrontendClaimToApiPayload(claimData)
       if (!payload.id) {
-        payload.id = crypto.randomUUID()
+        payload.id = generateId()
       }
       const newApiClaim = await apiService.createClaim(payload)
       const newClaim = transformApiClaimToFrontend(newApiClaim)

--- a/hooks/use-damages.ts
+++ b/hooks/use-damages.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCallback } from "react"
-import { API_ENDPOINTS } from "@/lib/constants"
+import { API_ENDPOINTS, generateId } from "@/lib/constants"
 import { authFetch } from "@/lib/auth-fetch"
 
 export interface Damage {
@@ -62,7 +62,7 @@ export function useDamages(eventId?: string) {
 
         body: JSON.stringify({
           ...damage,
-          id: damage.id || crypto.randomUUID(),
+          id: damage.id || generateId(),
           eventId: (damage as any).eventId || eventId,
         }),
       })

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -252,7 +252,10 @@ export const getEventStatusColor = (statusCode: string) => {
   return status?.color || "bg-gray-100 text-gray-800"
 }
 
-export const generateId = () => Math.random().toString(36).substr(2, 9)
+export const generateId = () =>
+  typeof globalThis.crypto?.randomUUID === "function"
+    ? globalThis.crypto.randomUUID()
+    : Math.random().toString(36).slice(2, 11)
 
 // Helper function to get label by value
 export const getLabelByValue = (items: Array<{ value: string; label: string }>, value: string): string => {


### PR DESCRIPTION
## Summary
- add generateId utility with crypto.randomUUID fallback
- use generateId across claim and document modules

## Testing
- `pnpm test` (fails: Cannot require() ES Module /app/api/appeals/route.ts in a cycle.)
- `pnpm lint` (fails: interactive configuration required)


------
https://chatgpt.com/codex/tasks/task_e_68ad07c4ad88832c8923b24b983c8b8a