### PR TITLE
feat: add auth header on logout

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -851,7 +851,12 @@ class ApiService {
   }
 
   async logout(): Promise<void> {
-    await this.request<void>("/auth/logout", { method: "POST" })
+    await this.request<void>("/auth/logout", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.getToken()}`,
+      },
+    })
     this.setToken(null)
   }
 


### PR DESCRIPTION
## Summary
- ensure logout requests send Authorization header

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1b6ef44c832ca1136917f3a81fde