### PR TITLE
Display claim number in email sections

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -1651,6 +1651,7 @@ export const ClaimMainContent = ({
             <CardContent className="p-0 bg-white">
               <EmailSection
                 claimId={claimFormData.id}
+                claimNumber={claimFormData.claimNumber}
                 uploadedFiles={uploadedFiles}
                 setUploadedFiles={setUploadedFiles}
                 requiredDocuments={requiredDocuments}

--- a/components/email/email-compose.tsx
+++ b/components/email/email-compose.tsx
@@ -42,7 +42,7 @@ interface EmailComposeProps {
   replyTo?: string
   replySubject?: string
   replyBody?: string
-  claimId: string
+  claimNumber: string
   availableDocuments?: UploadedFile[]
 }
 
@@ -53,7 +53,7 @@ export const EmailComposeComponent = ({
   replyTo,
   replySubject,
   replyBody,
-  claimId,
+  claimNumber,
   availableDocuments = [],
 }: EmailComposeProps) => {
   const { toast } = useToast()
@@ -159,9 +159,9 @@ export const EmailComposeComponent = ({
     if (template) {
       setEmailData((prev) => ({
         ...prev,
-        subject: template.subject.replace("{{claimNumber}}", claimId),
+        subject: template.subject.replace("{{claimNumber}}", claimNumber),
         body: template.body
-          .replace("{{claimNumber}}", claimId)
+          .replace("{{claimNumber}}", claimNumber)
           .replace("{{handlerName}}", "Piotr Raniecki")
           .replace("{{repairCost}}", "15,600.00")
           .replace("{{otherCosts}}", "0.00")

--- a/components/email/email-section-compact.tsx
+++ b/components/email/email-section-compact.tsx
@@ -30,6 +30,7 @@ import type { UploadedFile, RequiredDocument } from "@/types"
 
 interface EmailSectionProps {
   claimId?: string
+  claimNumber?: string
   uploadedFiles?: UploadedFile[]
   setUploadedFiles?: Dispatch<SetStateAction<UploadedFile[]>>
   requiredDocuments?: RequiredDocument[]
@@ -38,6 +39,7 @@ interface EmailSectionProps {
 
 export const EmailSection = ({
   claimId,
+  claimNumber,
   uploadedFiles,
   setUploadedFiles,
   requiredDocuments,
@@ -303,7 +305,7 @@ export const EmailSection = ({
         replyTo={composeData.replyTo}
         replySubject={composeData.replySubject}
         replyBody={composeData.replyBody}
-        claimId={claimId || ""}
+        claimNumber={claimNumber || ""}
         availableDocuments={documents}
       />
     )
@@ -346,7 +348,7 @@ export const EmailSection = ({
     <div className="space-y-6">
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
-          <CardTitle className="text-lg font-semibold">Korespondencja e-mail {claimId && `- ${claimId}`}</CardTitle>
+          <CardTitle className="text-lg font-semibold">Korespondencja e-mail {claimNumber && `- ${claimNumber}`}</CardTitle>
           <Button onClick={handleCompose} className="bg-blue-600 hover:bg-blue-700">
             <Plus className="h-4 w-4 mr-2" />
             Napisz e-mail

--- a/components/email/email-section.tsx
+++ b/components/email/email-section.tsx
@@ -13,6 +13,7 @@ import { API_BASE_URL } from "@/lib/api"
 
 interface EmailSectionProps {
   claimId?: string
+  claimNumber?: string
   uploadedFiles?: UploadedFile[]
   setUploadedFiles?: Dispatch<SetStateAction<UploadedFile[]>>
   requiredDocuments?: RequiredDocument[]
@@ -21,6 +22,7 @@ interface EmailSectionProps {
 
 export const EmailSection = ({
   claimId,
+  claimNumber,
   uploadedFiles,
   setUploadedFiles,
   requiredDocuments,
@@ -36,7 +38,7 @@ export const EmailSection = ({
     replyTo?: string
     replySubject?: string
     replyBody?: string
-    claimId?: string
+    claimNumber?: string
   }>({})
 
   const [internalDocuments, setInternalDocuments] = useState<UploadedFile[]>([
@@ -169,7 +171,7 @@ export const EmailSection = ({
       replyTo: email.from,
       replySubject: email.subject.startsWith("Re:") ? email.subject : `Re: ${email.subject}`,
       replyBody: email.body,
-      claimId: claimId,
+      claimNumber: claimNumber,
     })
     setCurrentView("compose")
   }
@@ -183,7 +185,7 @@ export const EmailSection = ({
       replyTo: allRecipients,
       replySubject: email.subject.startsWith("Re:") ? email.subject : `Re: ${email.subject}`,
       replyBody: email.body,
-      claimId: claimId,
+      claimNumber: claimNumber,
     })
     setCurrentView("compose")
   }
@@ -192,7 +194,7 @@ export const EmailSection = ({
     setComposeData({
       replySubject: email.subject.startsWith("Fwd:") ? email.subject : `Fwd: ${email.subject}`,
       replyBody: `\n\n--- Przekazana wiadomość ---\nOd: ${email.fromName} <${email.from}>\nData: ${email.date}\nTemat: ${email.subject}\n\n${email.body}`,
-      claimId: claimId,
+      claimNumber: claimNumber,
     })
     setCurrentView("compose")
   }
@@ -312,7 +314,7 @@ export const EmailSection = ({
             replyTo={composeData.replyTo}
             replySubject={composeData.replySubject}
             replyBody={composeData.replyBody}
-            claimId={composeData.claimId || ""}
+            claimNumber={composeData.claimNumber || claimNumber || ""}
             availableDocuments={documents}
           />
         </div>


### PR DESCRIPTION
## Summary
- show claim number in email section headers instead of raw ids
- pass claim numbers into email compose templates and references
- propagate claim number through claim form components

## Testing
- `pnpm lint` (fails: How would you like to configure ESLint?)
- `pnpm test` (fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)

------
https://chatgpt.com/codex/tasks/task_e_68b218aed418832c9584ab6834e2ca8c