### PR TITLE
feat: unify confirmation dialogs

### DIFF
--- a/components/claim-form/__tests__/repair-schedule-section.test.ts
+++ b/components/claim-form/__tests__/repair-schedule-section.test.ts
@@ -4,11 +4,10 @@ import { deleteRepairSchedule } from '@/lib/api/repair-schedules'
 
 type Schedule = { id: string }
 
-async function testHandleDelete(confirmResult: boolean) {
+async function testHandleDelete() {
   let fetchCalled = false
   let schedules: Schedule[] = [{ id: '1' }]
 
-  globalThis.confirm = () => confirmResult
   globalThis.fetch = async (_url: string, _opts?: any) => {
     if (_opts?.method === 'DELETE') {
       fetchCalled = true
@@ -24,7 +23,6 @@ async function testHandleDelete(confirmResult: boolean) {
   const toast = (_: any) => {}
 
   const handleDelete = async (scheduleId: string) => {
-    if (!confirm('Czy na pewno chcesz usunąć harmonogram?')) return
     try {
       await deleteRepairSchedule(scheduleId)
       setSchedules((prev) => prev.filter((s) => s.id !== scheduleId))
@@ -39,14 +37,8 @@ async function testHandleDelete(confirmResult: boolean) {
   return { fetchCalled, schedules }
 }
 
-test('rejecting confirmation aborts deletion', async () => {
-  const { fetchCalled, schedules } = await testHandleDelete(false)
-  assert.equal(fetchCalled, false)
-  assert.equal(schedules.length, 1)
-})
-
-test('accepting confirmation deletes schedule', async () => {
-  const { fetchCalled, schedules } = await testHandleDelete(true)
+test('deletes schedule', async () => {
+  const { fetchCalled, schedules } = await testHandleDelete()
   assert.equal(fetchCalled, true)
   assert.equal(schedules.length, 0)
 })

--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -16,7 +16,8 @@ import { useClaims } from '@/hooks/use-claims'
 import { useDamages } from '@/hooks/use-damages'
 import { useRouter } from 'next/navigation'
 import { useToast } from '@/hooks/use-toast'
-import { useUnsavedChangesWarning, UNSAVED_CHANGES_MESSAGE } from '@/hooks/use-unsaved-changes-warning'
+import { useUnsavedChangesWarning } from '@/hooks/use-unsaved-changes-warning'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import type { Claim, ParticipantInfo, UploadedFile, RequiredDocument } from '@/types'
 import { getRequiredDocumentsByObjectType } from '@/lib/required-documents'
 import { authFetch } from '@/lib/auth-fetch'
@@ -403,17 +404,18 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
         {/* Form Actions */}
         {mode !== 'view' && (
           <div className="flex justify-end space-x-4">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => {
-                if (confirm(UNSAVED_CHANGES_MESSAGE)) {
-                  router.back()
-                }
-              }}
-            >
-              Anuluj
-            </Button>
+            <ConfirmDialog
+              title="Czy na pewno chcesz zakończyć edycję?"
+              description="Ta akcja spowoduje utratę niezapisanych zmian."
+              confirmText="Wyjdź"
+              cancelText="Wróć"
+              onConfirm={() => router.back()}
+              trigger={
+                <Button type="button" variant="outline">
+                  Anuluj
+                </Button>
+              }
+            />
             <Button
               type="submit"
               disabled={loading}

--- a/components/claim-form/repair-details-section.tsx
+++ b/components/claim-form/repair-details-section.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
+import { ConfirmDialog } from "@/components/ui/confirm-dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
@@ -174,7 +175,6 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({
   }
 
   const handleDelete = async (id: string) => {
-    if (!confirm("Czy na pewno chcesz usunąć opis?")) return
     try {
       await deleteRepairDetail(id)
       toast({ title: "Sukces", description: "Opis naprawy został usunięty" })
@@ -596,14 +596,20 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({
                       >
                         <Edit className="h-4 w-4" />
                       </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleDelete(detail.id)}
-                        className="h-10 w-10 rounded-xl hover:bg-destructive/10 hover:text-destructive"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
+                      <ConfirmDialog
+                        title="Czy na pewno chcesz usunąć opis?"
+                        description="Ta akcja nie może być cofnięta. Opis zostanie trwale usunięty."
+                        onConfirm={() => handleDelete(detail.id)}
+                        trigger={
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-10 w-10 rounded-xl hover:bg-destructive/10 hover:text-destructive"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        }
+                      />
                     </div>
                   </div>
                 </div>

--- a/components/claim-form/repair-schedule-section.tsx
+++ b/components/claim-form/repair-schedule-section.tsx
@@ -4,6 +4,7 @@ import type React from "react"
 import { useState, useEffect } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import { ConfirmDialog } from "@/components/ui/confirm-dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
@@ -184,7 +185,6 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
   }
 
   const handleDelete = async (scheduleId: string) => {
-    if (!confirm("Czy na pewno chcesz usunąć harmonogram?")) return
     try {
       await deleteRepairSchedule(scheduleId)
       setSchedules((prev) => prev.filter((s) => s.id !== scheduleId))
@@ -814,14 +814,20 @@ export const RepairScheduleSection: React.FC<RepairScheduleSectionProps> = ({ ev
                         >
                           <Edit className="h-4 w-4" />
                         </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => handleDelete(schedule.id!)}
-                          className="h-10 w-10 rounded-xl hover:bg-destructive/10 hover:text-destructive"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
+                        <ConfirmDialog
+                          title="Czy na pewno chcesz usunąć harmonogram?"
+                          description="Ta akcja nie może być cofnięta. Harmonogram zostanie trwale usunięty."
+                          onConfirm={() => handleDelete(schedule.id!)}
+                          trigger={
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-10 w-10 rounded-xl hover:bg-destructive/10 hover:text-destructive"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          }
+                        />
                       </div>
                     </div>
                   </div>

--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 import { useState, useCallback, useMemo, useEffect, useRef } from "react"
 import { Button } from "@/components/ui/button"
+import { ConfirmDialog } from "@/components/ui/confirm-dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -292,7 +293,6 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
   // Delete settlement
   const removeSettlement = useCallback(
     async (settlementId: string) => {
-      if (!window.confirm("Czy na pewno chcesz usunąć tę ugodę?")) return
       try {
         await deleteSettlement(settlementId)
         toast({
@@ -977,15 +977,21 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
                           >
                             <Edit className="h-4 w-4" />
                           </Button>
-                          <Button
-                            onClick={() => removeSettlement(settlement.id!)}
-                            variant="ghost"
-                            size="sm"
-                            className="p-1 text-red-600 hover:text-red-800"
-                            title="Usuń"
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
+                          <ConfirmDialog
+                            title="Czy na pewno chcesz usunąć tę ugodę?"
+                            description="Ta akcja nie może być cofnięta. Ugoda zostanie trwale usunięta."
+                            onConfirm={() => removeSettlement(settlement.id!)}
+                            trigger={
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="p-1 text-red-600 hover:text-red-800"
+                                title="Usuń"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            }
+                          />
                         </div>
                       </td>
                     </tr>

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -1,0 +1,51 @@
+import { ReactNode } from "react"
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog"
+
+interface ConfirmDialogProps {
+  trigger: ReactNode
+  title: string
+  description: string
+  onConfirm: () => void
+  confirmText?: string
+  cancelText?: string
+}
+
+export function ConfirmDialog({
+  trigger,
+  title,
+  description,
+  onConfirm,
+  confirmText = "Usuń",
+  cancelText = "Anuluj",
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{cancelText}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className="bg-red-600 hover:bg-red-700"
+          >
+            {confirmText}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable ConfirmDialog component
- replace browser confirms with styled dialogs for claim form actions
- update repair schedule deletion test

## Testing
- `pnpm lint` *(fails: prompts for configuration)*
- `pnpm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68aef64226dc832c96e0ad542aee6d9b