### PR TITLE
style: remove border from schedule placeholder

### DIFF
--- a/components/claim-form/repair-schedule-section.tsx
+++ b/components/claim-form/repair-schedule-section.tsx
@@ -743,7 +743,7 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
 
       <div className="grid gap-4 w-full grid-cols-1">
         {schedules.length === 0 ? (
-          <Card className="col-span-full w-full bg-muted/20 rounded-2xl animate-fade-in">
+          <Card className="col-span-full w-full bg-muted/20 rounded-2xl animate-fade-in border-0">
             <CardContent className="text-center py-16">
               <div className="space-y-4">
                 <div className="p-6 bg-primary/10 rounded-2xl w-fit mx-auto">


### PR DESCRIPTION
## Summary
- restore empty repair schedule placeholder and drop its border for cleaner look

## Testing
- `pnpm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_e_68aee69bdc74832cadd2385067951b11