### PR TITLE
chore: remove min-h-screen from repair schedule container

### DIFF
--- a/components/claim-form/repair-schedule-section.tsx
+++ b/components/claim-form/repair-schedule-section.tsx
@@ -431,7 +431,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
   }
 
   return (
-    <div className="space-y-8 animate-fade-in w-full min-h-screen">
+    <div className="space-y-8 animate-fade-in w-full">
       <div className="flex justify-end">
         <Button
           onClick={() => setShowForm(true)}


### PR DESCRIPTION
## Summary
- remove redundant `min-h-screen` class from repair schedule section

## Testing
- `pnpm lint` *(fails: requires ESLint configuration)*
- `pnpm test` *(fails: Cannot require() ES Module route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68ae21c8ce0c832cb76d6cc9f8174e36