### PR TITLE
Hide duplicate repair schedule header

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -665,14 +665,6 @@ export const ClaimMainContent = ({
             <CardContent className="p-0 bg-white">
               {/* Harmonogram naprawy - expandable section with data preview */}
               <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-                <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center space-x-2">
-                      <Calendar className="h-4 w-4 text-blue-600" />
-                      <h3 className="text-sm font-semibold text-gray-900">Harmonogram naprawy</h3>
-                    </div>
-                  </div>
-                </div>
                 <div className="p-4">
                 {eventId ? (
                   <div className="rounded-lg overflow-hidden">


### PR DESCRIPTION
## Summary
- remove redundant repair schedule header block

## Testing
- `pnpm test` (fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)
- `pnpm lint` (fails: interactive ESLint configuration prompt)

------
https://chatgpt.com/codex/tasks/task_e_68ae2682d2f4832cb0202bee852293dd