### PR TITLE
Collapse document sections by default

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -90,7 +90,7 @@ export const DocumentsSection = React.forwardRef<
     return "list"
   })
   const fileInputRef = React.useRef<HTMLInputElement>(null)
-  const [openCategories, setOpenCategories] = useState<Record<string, boolean>>({ "Inne dokumenty": true })
+  const [openCategories, setOpenCategories] = useState<Record<string, boolean>>({})
   const [uploadingForCategory, setUploadingForCategory] = useState<string | null>(null)
   const [documents, setDocuments] = useState<Document[]>([])
   const [loading, setLoading] = useState(false)


### PR DESCRIPTION
## Summary
- Collapse all document categories by default when rendering the documents section

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle.)*

------
https://chatgpt.com/codex/tasks/task_e_68b199291518832c90e714db0a4d6e6e