### PR TITLE
fix: use case handler numeric id when filtering claims

### DIFF
--- a/app/vacations/manage/page.tsx
+++ b/app/vacations/manage/page.tsx
@@ -6,7 +6,7 @@ import { API_BASE_URL } from "@/lib/api";
 
 interface VacationRequest {
   id: string;
-  claimHandlerId: string;
+  caseHandlerId: string;
   substituteId: string;
   managerIds: string[];
   startDate: string;
@@ -32,7 +32,7 @@ export default function VacationManagePage() {
       <h1 className="text-xl font-semibold">Wnioski urlopowe</h1>
       {requests.map((r) => (
         <div key={r.id} className="p-4 border rounded space-y-2">
-          <p>Likwidator: {r.claimHandlerId}</p>
+          <p>Likwidator: {r.caseHandlerId}</p>
           <p>Od: {new Date(r.startDate).toLocaleDateString()}</p>
           <p>Do: {new Date(r.endDate).toLocaleDateString()}</p>
           <div className="space-x-2">

--- a/app/vacations/page.tsx
+++ b/app/vacations/page.tsx
@@ -22,7 +22,7 @@ export default function VacationPage() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        claimHandlerId: user?.id,
+        caseHandlerId: user?.id,
         substituteId,
         managerIds: managers.map((m) => m.id),
         startDate,

--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -61,7 +61,7 @@ namespace AutomotiveClaimsApi.Controllers
             [FromQuery] string? status = null,
             [FromQuery] string? riskType = null,
             [FromQuery] string? policyNumber = null,
-            [FromQuery] int? claimHandlerId = null,
+            [FromQuery] int? caseHandlerId = null,
             [FromQuery] DateTime? damageDate = null,
             [FromQuery] DateTime? reportFromDate = null,
             [FromQuery] DateTime? reportToDate = null,
@@ -141,9 +141,9 @@ namespace AutomotiveClaimsApi.Controllers
                     query = query.Where(e => e.PolicyNumber != null && e.PolicyNumber.Contains(policyNumber));
                 }
 
-                if (claimHandlerId.HasValue)
+                if (caseHandlerId.HasValue)
                 {
-                    query = query.Where(e => e.HandlerId == claimHandlerId.Value);
+                    query = query.Where(e => e.HandlerId == caseHandlerId.Value);
                 }
 
                 if (damageDate.HasValue)

--- a/backend/Controllers/VacationsController.cs
+++ b/backend/Controllers/VacationsController.cs
@@ -26,7 +26,7 @@ namespace AutomotiveClaimsApi.Controllers
             var request = new VacationRequest
             {
                 Id = Guid.NewGuid(),
-                ClaimHandlerId = dto.ClaimHandlerId,
+                CaseHandlerId = dto.CaseHandlerId,
                 SubstituteId = dto.SubstituteId,
                 ManagerIds = dto.ManagerIds,
                 StartDate = dto.StartDate,
@@ -88,7 +88,7 @@ namespace AutomotiveClaimsApi.Controllers
         private static VacationRequestDto ToDto(VacationRequest request) => new()
         {
             Id = request.Id,
-            ClaimHandlerId = request.ClaimHandlerId,
+            CaseHandlerId = request.CaseHandlerId,
             SubstituteId = request.SubstituteId,
             ManagerIds = request.ManagerIds,
             StartDate = request.StartDate,

--- a/backend/DTOs/CreateVacationRequestDto.cs
+++ b/backend/DTOs/CreateVacationRequestDto.cs
@@ -5,7 +5,7 @@ namespace AutomotiveClaimsApi.DTOs
 {
     public class CreateVacationRequestDto
     {
-        public string ClaimHandlerId { get; set; } = string.Empty;
+        public string CaseHandlerId { get; set; } = string.Empty;
         public string SubstituteId { get; set; } = string.Empty;
         public List<string> ManagerIds { get; set; } = new();
         public DateTime StartDate { get; set; }

--- a/backend/DTOs/VacationRequestDto.cs
+++ b/backend/DTOs/VacationRequestDto.cs
@@ -6,7 +6,7 @@ namespace AutomotiveClaimsApi.DTOs
     public class VacationRequestDto
     {
         public Guid Id { get; set; }
-        public string ClaimHandlerId { get; set; } = string.Empty;
+        public string CaseHandlerId { get; set; } = string.Empty;
         public string SubstituteId { get; set; } = string.Empty;
         public List<string> ManagerIds { get; set; } = new();
         public DateTime StartDate { get; set; }

--- a/backend/Models/VacationRequest.cs
+++ b/backend/Models/VacationRequest.cs
@@ -13,7 +13,7 @@ namespace AutomotiveClaimsApi.Models
     public class VacationRequest
     {
         public Guid Id { get; set; }
-        public string ClaimHandlerId { get; set; } = string.Empty;
+        public string CaseHandlerId { get; set; } = string.Empty;
         public string SubstituteId { get; set; } = string.Empty;
         public List<string> ManagerIds { get; set; } = new();
         public DateTime StartDate { get; set; }

--- a/components/claim-form/damage-data-section.tsx
+++ b/components/claim-form/damage-data-section.tsx
@@ -306,9 +306,9 @@ export function DamageDataSection({
                 Likwidator
               </Label>
               <HandlerDropdown
-                selectedHandlerId={claimFormData.claimHandlerId || undefined}
+                selectedHandlerId={claimFormData.caseHandlerId || undefined}
                 onHandlerSelected={(event: HandlerSelectionEvent) => {
-                  handleFormChange("claimHandlerId", event.handlerId.toString())
+                  handleFormChange("caseHandlerId", event.handlerId.toString())
                   handleFormChange("handler", event.handlerName)
                   handleFormChange("handlerEmail", event.handlerEmail || "")
                   handleFormChange("handlerPhone", event.handlerPhone || "")

--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -64,7 +64,7 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
     client: '',
     clientId: '',
     handler: '',
-    claimHandlerId: '',
+    caseHandlerId: '',
     handlerEmail: '',
     handlerPhone: '',
     insuranceCompany: '',

--- a/components/claim-form/property-damage-section.tsx
+++ b/components/claim-form/property-damage-section.tsx
@@ -252,9 +252,9 @@ export function PropertyDamageSection({
                 Likwidator
               </Label>
               <HandlerDropdown
-                selectedHandlerId={claimFormData.claimHandlerId || undefined}
+                selectedHandlerId={claimFormData.caseHandlerId || undefined}
                 onHandlerSelected={(event: HandlerSelectionEvent) => {
-                  handleFormChange("claimHandlerId", event.handlerId.toString())
+                  handleFormChange("caseHandlerId", event.handlerId.toString())
                   handleFormChange("handler", event.handlerName)
                   handleFormChange("handlerEmail", event.handlerEmail || "")
                   handleFormChange("handlerPhone", event.handlerPhone || "")

--- a/components/claims-list-desktop.tsx
+++ b/components/claims-list-desktop.tsx
@@ -174,7 +174,10 @@ export function ClaimsListDesktop({
               new Date(l.startDate) <= today &&
               new Date(l.endDate) >= today,
           )
-          .map((l: any) => ({ id: l.employeeId, name: l.employeeName }))
+          .map((l: any) => ({
+            id: String(l.caseHandlerId),
+            name: l.employeeName,
+          }))
         const unique = Array.from(
           new Map(options.map((o: any) => [o.id, o])).values(),
         )
@@ -202,8 +205,11 @@ export function ClaimsListDesktop({
             riskType: filterRisk !== "all" ? filterRisk : undefined,
             brand: filterRegistration || undefined,
             handler: filterHandler || undefined,
-            claimHandlerId:
-              showMyClaims ? user?.id : selectedSubstituteId || undefined,
+            caseHandlerId: showMyClaims
+              ? user?.caseHandlerId
+              : selectedSubstituteId
+              ? parseInt(selectedSubstituteId, 10)
+              : undefined,
             registeredById: showMyClaims ? user?.id : undefined,
             claimObjectTypeId,
             sortBy,
@@ -237,6 +243,7 @@ export function ClaimsListDesktop({
     selectedSubstituteId,
     showMyClaims,
     user?.id,
+    user?.caseHandlerId,
     dateFilters,
     claimObjectTypeId,
     sortBy,
@@ -363,8 +370,11 @@ export function ClaimsListDesktop({
           riskType: filterRisk !== "all" ? filterRisk : undefined,
           brand: filterRegistration || undefined,
           handler: filterHandler || undefined,
-          claimHandlerId:
-            showMyClaims ? user?.id : selectedSubstituteId || undefined,
+          caseHandlerId: showMyClaims
+            ? user?.caseHandlerId
+            : selectedSubstituteId
+            ? parseInt(selectedSubstituteId, 10)
+            : undefined,
           registeredById: showMyClaims ? user?.id : undefined,
           claimObjectTypeId,
           sortBy,

--- a/docs/vacation-module.md
+++ b/docs/vacation-module.md
@@ -27,7 +27,7 @@ This document proposes a vacation module for claim handlers.
 
 ## Backend
 - Add `VacationRequest` entity with fields:
-- `Id`, `ClaimHandlerId`, `ManagerIds`, `SubstituteId`.
+- `Id`, `CaseHandlerId`, `ManagerIds`, `SubstituteId`.
   - `StartDate`, `EndDate`, `Status` (Pending, Approved, Rejected).
 - Endpoints:
   - `POST /api/vacations` – create request (handler).
@@ -52,7 +52,7 @@ This document proposes a vacation module for claim handlers.
 VacationRequest
 ---------------
 Id: Guid
-ClaimHandlerId: string
+CaseHandlerId: string
 SubstituteId: string
 ManagerIds: List<string>
 StartDate: DateTime

--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -11,14 +11,14 @@ test('includes dropdown selections in payload', () => {
     damageType: { code: 'DT', name: 'Damage' } as any,
     insuranceCompanyId: '5',
     clientId: '7',
-    claimHandlerId: '9',
+    caseHandlerId: '9',
   } as any)
 
   assert.equal(payload.riskType, '5')
   assert.equal(payload.damageType, 'DT')
   assert.equal(payload.insuranceCompanyId, 5)
   assert.equal(payload.clientId, 7)
-  assert.equal(payload.claimHandlerId, 9)
+  assert.equal(payload.caseHandlerId, 9)
 })
 
 test('maps transportDamage fields', () => {

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -71,7 +71,7 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
     objectTypeId: rest.objectTypeId,
     insuranceCompanyId: rest.insuranceCompanyId?.toString(),
     leasingCompanyId: rest.leasingCompanyId?.toString(),
-    claimHandlerId: rest.claimHandlerId?.toString(),
+    caseHandlerId: rest.caseHandlerId?.toString(),
     clientId: rest.clientId?.toString(),
     totalClaim: rest.totalClaim ?? 0,
     payout: rest.payout ?? 0,
@@ -172,7 +172,7 @@ export const transformFrontendClaimToApiPayload = (
     documents,
     insuranceCompanyId,
     leasingCompanyId,
-    claimHandlerId,
+    caseHandlerId,
     clientId,
     riskType,
     damageType,
@@ -269,7 +269,7 @@ export const transformFrontendClaimToApiPayload = (
     insuranceCompanyId: insuranceCompanyId ? parseInt(insuranceCompanyId, 10) : undefined,
     leasingCompanyId: leasingCompanyId ? parseInt(leasingCompanyId, 10) : undefined,
     clientId: clientId ? parseInt(clientId, 10) : undefined,
-    claimHandlerId: claimHandlerId ? parseInt(claimHandlerId, 10) : undefined,
+    caseHandlerId: caseHandlerId ? parseInt(caseHandlerId, 10) : undefined,
     victimRegistrationNumber: injuredParty?.vehicleRegistration,
     perpetratorRegistrationNumber: perpetrator?.vehicleRegistration,
     riskType,
@@ -421,7 +421,7 @@ export function useClaims() {
           clientId: claim.clientId?.toString(),
           insuranceCompanyId: claim.insuranceCompanyId?.toString(),
           leasingCompanyId: claim.leasingCompanyId?.toString(),
-          claimHandlerId: claim.claimHandlerId?.toString(),
+          caseHandlerId: claim.caseHandlerId?.toString(),
         })) as Claim[]
 
         setClaims((prev) =>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -60,7 +60,7 @@ export interface EventListItemDto {
   damageType?: string
   leasingCompanyId?: number
   leasingCompany?: string
-  claimHandlerId?: number
+  caseHandlerId?: number
   handler?: string
   objectTypeId?: number
   registeredById?: string
@@ -91,7 +91,7 @@ export interface EventDto extends EventListItemDto {
   perpetratorData?: string
 
   insuranceCompanyId?: number
-  claimHandlerId?: number
+  caseHandlerId?: number
   riskType?: string
   damageType?: string
   subcontractorName?: string
@@ -182,7 +182,7 @@ export interface EventUpsertDto {
   insuranceCompany?: string
   leasingCompanyId?: number
   leasingCompany?: string
-  claimHandlerId?: number
+  caseHandlerId?: number
   handler?: string
   damageDate?: string
   reportDate?: string

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -82,7 +82,7 @@ export const initialClaimFormData: Partial<Claim> = {
   client: "",
   clientId: "",
   handler: "",
-  claimHandlerId: "",
+  caseHandlerId: "",
   handlerEmail: "",
   handlerPhone: "",
   leasingCompany: "",

--- a/types/index.ts
+++ b/types/index.ts
@@ -55,7 +55,7 @@ export interface Claim
     | "clientId"
     | "insuranceCompanyId"
     | "leasingCompanyId"
-    | "claimHandlerId"
+    | "caseHandlerId"
     | "servicesCalled"
     | "participants"
     | "damages"
@@ -87,7 +87,7 @@ export interface Claim
   clientId?: string
   insuranceCompanyId?: string
   leasingCompanyId?: string
-  claimHandlerId?: string
+  caseHandlerId?: string
   isDraft?: boolean
   /**
    * List of services called.


### PR DESCRIPTION
## Summary
- ensure claim filters use numeric case handler IDs instead of user GUIDs
- rename `claimHandlerId` to `caseHandlerId` across frontend and backend
- map leave substitution options to case handler IDs

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*


------
https://chatgpt.com/codex/tasks/task_e_68b210fd97e0832cb73026131f16097e