### PR TITLE
feat: update button color

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -9,7 +9,8 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-[rgb(26,58,108)] text-white hover:bg-[rgb(26,58,108)]/90",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:


### PR DESCRIPTION
## Summary
- apply brand blue rgb(26,58,108) to default button style

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b18d385488832c900f111e5fc65d18