### PR TITLE
Hide leasing dropdown for transport claims

### DIFF
--- a/components/claim-form/damage-data-section.tsx
+++ b/components/claim-form/damage-data-section.tsx
@@ -424,19 +424,28 @@ export function DamageDataSection({
               className="relative z-20"
             />
           </div>
-          <div className="relative z-10">
-            <Label htmlFor="leasingCompany" className="text-sm font-medium text-gray-700 mb-2 block">
-              Firma leasingowa
-            </Label>
-            <LeasingDropdown
-              selectedCompanyId={claimFormData.leasingCompanyId ? parseInt(claimFormData.leasingCompanyId) : undefined}
-              onCompanySelected={(event: LeasingCompanySelectionEvent) => {
-                handleFormChange("leasingCompany", event.companyName)
-                handleFormChange("leasingCompanyId", event.companyId.toString())
-              }}
-              className="relative z-10"
-            />
-          </div>
+          {claimObjectType !== "3" && (
+            <div className="relative z-10">
+              <Label
+                htmlFor="leasingCompany"
+                className="text-sm font-medium text-gray-700 mb-2 block"
+              >
+                Firma leasingowa
+              </Label>
+              <LeasingDropdown
+                selectedCompanyId={
+                  claimFormData.leasingCompanyId
+                    ? parseInt(claimFormData.leasingCompanyId)
+                    : undefined
+                }
+                onCompanySelected={(event: LeasingCompanySelectionEvent) => {
+                  handleFormChange("leasingCompany", event.companyName)
+                  handleFormChange("leasingCompanyId", event.companyId.toString())
+                }}
+                className="relative z-10"
+              />
+            </div>
+          )}
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- hide leasing company selector when editing transport damage claims

## Testing
- `pnpm test` *(fails: testCodeFailure)*
- `pnpm lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68ae29552cc0832cbdc12259d47762c3