### PR TITLE
Add category support for required documents

### DIFF
--- a/components/email/email-section.tsx
+++ b/components/email/email-section.tsx
@@ -10,6 +10,7 @@ import { emailFolders, sampleEmails } from "@/lib/email-data"
 import type { Email, EmailCompose, EmailAttachment } from "@/types/email"
 import type { UploadedFile, RequiredDocument } from "@/types"
 import { API_BASE_URL } from "@/lib/api"
+import { slugify } from "@/utils/slugify"
 
 interface EmailSectionProps {
   claimId?: string
@@ -63,8 +64,22 @@ export const EmailSection = ({
   const updateDocuments = setUploadedFiles ?? setInternalDocuments
 
   const [internalRequiredDocs, setInternalRequiredDocs] = useState<RequiredDocument[]>([
-    { id: "req1", name: "Umowa", required: true, uploaded: false, description: "" },
-    { id: "req2", name: "Protokół", required: false, uploaded: false, description: "" },
+    {
+      id: "req1",
+      name: "Umowa",
+      required: true,
+      uploaded: false,
+      description: "",
+      category: slugify("Umowa"),
+    },
+    {
+      id: "req2",
+      name: "Protokół",
+      required: false,
+      uploaded: false,
+      description: "",
+      category: slugify("Protokół"),
+    },
   ])
   const reqDocuments = requiredDocuments ?? internalRequiredDocs
   const updateRequiredDocs = setRequiredDocuments ?? setInternalRequiredDocs

--- a/lib/required-documents.ts
+++ b/lib/required-documents.ts
@@ -1,6 +1,10 @@
 import type { RequiredDocument } from "@/types"
+import { slugify } from "@/utils/slugify"
 
-const communicationDocuments: RequiredDocument[] = [
+const withCategory = (docs: Omit<RequiredDocument, "category">[]): RequiredDocument[] =>
+  docs.map((d) => ({ ...d, category: slugify(d.name) }))
+
+const communicationDocuments: RequiredDocument[] = withCategory([
   { id: "1", name: "Akta z TU", required: true, uploaded: false, description: "" },
   { id: "2", name: "Arkusz / Info", required: true, uploaded: false, description: "" },
   { id: "3", name: "Zgłoszenie szkody - Bank/Leasing", required: true, uploaded: false, description: "" },
@@ -115,9 +119,9 @@ const communicationDocuments: RequiredDocument[] = [
   { id: "112", name: "PBUK/UFG - potwierdzenie zapytania", required: true, uploaded: false, description: "" },
   { id: "113", name: "Europrotokół", required: true, uploaded: false, description: "" },
   { id: "114", name: "Faktura - uprzątnięcie", required: true, uploaded: false, description: "" }
-]
+])
 
-const propertyDocuments: RequiredDocument[] = [
+const propertyDocuments: RequiredDocument[] = withCategory([
   { id: "1", name: "Nr konta", required: true, uploaded: false, description: "" },
   {
     id: "2",
@@ -152,9 +156,9 @@ const propertyDocuments: RequiredDocument[] = [
     uploaded: false,
     description: "",
   },
-]
+])
 
-const transportDocuments: RequiredDocument[] = [
+const transportDocuments: RequiredDocument[] = withCategory([
   {
     id: "1",
     name: "Dowód rejestracyjny",
@@ -351,7 +355,7 @@ const transportDocuments: RequiredDocument[] = [
     uploaded: false,
     description: ""
   }
-]
+])
 
 export const getRequiredDocumentsByObjectType = (
   objectTypeId?: string | number

--- a/types/index.ts
+++ b/types/index.ts
@@ -295,7 +295,8 @@ export interface RequiredDocument {
   required: boolean
   uploaded: boolean
   description: string
-  category?: string
+  /** Machine readable category identifier */
+  category: string
 }
 
 export interface DocumentsSectionProps {

--- a/utils/slugify.ts
+++ b/utils/slugify.ts
@@ -1,0 +1,10 @@
+export function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export default slugify


### PR DESCRIPTION
## Summary
- add slugify utility for generating category identifiers
- require category in RequiredDocument and auto-generate categories for predefined documents
- propagate categories to email section's required document defaults

## Testing
- `pnpm lint` *(fails: asking for ESLint configuration)*
- `pnpm test` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_68b3592b30e0832c83417a96b9a3b839