### PR TITLE
feat: adjust space-y-4 vertical spacing

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,6 +6,11 @@
   .text-balance {
     text-wrap: balance;
   }
+  .space-y-4 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-y-reverse: 0;
+    margin-top: calc(1rem * calc(0.5 - var(--tw-space-y-reverse)));
+    margin-bottom: calc(1rem * var(--tw-space-y-reverse));
+  }
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- override Tailwind's space-y-4 utility to use half-height spacing

## Testing
- `pnpm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68aef850ac94832c91b4f7ff8bd78f68