### PR TITLE
feat: show vehicle details for property claims

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, useMemo } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { FormHeader } from "@/components/ui/form-header"
 import { Button } from "@/components/ui/button"
@@ -246,6 +246,15 @@ export const ClaimMainContent = ({
   const [riskTypes, setRiskTypes] = useState<RiskType[]>([])
   const [loadingRiskTypes, setLoadingRiskTypes] = useState(false)
   const [claimObjectType, setClaimObjectType] = useState<string>(initialClaimObjectType) // Default to communication claims
+
+  const selectedRiskTypeLabel = useMemo(() => {
+    const rt = riskTypes.find((r) => r.value === claimFormData.riskType)
+    return rt?.label
+  }, [riskTypes, claimFormData.riskType])
+
+  const showVehicleFields =
+    selectedRiskTypeLabel === "OC SPRAWCY" ||
+    selectedRiskTypeLabel === "OC PPM"
 
   // Keep local state in sync when initial value changes (e.g. after loading claim)
   useEffect(() => {
@@ -1227,6 +1236,7 @@ export const ClaimMainContent = ({
             <PropertyParticipantsSection
               claimFormData={claimFormData}
               handleFormChange={(field, value) => handleFormChange(field as keyof Claim, value)}
+              showVehicleFields={showVehicleFields}
             />
           </div>
         )

--- a/components/claim-form/property-participants-section.tsx
+++ b/components/claim-form/property-participants-section.tsx
@@ -4,14 +4,40 @@ import { Card, CardContent } from "@/components/ui/card"
 import { FormHeader } from "@/components/ui/form-header"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { FileText } from "lucide-react"
 
 interface PropertyParticipantsSectionProps {
   claimFormData: Record<string, any>
   handleFormChange: (field: string, value: any) => void
+  showVehicleFields?: boolean
 }
 
-export function PropertyParticipantsSection({ claimFormData, handleFormChange }: PropertyParticipantsSectionProps) {
+const countries = [
+  { id: "PL", displayName: "Polska" },
+  { id: "DE", displayName: "Niemcy" },
+  { id: "FR", displayName: "Francja" },
+  { id: "GB", displayName: "Wielka Brytania" },
+  { id: "IT", displayName: "Włochy" },
+  { id: "ES", displayName: "Hiszpania" },
+  { id: "CZ", displayName: "Czechy" },
+  { id: "SK", displayName: "Słowacja" },
+  { id: "UA", displayName: "Ukraina" },
+  { id: "LT", displayName: "Litwa" },
+]
+
+export function PropertyParticipantsSection({
+  claimFormData,
+  handleFormChange,
+  showVehicleFields = false,
+}: PropertyParticipantsSectionProps) {
   return (
     <Card className="border border-gray-200 bg-white shadow-sm">
       <FormHeader icon={FileText} title="Poszkodowany / Sprawca" />
@@ -25,6 +51,60 @@ export function PropertyParticipantsSection({ claimFormData, handleFormChange }:
             placeholder="Wprowadź dane poszkodowanego"
           />
         </div>
+        {showVehicleFields && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <Label htmlFor="victimRegistrationNumber">Nr rejestracyjny</Label>
+              <Input
+                id="victimRegistrationNumber"
+                value={claimFormData.victimRegistrationNumber || ""}
+                onChange={(e) =>
+                  handleFormChange("victimRegistrationNumber", e.target.value)
+                }
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="victimVehicleBrand">Marka</Label>
+              <Input
+                id="victimVehicleBrand"
+                value={claimFormData.victimVehicleBrand || ""}
+                onChange={(e) =>
+                  handleFormChange("victimVehicleBrand", e.target.value)
+                }
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="victimVehicleModel">Model</Label>
+              <Input
+                id="victimVehicleModel"
+                value={claimFormData.victimVehicleModel || ""}
+                onChange={(e) =>
+                  handleFormChange("victimVehicleModel", e.target.value)
+                }
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="victimVehicleCountry">Kraj rejestracji</Label>
+              <Select
+                value={claimFormData.victimVehicleCountry || "PL"}
+                onValueChange={(value) =>
+                  handleFormChange("victimVehicleCountry", value)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Wybierz kraj" />
+                </SelectTrigger>
+                <SelectContent>
+                  {countries.map((country) => (
+                    <SelectItem key={country.id} value={country.id}>
+                      {country.displayName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        )}
         <div className="space-y-2">
           <Label htmlFor="perpetratorData">Dane sprawcy</Label>
           <Textarea
@@ -34,6 +114,63 @@ export function PropertyParticipantsSection({ claimFormData, handleFormChange }:
             placeholder="Wprowadź dane sprawcy"
           />
         </div>
+        {showVehicleFields && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <Label htmlFor="perpetratorRegistrationNumber">Nr rejestracyjny</Label>
+              <Input
+                id="perpetratorRegistrationNumber"
+                value={claimFormData.perpetratorRegistrationNumber || ""}
+                onChange={(e) =>
+                  handleFormChange(
+                    "perpetratorRegistrationNumber",
+                    e.target.value,
+                  )
+                }
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="perpetratorVehicleBrand">Marka</Label>
+              <Input
+                id="perpetratorVehicleBrand"
+                value={claimFormData.perpetratorVehicleBrand || ""}
+                onChange={(e) =>
+                  handleFormChange("perpetratorVehicleBrand", e.target.value)
+                }
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="perpetratorVehicleModel">Model</Label>
+              <Input
+                id="perpetratorVehicleModel"
+                value={claimFormData.perpetratorVehicleModel || ""}
+                onChange={(e) =>
+                  handleFormChange("perpetratorVehicleModel", e.target.value)
+                }
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="perpetratorVehicleCountry">Kraj rejestracji</Label>
+              <Select
+                value={claimFormData.perpetratorVehicleCountry || "PL"}
+                onValueChange={(value) =>
+                  handleFormChange("perpetratorVehicleCountry", value)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Wybierz kraj" />
+                </SelectTrigger>
+                <SelectContent>
+                  {countries.map((country) => (
+                    <SelectItem key={country.id} value={country.id}>
+                      {country.displayName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -35,6 +35,12 @@ export interface EventListItemDto {
   vehicleNumber?: string
   victimRegistrationNumber?: string
   perpetratorRegistrationNumber?: string
+  victimVehicleBrand?: string
+  victimVehicleModel?: string
+  victimVehicleCountry?: string
+  perpetratorVehicleBrand?: string
+  perpetratorVehicleModel?: string
+  perpetratorVehicleCountry?: string
   clientId?: number
   client?: string
   liquidator?: string
@@ -153,6 +159,12 @@ export interface EventUpsertDto {
   vehicleNumber?: string
   victimRegistrationNumber?: string
   perpetratorRegistrationNumber?: string
+  victimVehicleBrand?: string
+  victimVehicleModel?: string
+  victimVehicleCountry?: string
+  perpetratorVehicleBrand?: string
+  perpetratorVehicleModel?: string
+  perpetratorVehicleCountry?: string
   clientId?: number
   client?: string
   liquidator?: string


### PR DESCRIPTION
## Summary
- show license plate, brand, model and country fields for property claim participants
- toggle vehicle fields when risk type is OC SPRAWCY or OC PPM
- extend API DTOs with vehicle detail properties

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1a67fb10832c9b1ede57928928f4