### PR TITLE
Expand My Leaves page to full width

### DIFF
--- a/app/vacations/leaves/my/page.tsx
+++ b/app/vacations/leaves/my/page.tsx
@@ -50,7 +50,7 @@ export default function MyLeavesPage() {
   });
 
   return (
-    <div className="container mx-auto p-4 sm:p-6 lg:p-8 h-screen flex flex-col">
+    <div className="p-4 sm:p-6 lg:p-8 flex flex-col h-full w-full">
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Moje urlopy</h1>


### PR DESCRIPTION
## Summary
- remove container width constraint from MyLeavesPage to span full screen

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c73ab46c832c8b91978c162535e1