### PR TITLE
Remove unassigned claims link from sidebar

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -2,9 +2,8 @@
 import Link from "next/link"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 
-import { LayoutDashboard, FileText, Car, Settings, Inbox, Calendar, CalendarCheck, BarChart3 } from "lucide-react"
+import { LayoutDashboard, FileText, Car, Settings, Calendar, CalendarCheck, BarChart3 } from "lucide-react"
 
 import { useAuth } from "@/hooks/use-auth"
 
@@ -38,14 +37,6 @@ const menuItems = [
     icon: CalendarCheck,
     href: "/vacations/leaves",
     roles: ["Admin", "admin"],
-  },
-  {
-    id: "unassigned",
-    label: "Szkody nieprzydzielone",
-
-    icon: Inbox,
-
-    href: "/emails/unassigned",
   },
   {
     id: "reports",
@@ -104,9 +95,6 @@ export function Sidebar(props: SidebarProps) {
                 className="flex items-center"
               >
                 <Icon className="h-5 w-5" />
-                {item.id === "unassigned" && (
-                  <Badge className="ml-2 bg-blue-100 text-blue-800">1</Badge>
-                )}
               </Link>
             </Button>
           )


### PR DESCRIPTION
## Summary
- remove "Szkody nieprzydzielone" menu link and badge

## Testing
- `pnpm lint` (fails: configuration prompt / exit code 1)
- `pnpm test` (fails: 1 failing test)


------
https://chatgpt.com/codex/tasks/task_e_68b21f2a6310832caddaf84366d76d4d