### PR TITLE
Defer claim ID generation to first save

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -28,7 +28,6 @@ import { ClaimMainContent } from "@/components/claim-form/claim-main-content"
 import { useClaimForm } from "@/hooks/use-claim-form"
 import { useClaims, transformApiClaimToFrontend } from "@/hooks/use-claims"
 import { useAuth } from "@/hooks/use-auth"
-import { generateId } from "@/lib/constants"
 import type { Claim, UploadedFile, RequiredDocument } from "@/types"
 import { getRequiredDocumentsByObjectType } from "@/lib/required-documents"
 
@@ -164,7 +163,6 @@ export default function ClaimPage() {
       if (mode === "new") {
         const newClaimData = {
           ...claimFormData,
-          id: generateId(),
           claimNumber: `PL${new Date().getFullYear()}${String(Date.now()).slice(-8)}`,
           registeredById: user?.id,
         } as Claim

--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -54,6 +54,11 @@ namespace AutomotiveClaimsApi.Controllers
             _eventDocumentStore = eventDocumentStore ?? throw new ArgumentNullException(nameof(eventDocumentStore));
         }
 
+        private static Guid EnsureClaimId(Guid? id)
+        {
+            return !id.HasValue || id == Guid.Empty ? Guid.NewGuid() : id.Value;
+        }
+
         [HttpGet]
         public async Task<ActionResult<IEnumerable<ClaimListItemDto>>> GetClaims(
             [FromQuery] string? search = null,
@@ -337,10 +342,8 @@ namespace AutomotiveClaimsApi.Controllers
         {
             try
             {
-                if (!eventDto.Id.HasValue || eventDto.Id == Guid.Empty)
-                {
-                    return BadRequest("Claim ID is required. Use the initialize endpoint to obtain one.");
-                }
+                var claimId = EnsureClaimId(eventDto.Id);
+                eventDto.Id = claimId;
 
                 var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
                 ApplicationUser? currentUser = null;

--- a/hooks/use-claim-form.ts
+++ b/hooks/use-claim-form.ts
@@ -4,28 +4,11 @@ import { useState, useCallback } from "react"
 import { initialClaimFormData, emptyDriver, generateId } from "@/lib/constants"
 import type { Claim, ParticipantInfo, DriverInfo } from "@/types"
 
-// Global claim identifier handling
-let globalClaimId: string | null = null
-
-const generateClaimId = () =>
-  typeof crypto !== "undefined" && "randomUUID" in crypto
-    ? crypto.randomUUID()
-    : generateId()
-
-const createNewClaimId = () => {
-  globalClaimId = generateClaimId()
-  return globalClaimId
-}
-
-export const getGlobalClaimId = () => {
-  return globalClaimId || createNewClaimId()
-}
-
 export function useClaimForm(initialData?: Partial<Claim>) {
   const [claimFormData, setClaimFormData] = useState<Partial<Claim>>({
     ...initialClaimFormData,
 
-    id: initialData?.id ?? generateId(),
+    id: initialData?.id,
 
     ...initialData,
   })
@@ -143,8 +126,7 @@ export function useClaimForm(initialData?: Partial<Claim>) {
   }, [])
 
   const resetForm = useCallback(() => {
-    const newId = createNewClaimId()
-    setClaimFormData({ ...initialClaimFormData, id: newId })
+    setClaimFormData({ ...initialClaimFormData })
   }, [])
 
   return {

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -9,7 +9,6 @@ import {
   type ParticipantUpsertDto,
 } from "@/lib/api"
 import type { Claim, ParticipantInfo, DriverInfo, Note } from "@/types"
-import { generateId } from "@/lib/constants"
 
 const toIso = (value?: string, field?: string): string | undefined => {
   if (!value) return undefined
@@ -471,10 +470,6 @@ export function useClaims() {
     try {
       setError(null)
       const payload = transformFrontendClaimToApiPayload(claimData)
-
-      if (!payload.id) {
-        payload.id = generateId()
-      }
 
       const newApiClaim = await apiService.createClaim(payload)
       const newClaim = transformApiClaimToFrontend(newApiClaim)


### PR DESCRIPTION
## Summary
- Generate new claim IDs on the server when missing
- Stop pre-initializing claim IDs on the frontend and create ID on first save
- Allow subsequent saves to update existing claims
- Clarify server-side claim ID generation and drop client-side form ID resets

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*
- `npm run lint` *(prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d6a1f5dc832cb24ae755d7c3c118