### PR TITLE
fix: prevent interval init error

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -39,11 +39,13 @@ export default function Footer() {
 
     const exp = payload.exp * 1000
 
+    let interval: ReturnType<typeof setInterval> | null = null
+
     const updateTimer = () => {
       const remaining = exp - Date.now()
       if (remaining <= 0) {
         setTimeLeft(null)
-        clearInterval(interval)
+        if (interval) clearInterval(interval)
         void logout().finally(() => {
           alert('Sesja wygasła. Zostałeś wylogowany.')
           router.push('/login')
@@ -65,8 +67,10 @@ export default function Footer() {
     }
 
     updateTimer()
-    const interval = setInterval(updateTimer, 1000)
-    return () => clearInterval(interval)
+    interval = setInterval(updateTimer, 1000)
+    return () => {
+      if (interval) clearInterval(interval)
+    }
   }, [logout, router, sessionRefresh])
 
   return (


### PR DESCRIPTION
## Summary
- avoid referencing session timer before initialization

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Cannot require() ES Module /app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68ade3cb95cc832c9e0c034af39a3c07