### PR TITLE
Override my-8 margin to 1rem

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,6 +6,10 @@
   .text-balance {
     text-wrap: balance;
   }
+  .my-8 {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- override my-8 utility to apply 1rem top and bottom margins

## Testing
- `pnpm lint` *(fails: requires interactive eslint setup)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)*

------
https://chatgpt.com/codex/tasks/task_e_68aef87f7ac8832cb79bfa48aa3f2843