### PR TITLE
Expand damage and document sections

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -1175,7 +1175,7 @@ export const ClaimMainContent = ({
                   </div>
                   <div>
                     <Label className="text-sm font-medium text-gray-700">Powstałe uszkodzenia</Label>
-                    <div className="p-4 border rounded-lg bg-gray-50 space-y-2 mt-2 max-h-60 overflow-y-auto">
+                    <div className="p-4 border rounded-lg bg-gray-50 space-y-2 mt-2 max-h-96 overflow-y-auto">
                       {claimFormData.damages && claimFormData.damages.length > 0 ? (
                         claimFormData.damages.map((damage, index) => (
                           <div

--- a/components/email/email-compose.tsx
+++ b/components/email/email-compose.tsx
@@ -417,7 +417,7 @@ export const EmailComposeComponent = ({
                   <DialogTitle>Wybierz dokumenty</DialogTitle>
                 </DialogHeader>
                 {availableDocuments.length ? (
-                  <div className="flex flex-col gap-2 max-h-60 overflow-y-auto">
+                  <div className="flex flex-col gap-2 max-h-96 overflow-y-auto">
                     {availableDocuments.map((doc) => {
                       const checked = selectedDocIds.includes(doc.id)
                       return (


### PR DESCRIPTION
## Summary
- expand damage list section to show more items
- expand document picker section to show more documents

## Testing
- `pnpm lint` *(fails: Couldn't configure ESLint)*
- `pnpm test` *(fails: Test failed, see above for details)*

------
https://chatgpt.com/codex/tasks/task_e_68af286b0008832cb091c5697433243d