### PR TITLE
Reduce document placeholder padding

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -1745,7 +1745,7 @@ export const DocumentsSection = React.forwardRef<
                       </table>
                       {documentsForCategory.length === 0 && (
                         <div
-                          className={`flex flex-col items-center justify-center text-center py-12 text-gray-500 border-2 border-dashed rounded-lg cursor-pointer transition-colors m-4 ${
+                          className={`flex flex-col items-center justify-center text-center py-4 text-gray-500 border-2 border-dashed rounded-lg cursor-pointer transition-colors m-4 ${
                             dragActive && dragCategory === category
                               ? "border-blue-500 bg-blue-50"
                               : "border-gray-300 hover:bg-gray-50"
@@ -1777,7 +1777,7 @@ export const DocumentsSection = React.forwardRef<
                     </div>
                   ) : (
                     <div
-                      className={`flex flex-col items-center justify-center text-center py-12 text-gray-500 border-2 border-dashed rounded-lg cursor-pointer transition-colors ${
+                      className={`flex flex-col items-center justify-center text-center py-4 text-gray-500 border-2 border-dashed rounded-lg cursor-pointer transition-colors ${
                         dragActive && dragCategory === category
                           ? "border-blue-500 bg-blue-50"
                           : "border-gray-300 hover:bg-gray-50"


### PR DESCRIPTION
## Summary
- shrink empty document dropzone padding for a more compact placeholder

## Testing
- `pnpm test` *(fails: Cannot require() ES Module /app/api/appeals/route.ts in a cycle)*
- `pnpm lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b2187fb680832c8999eaec6d858bc6