### PR TITLE
feat: link email attachments to required docs and show send status

### DIFF
--- a/backend/Services/EmailService.cs
+++ b/backend/Services/EmailService.cs
@@ -130,6 +130,7 @@ namespace AutomotiveClaimsApi.Services
                 return false;
 
             email.NeedsSending = true;
+            email.Direction = "Outbound";
             email.Status = "Pending";
             email.UpdatedAt = DateTime.UtcNow;
             await _context.SaveChangesAsync();

--- a/components/email/email-inbox.tsx
+++ b/components/email/email-inbox.tsx
@@ -23,6 +23,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
+import { Badge } from "@/components/ui/badge"
 import { emailService, type EmailDto, type AttachmentDto, type SendEmailRequestDto } from "@/lib/email-service"
 import { EmailFolder } from "@/types/email"
 import { useDebounce } from "@/hooks/use-debounce"
@@ -574,6 +575,21 @@ export default function EmailInbox({ claimId, claimNumber, claimInsuranceNumber 
     }
   }, [])
 
+  const getStatusLabel = (status?: string): string => {
+    switch (status) {
+      case "Pending":
+        return "Do wysłania"
+      case "Sent":
+        return "Wysłany"
+      case "Failed":
+        return "Błąd"
+      case "Draft":
+        return "Szkic"
+      default:
+        return status || ""
+    }
+  }
+
   // Check if image
   const isImage = useCallback((contentType: string): boolean => {
     return contentType.startsWith("image/")
@@ -734,6 +750,11 @@ export default function EmailInbox({ claimId, claimNumber, claimInsuranceNumber 
                         <span className="email-mail-subject font-medium">{email.subject}</span>
                         <span className="email-mail-separator text-gray-400 mx-1">-</span>
                         <span className="email-mail-snippet text-gray-500">{stripHtml(email.body)}</span>
+                        {email.status && email.status !== "Received" && (
+                          <Badge variant="secondary" className="ml-2">
+                            {getStatusLabel(email.status)}
+                          </Badge>
+                        )}
                       </div>
                       <div className="flex items-center gap-2">
                         {emailService.hasAttachments(email) && (

--- a/components/email/email-section-compact.tsx
+++ b/components/email/email-section-compact.tsx
@@ -57,6 +57,7 @@ export const EmailSection = ({
     isStarred: false,
     isImportant: dto.isImportant ?? false,
     folder: dto.direction === "Outbound" ? "sent" : "inbox",
+    status: dto.status,
     date: dto.receivedDate || new Date().toISOString(),
     attachments:
       dto.attachments?.map((a) => ({
@@ -71,10 +72,10 @@ export const EmailSection = ({
     claimIds: dto.claimIds,
     eventId: dto.eventId,
   })
-  const loadEmails = async (folder: string) => {
+  const loadEmails = async (folder?: string) => {
     try {
       let data: EmailDto[]
-      const folderEnum = folder as EmailFolder
+      const folderEnum = (folder ?? activeTab) as EmailFolder
       if (claimId) {
         data = await emailService.getEmailsByEventId(claimId, folderEnum)
       } else {
@@ -138,6 +139,21 @@ export const EmailSection = ({
       return date.toLocaleDateString("pl-PL", { weekday: "short" })
     } else {
       return date.toLocaleDateString("pl-PL", { day: "2-digit", month: "2-digit" })
+    }
+  }
+
+  const getStatusLabel = (status: string) => {
+    switch (status) {
+      case "Pending":
+        return "Do wysłania"
+      case "Sent":
+        return "Wysłany"
+      case "Failed":
+        return "Błąd"
+      case "Draft":
+        return "Szkic"
+      default:
+        return status
     }
   }
 
@@ -234,7 +250,7 @@ export const EmailSection = ({
     })
     if (success) {
       toast({ title: "E-mail wysłany", description: "Wiadomość została wysłana pomyślnie" })
-      await loadEmails()
+      await loadEmails(activeTab)
       setCurrentView("list")
       setComposeData({})
     } else {
@@ -258,7 +274,7 @@ export const EmailSection = ({
     })
     if (success) {
       toast({ title: "Szkic zapisany", description: "Wiadomość została zapisana w szkicach" })
-      await loadEmails()
+      await loadEmails(activeTab)
       setCurrentView("list")
       setComposeData({})
     } else {
@@ -433,6 +449,11 @@ export const EmailSection = ({
                                   {label}
                                 </Badge>
                               ))}
+                              {email.status && email.status !== "Received" && (
+                                <Badge variant="secondary" className="text-xs">
+                                  {getStatusLabel(email.status)}
+                                </Badge>
+                              )}
                             </div>
                             <div className="flex items-center space-x-2 flex-shrink-0">
                               {email.attachments.length > 0 && <Paperclip className="h-4 w-4 text-gray-400" />}

--- a/components/email/email-view.tsx
+++ b/components/email/email-view.tsx
@@ -53,6 +53,7 @@ export const EmailView = ({
   onAssignAttachment,
 }: EmailViewProps) => {
   const [showFullHeaders, setShowFullHeaders] = useState(false)
+  const availableDocs = requiredDocuments.filter((d) => d.required && !d.uploaded)
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString)
@@ -265,8 +266,8 @@ export const EmailView = ({
                                 <DialogTitle>Przypisz do dokumentu</DialogTitle>
                               </DialogHeader>
                               <div className="flex flex-col gap-2">
-                                {requiredDocuments.length ? (
-                                  requiredDocuments.map((doc) => (
+                                {availableDocs.length ? (
+                                  availableDocs.map((doc) => (
                                     <Button
                                       key={doc.id}
                                       variant="outline"

--- a/emailservice/EmailClient.cs
+++ b/emailservice/EmailClient.cs
@@ -214,6 +214,7 @@ public class EmailClient
                 await client.SendAsync(message);
                 await client.DisconnectAsync(true);
 
+                email.Direction = "Outbound";
                 email.NeedsSending = false;
                 email.Status = "Sent";
                 email.SentAt = DateTime.UtcNow;

--- a/types/email.ts
+++ b/types/email.ts
@@ -43,6 +43,7 @@ export interface Email {
   date: string
   attachments: EmailAttachment[]
   labels: string[]
+  status?: string
   claimId?: string
   eventId?: string
   claimIds?: string[]


### PR DESCRIPTION
## Summary
- keep email list scoped to current folder
- surface email sending status for sent items
- display email status badge in inbox list
- mark queued emails as outbound and update status after sending
- allow assigning email attachments to missing required documents

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `dotnet test backend/AutomotiveClaimsApi.Tests` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b201a79a98832cb465a98d4a997dce