### PR TITLE
Fix unauthorized error by using authFetch

### DIFF
--- a/app/claims/[id]/view/page.tsx
+++ b/app/claims/[id]/view/page.tsx
@@ -9,6 +9,7 @@ import { Toaster } from '@/components/ui/toaster';
 import { ArrowLeft, Edit } from 'lucide-react';
 import type { Claim, Note, UploadedFile } from '@/types';
 import { transformApiClaimToFrontend } from '@/hooks/use-claims';
+import { authFetch } from '@/lib/auth-fetch';
 import { dictionaryService, type DictionaryItemDto } from '@/lib/dictionary-service';
 import CommunicationClaimSummary from '@/components/claim-form/communication-claim-summary';
 import { PropertyClaimSummary } from '@/components/claim-form/property-claim-summary';
@@ -38,9 +39,8 @@ export default function ViewClaimPage() {
     try {
       setIsLoading(true);
       setLoadError(null);
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/claims/${id}`, {
+      const response = await authFetch(`${process.env.NEXT_PUBLIC_API_URL}/claims/${id}`, {
         method: 'GET',
-        credentials: 'omit',
       });
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);


### PR DESCRIPTION
## Summary
- use authFetch in claim view page to send auth header

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1)*
- `pnpm test` *(fails: Test failed. See above for more details.)*


------
https://chatgpt.com/codex/tasks/task_e_68b22045cc5c832c8e6046c2d0d80c5f