### PR TITLE
Remove border styling from repair schedule section

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -675,7 +675,7 @@ export const ClaimMainContent = ({
                 </div>
                 <div className="p-4">
                 {eventId ? (
-                  <div className="border rounded-lg overflow-hidden">
+                  <div className="rounded-lg overflow-hidden">
                     <RepairScheduleSection eventId={eventId} />
                   </div>
                 ) : (
@@ -1738,7 +1738,7 @@ export const ClaimMainContent = ({
                 </div>
                 <div className="p-4">
                 {eventId ? (
-                  <div className="border rounded-lg overflow-hidden">
+                  <div className="rounded-lg overflow-hidden">
                     <RepairScheduleSection eventId={eventId} />
                   </div>
                 ) : (

--- a/components/claim-form/repair-schedule-section.tsx
+++ b/components/claim-form/repair-schedule-section.tsx
@@ -735,7 +735,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
 
       <div className="grid gap-4 w-full grid-cols-1">
         {schedules.length === 0 ? (
-          <Card className="col-span-full w-full border-2 border-dashed border-border bg-muted/20 rounded-2xl animate-fade-in">
+          <Card className="col-span-full w-full bg-muted/20 rounded-2xl animate-fade-in">
             <CardContent className="text-center py-16">
               <div className="space-y-4">
                 <div className="p-6 bg-primary/10 rounded-2xl w-fit mx-auto">


### PR DESCRIPTION
## Summary
- drop outer border from RepairScheduleSection wrapper
- remove border styling from empty repair schedule card

## Testing
- `pnpm test` (fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)
- `pnpm lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68ae21e78040832cb7798cb8bb1d70c2