### PR TITLE
Sort admin settings navigation and document

### DIFF
--- a/app/settings/layout.tsx
+++ b/app/settings/layout.tsx
@@ -10,21 +10,26 @@ import { ProtectedRoute } from '@/components/protected-route'
 import { cn } from '@/lib/utils'
 import { useAuth } from '@/hooks/use-auth'
 
+const BASE_SETTINGS_NAV = [
+  { href: '/settings/casehandlers', label: 'Likwidatorzy' },
+  { href: '/settings/clients', label: 'Klienci' },
+  { href: '/settings/damage-types', label: 'Typy szkód' },
+  { href: '/settings/dictionaries', label: 'Słowniki' },
+  { href: '/settings/notifications', label: 'Powiadomienia' },
+  { href: '/settings/risk-types', label: 'Typy ryzyka' },
+  { href: '/settings/users', label: 'Użytkownicy' },
+]
+  .sort((a, b) => a.label.localeCompare(b.label, 'pl'))
+
+const SETTINGS_NAV_ITEMS = [
+  ...BASE_SETTINGS_NAV,
+  { href: '/admin', label: 'Panel administracyjny' },
+]
+
 export default function SettingsLayout({ children }: { children: ReactNode }) {
   const [activeTab, setActiveTab] = useState('settings')
   const pathname = usePathname()
   const { user, logout } = useAuth()
-
-  const settingsItems = [
-    { href: '/settings/clients', label: 'Klienci' },
-    { href: '/settings/users', label: 'Użytkownicy' },
-    { href: '/settings/casehandlers', label: 'Likwidatorzy' },
-    { href: '/settings/risk-types', label: 'Typy ryzyka' },
-    { href: '/settings/damage-types', label: 'Typy szkód' },
-    { href: '/settings/dictionaries', label: 'Słowniki' },
-    { href: '/settings/notifications', label: 'Powiadomienia' },
-    { href: '/admin', label: 'Panel administracyjny' },
-  ]
 
   return (
     <ProtectedRoute roles={["Admin", "admin"]}>
@@ -34,7 +39,7 @@ export default function SettingsLayout({ children }: { children: ReactNode }) {
           <Header onMenuClick={() => {}} user={user ?? undefined} onLogout={logout} />
           <div className="flex flex-1">
             <nav className="w-48 border-r bg-white p-4 space-y-2">
-              {settingsItems.map((item) => (
+              {SETTINGS_NAV_ITEMS.map((item) => (
                 <Link
                   key={item.href}
                   href={item.href}

--- a/docs/admin-settings-details.md
+++ b/docs/admin-settings-details.md
@@ -1,0 +1,27 @@
+# Szczegółowy opis modułów ustawień administracyjnych
+
+Poniższe sekcje opisują w większych szczegółach poszczególne moduły dostępne w nawigacji pliku `app/settings/layout.tsx`.
+
+## Klienci
+Moduł zarządzania danymi klientów. Umożliwia dodawanie, edycję i usuwanie informacji o klientach, a także wyszukiwanie po kluczowych atrybutach, takich jak numer polisy czy nazwa.
+
+## Likwidatorzy
+Sekcja poświęcona obsłudze likwidatorów szkód. Dostarcza funkcje rejestracji nowych likwidatorów, aktualizacji ich danych kontaktowych oraz dezaktywacji kont nieaktywnych.
+
+## Powiadomienia
+Moduł konfiguracji powiadomień systemowych. Pozwala definiować reguły wysyłki, treść wiadomości oraz kanały komunikacji wykorzystywane do informowania użytkowników.
+
+## Słowniki
+Sekcja zawiera edytor słowników referencyjnych wykorzystywanych w aplikacji. Administrator może dodawać nowe pozycje, aktualizować istniejące oraz określać ich aktywność.
+
+## Typy ryzyka
+Moduł zarządzania listą typów ryzyka. Umożliwia tworzenie nowych kategorii ryzyka, aktualizację opisów oraz oznaczanie ich jako aktywne lub nieaktywne w systemie.
+
+## Typy szkód
+Sekcja odpowiedzialna za administrację typami szkód. Zapewnia funkcje dodawania, modyfikacji i usuwania kategorii szkód oraz powiązania ich z odpowiednimi procedurami likwidacyjnymi.
+
+## Użytkownicy
+Moduł obsługi użytkowników systemu. Zawiera formularze rejestracji, narzędzia do zarządzania rolami i uprawnieniami oraz mechanizmy blokowania i odblokowywania kont.
+
+## Panel administracyjny
+Link prowadzi do głównego panelu administracyjnego, w którym można monitorować działanie systemu, przeglądać statystyki oraz wykonywać dodatkowe operacje administracyjne.

--- a/docs/admin-settings-summary.md
+++ b/docs/admin-settings-summary.md
@@ -1,0 +1,14 @@
+# Podsumowanie ustawień panelu administracyjnego
+
+Nawigacja w pliku `app/settings/layout.tsx` obejmuje następujące sekcje:
+
+- **Klienci** – zarządzanie klientami.
+- **Likwidatorzy** – zarządzanie likwidatorami.
+- **Powiadomienia** – konfiguracja powiadomień.
+- **Słowniki** – edycja słowników.
+- **Typy ryzyka** – zarządzanie typami ryzyka.
+- **Typy szkód** – zarządzanie typami szkód.
+- **Użytkownicy** – zarządzanie użytkownikami.
+- **Panel administracyjny** – przejście do panelu zarządzania systemem.
+
+Elementy ustawień są sortowane alfabetycznie (z wyjątkiem linku do panelu administracyjnego, który znajduje się na końcu).


### PR DESCRIPTION
## Summary
- sort settings navigation items and extract constants in app/settings/layout
- add documentation summarizing admin settings
- add detailed descriptions for each admin settings module

## Testing
- `pnpm lint` (fails: requires manual ESLint configuration)
- `pnpm test` (fails: ERR_REQUIRE_CYCLE_MODULE in appeals route test)


------
https://chatgpt.com/codex/tasks/task_e_68ad73e45c20832cb2646f7e38525591