### PR TITLE
feat: fetch dashboard stats

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -66,24 +66,8 @@ function HomePage({ user, onLogout }: PageProps) {
   useEffect(() => {
     async function loadStats() {
       try {
-        const res = await fetch("/api/dashboard");
-        if (!res.ok) {
-          console.warn(
-            "Failed to fetch dashboard stats:",
-            res.status,
-            res.statusText,
-          );
-          return;
-        }
-        const contentType = res.headers.get("content-type");
-        if (!contentType || !contentType.includes("application/json")) {
-          console.warn(
-            "Unexpected response format for dashboard stats:",
-            contentType,
-          );
-          return;
-        }
-        const data = await res.json();
+        const scope = isBasicUser ? "user" : "client";
+        const data = await apiService.getDashboardStats(scope);
         setStats([
           { ...initialStats[0], value: data.totalClaims?.toString() },
           { ...initialStats[1], value: data.activeClaims?.toString() },

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -153,6 +153,12 @@ export interface AdminSettings {
   serverTime: string
 }
 
+export interface DashboardStats {
+  totalClaims: number
+  activeClaims: number
+  closedClaims: number
+}
+
 export interface EventUpsertDto {
   id?: string
   rowVersion?: string
@@ -941,6 +947,10 @@ class ApiService {
     }
     const query = search.toString()
     return this.request<NoteDto[]>(`/notes${query ? `?${query}` : ""}`)
+  }
+
+  async getDashboardStats(scope: "user" | "client" = "user"): Promise<DashboardStats> {
+    return this.request<DashboardStats>(`/dashboard/${scope}`)
   }
 
   async getCurrentUser(): Promise<{ id: string; username: string; email?: string; caseHandlerId?: number; roles?: string[]; createdAt?: string; lastLogin?: string } | undefined> {


### PR DESCRIPTION
## Summary
- extend API service with dashboard stats retrieval
- populate dashboard counters using authenticated API service

## Testing
- `npm test` *(fails: Cannot require() ES Module /app/api/appeals/route.ts in a cycle)*
- `dotnet test backend/AutomotiveClaimsApi.Tests` *(fails: command not found: dotnet)*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b356f94a38832c92368774fe47e51a