### PR TITLE
Load risk types for all claim object types

### DIFF
--- a/components/claims-list.tsx
+++ b/components/claims-list.tsx
@@ -136,11 +136,16 @@ export function ClaimsList({
   useEffect(() => {
     const loadRiskTypes = async () => {
       try {
+        const responses = await Promise.all(
+          [1, 2, 3].map((type) =>
+            dictionaryService.getRiskTypes(String(type)),
+          ),
+        )
 
-        const data = await dictionaryService.getRiskTypes(claimObjectTypeId)
+        const allItems = responses.flatMap((data) => data.items ?? [])
 
         setRiskTypes(
-          (data.items ?? []) as { id: number; code: string; name: string }[],
+          allItems as { id: number; code: string; name: string }[],
         )
       } catch (error) {
         console.error("Error loading risk types:", error)
@@ -148,7 +153,7 @@ export function ClaimsList({
       }
     }
     loadRiskTypes()
-  }, [claimObjectTypeId])
+  }, [])
 
   useEffect(() => {
     if (initialClaims?.length) return


### PR DESCRIPTION
## Summary
- fetch risk types for object types 1, 2 and 3

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_68ae21866524832ca444528c22e345f0