### PR TITLE
Embed admin panel within main layout

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,125 +1,52 @@
-"use client"
+'use client'
 
-import type React from "react"
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Header } from '@/components/header'
+import { Sidebar } from '@/components/sidebar'
+import { ProtectedRoute } from '@/components/protected-route'
+import { cn } from '@/lib/utils'
+import { useAuth } from '@/hooks/use-auth'
 
-import { useState } from "react"
-import Link from "next/link"
-import { usePathname } from "next/navigation"
-import { Button } from "@/components/ui/button"
-import { Users, Shield, BarChart3, Menu, X, Lock } from "lucide-react"
-import { cn } from "@/lib/utils"
-
-const navigation = [
-  {
-    name: "Dashboard",
-    href: "/admin",
-    icon: BarChart3,
-    exact: true,
-  },
-  {
-    name: "Użytkownicy",
-    href: "/admin/users",
-    icon: Users,
-  },
-  {
-    name: "Role",
-    href: "/admin/roles",
-    icon: Shield,
-  },
-  {
-    name: "Uprawnienia",
-    href: "/admin/permissions",
-    icon: Lock,
-  },
+const ADMIN_NAV_ITEMS = [
+  { href: '/admin', label: 'Dashboard' },
+  { href: '/admin/users', label: 'Użytkownicy' },
+  { href: '/admin/roles', label: 'Role' },
+  { href: '/admin/permissions', label: 'Uprawnienia' },
 ]
 
-export default function AdminLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  const [sidebarOpen, setSidebarOpen] = useState(false)
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  const [activeTab, setActiveTab] = useState('settings')
   const pathname = usePathname()
+  const { user, logout } = useAuth()
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* Mobile sidebar overlay */}
-      {sidebarOpen && (
-        <div className="fixed inset-0 z-40 bg-black/50 lg:hidden" onClick={() => setSidebarOpen(false)} />
-      )}
-
-      {/* Sidebar */}
-      <div
-        className={cn(
-          "fixed inset-y-0 left-0 z-50 w-64 bg-card border-r transform transition-transform duration-200 ease-in-out lg:translate-x-0",
-          sidebarOpen ? "translate-x-0" : "-translate-x-full",
-        )}
-      >
-        <div className="flex h-full flex-col">
-          {/* Header */}
-          <div className="flex h-16 items-center justify-between border-b px-4">
-            <span className="font-semibold">Admin</span>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="lg:hidden"
-              onClick={() => setSidebarOpen(false)}
-            >
-              <X className="h-5 w-5" />
-              <span className="sr-only">Close sidebar</span>
-            </Button>
-          </div>
-
-          {/* Navigation */}
-          <nav className="flex-1 space-y-1 px-4 py-4">
-            {navigation.map((item) => {
-              const isActive = item.exact
-                ? pathname === item.href
-                : pathname.startsWith(item.href) && item.href !== "/admin"
-
-              return (
+    <ProtectedRoute roles={["Admin", "admin"]}>
+      <div className="min-h-screen bg-gray-50">
+        <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+        <div className="ml-16 flex flex-col min-h-screen">
+          <Header onMenuClick={() => {}} user={user ?? undefined} onLogout={logout} />
+          <div className="flex flex-1">
+            <nav className="w-48 border-r bg-white p-4 space-y-2">
+              {ADMIN_NAV_ITEMS.map((item) => (
                 <Link
-                  key={item.name}
+                  key={item.href}
                   href={item.href}
                   className={cn(
-                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-                    isActive
-                      ? "bg-primary text-primary-foreground"
-                      : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                    'block px-3 py-2 rounded-md text-sm font-medium hover:bg-gray-100',
+                    pathname === item.href ? 'bg-gray-100 text-[#1a3a6c]' : 'text-gray-700',
                   )}
-                  onClick={() => setSidebarOpen(false)}
                 >
-                  <item.icon className="h-4 w-4" />
-                  {item.name}
+                  {item.label}
                 </Link>
-              )
-            })}
-          </nav>
-
-          {/* Footer */}
-          
+              ))}
+            </nav>
+            <main className="flex-1 p-6">{children}</main>
+          </div>
         </div>
       </div>
-
-      {/* Main content */}
-      <div className="lg:pl-64">
-        {/* Top bar */}
-        <div className="flex h-16 items-center border-b px-4 lg:px-6">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="lg:hidden"
-            onClick={() => setSidebarOpen(true)}
-          >
-            <Menu className="h-5 w-5" />
-            <span className="sr-only">Open sidebar</span>
-          </Button>
-          <h1 className="ml-2 text-lg font-semibold">Panel administratora</h1>
-        </div>
-
-        {/* Page content */}
-        <main className="flex-1 p-6">{children}</main>
-      </div>
-    </div>
+    </ProtectedRoute>
   )
 }


### PR DESCRIPTION
## Summary
- Integrate admin routes with main layout using global sidebar and header
- Provide internal navigation for admin dashboard, users, roles and permissions

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Module loader error)*

------
https://chatgpt.com/codex/tasks/task_e_68b054e3ffdc832c885efecfa2149e74