### PR TITLE
feat: enable edit via type icon

### DIFF
--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -653,7 +653,18 @@ export function ClaimsList({
                         <div className="flex items-center gap-2">
                           {(() => {
                             const Icon = typeIconMap[claim.objectTypeId as number]
-                            return Icon ? <Icon className="h-4 w-4" /> : null
+                            return Icon ? (
+                              <Icon
+                                className="h-4 w-4 cursor-pointer"
+                                onClick={() =>
+                                  claim.id &&
+                                  (onEditClaim
+                                    ? onEditClaim(claim.id)
+                                    : handleEditClaimDirect(claim.id))
+                                }
+                                title="Edytuj"
+                              />
+                            ) : null
                           })()}
                           <span>{typeLabelMap[claim.objectTypeId as number]}</span>
                         </div>


### PR DESCRIPTION
## Summary
- allow editing a claim directly from the type icon in claim list

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(fails: How would you like to configure ESLint?)*


------
https://chatgpt.com/codex/tasks/task_e_68ad7d33f45c832c9b277dea44140381