### PR TITLE
Display transport type under damage type

### DIFF
--- a/components/claim-form/damage-data-section.tsx
+++ b/components/claim-form/damage-data-section.tsx
@@ -261,6 +261,26 @@ export function DamageDataSection({
                 disabled={!claimFormData.riskType}
               />
             </div>
+            {claimObjectType === "3" && (
+              <div>
+                <Label htmlFor="transportType">Rodzaj transportu</Label>
+                <Select
+                  value={transportDamage.transportTypeId}
+                  onValueChange={handleTransportTypeChange}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Wybierz rodzaj transportu" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TRANSPORT_TYPES.map((type) => (
+                      <SelectItem key={type.value} value={type.value}>
+                        {type.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
             <div>
               <Label htmlFor="insurerClaimNumber" className="text-sm font-medium text-gray-700">
                 Nr szkody TU
@@ -302,37 +322,17 @@ export function DamageDataSection({
           <>
             <div className="border-t border-gray-200 my-8" />
             <div className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="transportType">Rodzaj transportu</Label>
-                  <Select
-                    value={transportDamage.transportTypeId}
-                    onValueChange={handleTransportTypeChange}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Wybierz rodzaj transportu" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {TRANSPORT_TYPES.map((type) => (
-                        <SelectItem key={type.value} value={type.value}>
-                          {type.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2 md:col-span-2">
-                  <Label htmlFor="cargoDescription">Opis ładunku / lista strat</Label>
-                  <Textarea
-                    id="cargoDescription"
-                    placeholder="Opisz ładunek lub ogólną listę strat"
-                    value={transportDamage.cargoDescription}
-                    onChange={(e) =>
-                      handleTransportFieldChange("cargoDescription", e.target.value)
-                    }
-                    rows={3}
-                  />
-                </div>
+              <div className="space-y-2">
+                <Label htmlFor="cargoDescription">Opis ładunku / lista strat</Label>
+                <Textarea
+                  id="cargoDescription"
+                  placeholder="Opisz ładunek lub ogólną listę strat"
+                  value={transportDamage.cargoDescription}
+                  onChange={(e) =>
+                    handleTransportFieldChange("cargoDescription", e.target.value)
+                  }
+                  rows={3}
+                />
               </div>
               <div className="space-y-2">
                 <Label>Lista strat</Label>

--- a/components/claim-form/transport-claim-summary.tsx
+++ b/components/claim-form/transport-claim-summary.tsx
@@ -95,6 +95,13 @@ export function TransportClaimSummary({
             </div>
           )}
           <InfoCard label="Rodzaj szkody" value={claimFormData.damageType} />
+          <InfoCard
+            label="Rodzaj transportu"
+            value={getTransportTypeLabel(
+              transportDamage.transportTypeId,
+              transportDamage.transportType,
+            )}
+          />
           <InfoCard label="Ryzyko szkody" value={getRiskTypeLabel(claimFormData.riskType)} />
           <div className="grid grid-cols-2 gap-3">
             <InfoCard label="Data zdarzenia" value={claimFormData.damageDate} />
@@ -135,13 +142,6 @@ export function TransportClaimSummary({
           </div>
         </div>
         <div className="p-4 space-y-4">
-          <InfoCard
-            label="Rodzaj transportu"
-            value={getTransportTypeLabel(
-              transportDamage.transportTypeId,
-              transportDamage.transportType,
-            )}
-          />
           <div>
             <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
               Opis ładunku / lista strat


### PR DESCRIPTION
## Summary
- Show transport type directly under damage type in claim form
- Move transport type info into main claim summary and remove duplicate

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(fails: next lint prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68aed1fa54dc832c810c6f693d58067a