### PR TITLE
feat: reload client dropdown on client changes

### DIFF
--- a/app/settings/clients/page.tsx
+++ b/app/settings/clients/page.tsx
@@ -57,7 +57,8 @@ export default function ClientsPage() {
       isActive: true,
     })
     setEditingId(null)
-    loadClients()
+    await loadClients()
+    window.dispatchEvent(new Event("clientsUpdated"))
   }
 
   const handleEdit = (client: ClientDto) => {
@@ -77,7 +78,8 @@ export default function ClientsPage() {
 
   const handleDelete = async (id: number) => {
     await apiService.deleteClient(id)
-    loadClients()
+    await loadClients()
+    window.dispatchEvent(new Event("clientsUpdated"))
   }
 
   return (

--- a/components/client-dropdown.tsx
+++ b/components/client-dropdown.tsx
@@ -43,20 +43,26 @@ export default function ClientDropdown({
     return () => setMounted(false)
   }, [])
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const data = await apiService.getClients()
-        const sorted = [...data].sort((a, b) =>
-          a.name.localeCompare(b.name, "pl", { sensitivity: "base" }),
-        )
-        setClients(sorted)
-        setFilteredClients(sorted)
-      } catch (e) {
-        console.error(e)
-      }
+  const loadClients = async () => {
+    try {
+      const data = await apiService.getClients()
+      const sorted = [...data].sort((a, b) =>
+        a.name.localeCompare(b.name, "pl", { sensitivity: "base" }),
+      )
+      setClients(sorted)
+      setFilteredClients(sorted)
+    } catch (e) {
+      console.error(e)
     }
-    load()
+  }
+
+  useEffect(() => {
+    loadClients()
+    const handleUpdate = () => {
+      loadClients()
+    }
+    window.addEventListener("clientsUpdated", handleUpdate)
+    return () => window.removeEventListener("clientsUpdated", handleUpdate)
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- refresh client dropdown when client list updates via clientsUpdated event
- emit clientsUpdated after client add, edit, or delete

## Testing
- `pnpm lint` (fails: Command failed with exit code 1)
- `pnpm test` (fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)


------
https://chatgpt.com/codex/tasks/task_e_68b098dcf664832c832af001ef13673c