### PR TITLE
Add transport type dictionary for transport damages

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -1052,6 +1052,8 @@ namespace AutomotiveClaimsApi.Controllers
             entity.ClaimFromSubcontractorPolicyDate = dto.ClaimFromSubcontractorPolicyDate;
             entity.ComplaintResponse = dto.ComplaintResponse;
             entity.ComplaintResponseDate = dto.ComplaintResponseDate;
+            entity.TransportTypeId = dto.TransportTypeId;
+            entity.TransportType = dto.TransportType;
             entity.CargoDescription = dto.CargoDescription;
             entity.Losses = dto.Losses;
             entity.Carrier = dto.Carrier;
@@ -1869,6 +1871,8 @@ namespace AutomotiveClaimsApi.Controllers
             ClaimFromSubcontractorPolicyDate = e.ClaimFromSubcontractorPolicyDate,
             ComplaintResponse = e.ComplaintResponse,
             ComplaintResponseDate = e.ComplaintResponseDate,
+            TransportTypeId = e.TransportTypeId,
+            TransportType = e.TransportType,
             CargoDescription = e.CargoDescription,
             Losses = e.Losses?.Split(',', StringSplitOptions.RemoveEmptyEntries),
             Carrier = e.Carrier,

--- a/backend/DTOs/EventDto.cs
+++ b/backend/DTOs/EventDto.cs
@@ -73,6 +73,8 @@ namespace AutomotiveClaimsApi.DTOs
         public DateTime? ClaimFromSubcontractorPolicyDate { get; set; }
         public bool? ComplaintResponse { get; set; }
         public DateTime? ComplaintResponseDate { get; set; }
+        public int? TransportTypeId { get; set; }
+        public string? TransportType { get; set; }
         public string? CargoDescription { get; set; }
         public string[]? Losses { get; set; }
         public string? Carrier { get; set; }

--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -187,6 +187,11 @@ namespace AutomotiveClaimsApi.DTOs
 
         public DateTime? ComplaintResponseDate { get; set; }
 
+        public int? TransportTypeId { get; set; }
+
+        [StringLength(50)]
+        public string? TransportType { get; set; }
+
         [StringLength(2000)]
         public string? CargoDescription { get; set; }
 

--- a/backend/Migrations/20250226000001_AddTransportTypeToEvents.cs
+++ b/backend/Migrations/20250226000001_AddTransportTypeToEvents.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTransportTypeToEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TransportTypeId",
+                table: "Events",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TransportType",
+                table: "Events",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TransportTypeId",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "TransportType",
+                table: "Events");
+        }
+    }
+}

--- a/backend/Models/Event.cs
+++ b/backend/Models/Event.cs
@@ -185,6 +185,11 @@ namespace AutomotiveClaimsApi.Models
 
         public DateTime? ComplaintResponseDate { get; set; }
 
+        public int? TransportTypeId { get; set; }
+
+        [MaxLength(50)]
+        public string? TransportType { get; set; }
+
         [MaxLength(2000)]
         public string? CargoDescription { get; set; }
 

--- a/components/claim-form/transport-claim-summary.tsx
+++ b/components/claim-form/transport-claim-summary.tsx
@@ -3,6 +3,7 @@
 import { FileText, MessageSquare } from "lucide-react"
 import { DocumentsSection } from "../documents-section"
 import type { Claim, Note, UploadedFile } from "@/types"
+import { TRANSPORT_TYPES } from "@/lib/constants"
 
 interface ClaimStatus {
   id: number
@@ -57,6 +58,13 @@ export function TransportClaimSummary({
   }
 
   const transportDamage = (claimFormData.transportDamage || {}) as any
+
+  const getTransportTypeLabel = (id?: string, code?: string) => {
+    const typeById = TRANSPORT_TYPES.find((t) => t.value === id)
+    if (typeById) return typeById.label
+    const typeByCode = TRANSPORT_TYPES.find((t) => t.code === code)
+    return typeByCode ? typeByCode.label : code || id || "Nie określono"
+  }
 
   return (
     <div className="space-y-4">
@@ -127,6 +135,13 @@ export function TransportClaimSummary({
           </div>
         </div>
         <div className="p-4 space-y-4">
+          <InfoCard
+            label="Rodzaj transportu"
+            value={getTransportTypeLabel(
+              transportDamage.transportTypeId,
+              transportDamage.transportType,
+            )}
+          />
           <div>
             <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
               Opis ładunku / lista strat

--- a/components/claim-form/transport-damage-section.tsx
+++ b/components/claim-form/transport-damage-section.tsx
@@ -6,9 +6,19 @@ import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { TRANSPORT_TYPES } from "@/lib/constants"
 import { FileText, Plus, Trash2 } from "lucide-react"
 
 interface TransportDamage {
+  transportType: string
+  transportTypeId: string
   cargoDescription: string
   losses: string[]
   carrier: string
@@ -31,6 +41,8 @@ export function TransportDamageSection({
 }: TransportDamageSectionProps) {
   const transportDamage: TransportDamage =
     claimFormData.transportDamage || {
+      transportType: "",
+      transportTypeId: "",
       cargoDescription: "",
       losses: [""],
       carrier: "",
@@ -62,10 +74,38 @@ export function TransportDamageSection({
     handleFieldChange("losses", updated)
   }
 
+  const handleTransportTypeChange = (value: string) => {
+    const selected = TRANSPORT_TYPES.find((t) => t.value === value)
+    handleFormChange("transportDamage", {
+      ...transportDamage,
+      transportTypeId: value,
+      transportType: selected?.code || "",
+    })
+  }
+
   return (
     <Card>
       <FormHeader icon={FileText} title="Szkoda w transporcie" />
       <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="transportType">Rodzaj transportu</Label>
+          <Select
+            value={transportDamage.transportTypeId}
+            onValueChange={handleTransportTypeChange}
+            disabled={disabled}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Wybierz rodzaj transportu" />
+            </SelectTrigger>
+            <SelectContent>
+              {TRANSPORT_TYPES.map((type) => (
+                <SelectItem key={type.value} value={type.value}>
+                  {type.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
         <div className="space-y-2">
           <Label htmlFor="cargoDescription">Opis ładunku / lista strat</Label>
           <Textarea

--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -24,6 +24,8 @@ test('includes dropdown selections in payload', () => {
 test('maps transportDamage fields', () => {
   const payload = transformFrontendClaimToApiPayload({
     transportDamage: {
+      transportType: 'LAND',
+      transportTypeId: '1',
       cargoDescription: 'desc',
       losses: ['a', 'b'],
       carrier: 'carrier',
@@ -41,6 +43,8 @@ test('maps transportDamage fields', () => {
   assert.equal(payload.inspectionContactName, 'John')
   assert.equal(payload.inspectionContactPhone, '123')
   assert.equal(payload.inspectionContactEmail, 'john@example.com')
+  assert.equal(payload.transportType, 'LAND')
+  assert.equal(payload.transportTypeId, 1)
 })
 
 test('maps damageType object to its code value', () => {

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -34,6 +34,8 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
     recourses,
     settlements,
     servicesCalled,
+    transportType,
+    transportTypeId,
     cargoDescription,
     losses,
     carrier,
@@ -136,6 +138,8 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
     recourses: recourses || [],
     settlements: settlements || [],
     transportDamage: {
+      transportType: transportType || "",
+      transportTypeId: transportTypeId?.toString() || "",
       cargoDescription: cargoDescription || "",
       losses: losses || [],
       carrier: carrier || "",
@@ -289,6 +293,10 @@ export const transformFrontendClaimToApiPayload = (
           inspectionContactName: transportDamage.inspectionContactName,
           inspectionContactPhone: transportDamage.inspectionContactPhone,
           inspectionContactEmail: transportDamage.inspectionContactEmail,
+          transportType: transportDamage.transportType,
+          transportTypeId: transportDamage.transportTypeId
+            ? parseInt(transportDamage.transportTypeId, 10)
+            : undefined,
         }
       : {}),
     participants: participants,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -97,6 +97,8 @@ export interface EventDto extends EventListItemDto {
   claimFromSubcontractorPolicyDate?: string
   complaintResponse?: boolean
   complaintResponseDate?: string
+  transportTypeId?: number
+  transportType?: string
   cargoDescription?: string
   losses?: string[]
   carrier?: string
@@ -205,6 +207,8 @@ export interface EventUpsertDto {
   claimFromSubcontractorPolicyDate?: string
   complaintResponse?: boolean
   complaintResponseDate?: string
+  transportTypeId?: number
+  transportType?: string
   cargoDescription?: string
   losses?: string
   carrier?: string

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -139,6 +139,14 @@ export const VEHICLE_TYPES = [
   { value: "TRAILER", label: "Przyczepa" },
 ]
 
+// Transport types
+export const TRANSPORT_TYPES = [
+  { value: "1", code: "LAND", label: "Lądowy" },
+  { value: "2", code: "SEA", label: "Morski" },
+  { value: "3", code: "AIR", label: "Lotniczy" },
+  { value: "4", code: "RAIL", label: "Kolejowy" },
+]
+
 // Damage types
 export const DAMAGE_TYPES = [
   "Kolizja",

--- a/types/index.ts
+++ b/types/index.ts
@@ -25,6 +25,8 @@ export interface Note {
 
 
 export interface TransportDamage {
+  transportType: string
+  transportTypeId: string
   cargoDescription: string
   losses: string[]
   carrier: string
@@ -78,6 +80,8 @@ export interface Claim
     | "inspectionContactName"
     | "inspectionContactPhone"
     | "inspectionContactEmail"
+    | "transportType"
+    | "transportTypeId"
   > {
   id?: string
   clientId?: string


### PR DESCRIPTION
## Summary
- track numeric transport type IDs alongside transport type codes
- wire transportTypeId through claim form components, hooks, backend DTOs/models, and migrations

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(fails: interactive configuration prompt)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16b1363c832cac4ad75fdbf83ac1