### PR TITLE
feat: extend simple claim form

### DIFF
--- a/components/claim-form/simple-claim-form-desktop.tsx
+++ b/components/claim-form/simple-claim-form-desktop.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@/hooks/use-auth"
 import { Card, CardContent } from "@/components/ui/card"
 import { FormHeader } from "@/components/ui/form-header"
 import { Label } from "@/components/ui/label"
+import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
 import { FileText } from "lucide-react"
@@ -14,6 +15,9 @@ import type { DriverInfo } from "@/types"
 export function SimpleClaimFormDesktop() {
   const { user } = useAuth()
   const isReadOnly = user?.roles?.includes("user")
+  const [damageNumber, setDamageNumber] = useState("")
+  const [damageDate, setDamageDate] = useState("")
+  const [damageTime, setDamageTime] = useState("")
   const [description, setDescription] = useState("")
   const [driver, setDriver] = useState<DriverInfo & Record<string, any>>({
     id: Date.now().toString(),
@@ -46,7 +50,7 @@ export function SimpleClaimFormDesktop() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    console.log({ description, driver })
+    console.log({ damageNumber, damageDate, damageTime, description, driver })
   }
 
   return (
@@ -55,6 +59,35 @@ export function SimpleClaimFormDesktop() {
         <Card className="border border-gray-200 bg-white shadow-sm">
           <FormHeader icon={FileText} title="Dane szkody" />
           <CardContent className="p-6 space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="damageNumber">Nr szkody</Label>
+              <Input
+                id="damageNumber"
+                value={damageNumber}
+                onChange={(e) => setDamageNumber(e.target.value)}
+                placeholder="Wprowadź numer szkody"
+              />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="damageDate">Data szkody</Label>
+                <Input
+                  id="damageDate"
+                  type="date"
+                  value={damageDate}
+                  onChange={(e) => setDamageDate(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="damageTime">Godzina szkody</Label>
+                <Input
+                  id="damageTime"
+                  type="time"
+                  value={damageTime}
+                  onChange={(e) => setDamageTime(e.target.value)}
+                />
+              </div>
+            </div>
             <div className="space-y-2">
               <Label htmlFor="description">Opis szkody</Label>
               <Textarea

--- a/components/mobile/claim-form/simple-claim-form.tsx
+++ b/components/mobile/claim-form/simple-claim-form.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@/hooks/use-auth"
 import { Card, CardContent } from "@/components/ui/card"
 import { FormHeader } from "@/components/ui/form-header"
 import { Label } from "@/components/ui/label"
+import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
 import { FileText } from "lucide-react"
@@ -14,6 +15,9 @@ import type { DriverInfo } from "@/types"
 export function SimpleClaimFormMobile() {
   const { user } = useAuth()
   const isReadOnly = user?.roles?.includes("user")
+  const [damageNumber, setDamageNumber] = useState("")
+  const [damageDate, setDamageDate] = useState("")
+  const [damageTime, setDamageTime] = useState("")
   const [description, setDescription] = useState("")
   const [driver, setDriver] = useState<DriverInfo & Record<string, any>>({
     id: Date.now().toString(),
@@ -46,7 +50,7 @@ export function SimpleClaimFormMobile() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    console.log({ description, driver })
+    console.log({ damageNumber, damageDate, damageTime, description, driver })
   }
 
   return (
@@ -55,6 +59,35 @@ export function SimpleClaimFormMobile() {
         <Card className="border border-gray-200 bg-white shadow-sm">
           <FormHeader icon={FileText} title="Dane szkody" />
           <CardContent className="p-4 space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="damageNumber">Nr szkody</Label>
+              <Input
+                id="damageNumber"
+                value={damageNumber}
+                onChange={(e) => setDamageNumber(e.target.value)}
+                placeholder="Wprowadź numer szkody"
+              />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="damageDate">Data szkody</Label>
+                <Input
+                  id="damageDate"
+                  type="date"
+                  value={damageDate}
+                  onChange={(e) => setDamageDate(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="damageTime">Godzina szkody</Label>
+                <Input
+                  id="damageTime"
+                  type="time"
+                  value={damageTime}
+                  onChange={(e) => setDamageTime(e.target.value)}
+                />
+              </div>
+            </div>
             <div className="space-y-2">
               <Label htmlFor="description">Opis szkody</Label>
               <Textarea


### PR DESCRIPTION
## Summary
- expand simple claim form with damage number, date, and time fields on desktop and mobile

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b29c14d4a0832c8640034e4eb48d8f