### PR TITLE
feat(user): allow assigning case handler

### DIFF
--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -90,7 +90,7 @@ namespace AutomotiveClaimsApi.Controllers
             if (dto.UserName == null || dto.Password == null)
                 return BadRequest();
 
-            var user = new ApplicationUser { UserName = dto.UserName, Email = dto.Email, MustChangePassword = true , CreatedAt = DateTime.UtcNow};
+            var user = new ApplicationUser { UserName = dto.UserName, Email = dto.Email, MustChangePassword = true , CreatedAt = DateTime.UtcNow, CaseHandlerId = dto.CaseHandlerId };
 
             var result = await _userManager.CreateAsync(user, dto.Password);
             if (!result.Succeeded)
@@ -221,7 +221,8 @@ namespace AutomotiveClaimsApi.Controllers
                 CreatedAt = user.CreatedAt,
                 LastLogin = user.LastLogin,
                 FullAccess = user.FullAccess,
-                ClientIds = user.UserClients.Select(uc => uc.ClientId)
+                ClientIds = user.UserClients.Select(uc => uc.ClientId),
+                CaseHandlerId = user.CaseHandlerId
             };
         }
 
@@ -243,7 +244,8 @@ namespace AutomotiveClaimsApi.Controllers
                 CreatedAt = user.CreatedAt,
                 LastLogin = user.LastLogin,
                 FullAccess = user.FullAccess,
-                ClientIds = user.UserClients.Select(uc => uc.ClientId)
+                ClientIds = user.UserClients.Select(uc => uc.ClientId),
+                CaseHandlerId = user.CaseHandlerId
             };
         }
 
@@ -256,6 +258,7 @@ namespace AutomotiveClaimsApi.Controllers
             if (dto.UserName != null) user.UserName = dto.UserName;
             if (dto.Email != null) user.Email = dto.Email;
             if (dto.FullAccess.HasValue) user.FullAccess = dto.FullAccess.Value;
+            if (dto.CaseHandlerId.HasValue) user.CaseHandlerId = dto.CaseHandlerId;
 
             if (dto.ClientIds != null)
             {
@@ -310,7 +313,8 @@ namespace AutomotiveClaimsApi.Controllers
                     Role = roles.FirstOrDefault(),
                     Status = u.LockoutEnd.HasValue && u.LockoutEnd.Value.UtcDateTime > DateTime.UtcNow ? "inactive" : "active",
                     CreatedAt = u.CreatedAt,
-                    LastLogin = u.LastLogin
+                    LastLogin = u.LastLogin,
+                    CaseHandlerId = u.CaseHandlerId
                 });
             }
 

--- a/backend/DTOs/AuthDtos.cs
+++ b/backend/DTOs/AuthDtos.cs
@@ -11,6 +11,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Password { get; set; }
         [JsonPropertyName("role")]
         public string? Role { get; set; }
+        public int? CaseHandlerId { get; set; }
     }
 
     public class LoginDto
@@ -39,6 +40,7 @@ namespace AutomotiveClaimsApi.DTOs
         public IEnumerable<int>? ClientIds { get; set; }
         [JsonPropertyName("role")]
         public string? Role { get; set; }
+        public int? CaseHandlerId { get; set; }
     }
 
     public class UserDto
@@ -51,6 +53,7 @@ namespace AutomotiveClaimsApi.DTOs
         public DateTime? LastLogin { get; set; }
         public bool FullAccess { get; set; }
         public IEnumerable<int> ClientIds { get; set; } = Array.Empty<int>();
+        public int? CaseHandlerId { get; set; }
     }
 
     public class UserListItemDto
@@ -64,6 +67,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? Status { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime? LastLogin { get; set; }
+        public int? CaseHandlerId { get; set; }
     }
 
     public class UpdateUsersBulkDto

--- a/components/admin/user-form-dialog.tsx
+++ b/components/admin/user-form-dialog.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
 import type { Role, User } from "@/lib/types/admin"
 import { Checkbox } from "@/components/ui/checkbox"
-import { apiService, type ClientDto } from "@/lib/api"
+import { apiService, type ClientDto, type CaseHandlerDto } from "@/lib/api"
 import { adminService } from "@/lib/services/admin-service"
 
 interface UserFormDialogProps {
@@ -30,9 +30,12 @@ export function UserFormDialog({ open, onOpenChange, user, roles, onSave }: User
   const [fullAccess, setFullAccess] = useState(false)
   const [clients, setClients] = useState<ClientDto[]>([])
   const [clientIds, setClientIds] = useState<number[]>([])
+  const [caseHandlers, setCaseHandlers] = useState<CaseHandlerDto[]>([])
+  const [caseHandlerId, setCaseHandlerId] = useState("")
 
   useEffect(() => {
     apiService.getClients().then(setClients)
+    apiService.getCaseHandlers().then(setCaseHandlers)
   }, [])
 
   useEffect(() => {
@@ -45,6 +48,7 @@ export function UserFormDialog({ open, onOpenChange, user, roles, onSave }: User
       adminService.getUser(user.id).then((u) => {
         setFullAccess(u.fullAccess ?? false)
         setClientIds(u.clientIds ?? [])
+        setCaseHandlerId(u.caseHandlerId ? String(u.caseHandlerId) : "")
       })
     } else {
       setFirstName("")
@@ -55,6 +59,7 @@ export function UserFormDialog({ open, onOpenChange, user, roles, onSave }: User
       setPassword("")
       setFullAccess(false)
       setClientIds([])
+      setCaseHandlerId("")
     }
   }, [user, roles])
 
@@ -75,6 +80,7 @@ export function UserFormDialog({ open, onOpenChange, user, roles, onSave }: User
       password: isEdit ? undefined : password,
       fullAccess,
       clientIds,
+      caseHandlerId: caseHandlerId ? parseInt(caseHandlerId) : undefined,
     })
   }
 
@@ -172,6 +178,22 @@ export function UserFormDialog({ open, onOpenChange, user, roles, onSave }: User
               </div>
             </div>
           )}
+          <div>
+            <Label>Likwidator</Label>
+            <Select value={caseHandlerId} onValueChange={setCaseHandlerId}>
+              <SelectTrigger>
+                <SelectValue placeholder="Wybierz likwidatora" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="">Brak</SelectItem>
+                {caseHandlers.map((h) => (
+                  <SelectItem key={h.id} value={String(h.id)}>
+                    {h.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
           <Button type="submit">{isEdit ? "Zapisz" : "Utwórz"}</Button>
         </form>
       </DialogContent>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -259,6 +259,7 @@ export interface UserListItemDto {
   lastLogin?: string
   fullAccess?: boolean
   clientIds?: number[]
+  caseHandlerId?: number
 }
 
 export interface UpdateUsersBulkDto {
@@ -975,6 +976,7 @@ class ApiService {
     status?: string
     fullAccess?: boolean
     clientIds?: number[]
+    caseHandlerId?: number
   }> {
     return await this.request<{
       id: string
@@ -989,6 +991,7 @@ class ApiService {
       status?: string
       fullAccess?: boolean
       clientIds?: number[]
+      caseHandlerId?: number
     }>(`/auth/users/${id}`)
 
   }
@@ -1005,6 +1008,7 @@ class ApiService {
       phone?: string
       fullAccess?: boolean
       clientIds?: number[]
+      caseHandlerId?: number
     },
   ): Promise<void> {
     await this.request<void>(`/auth/users/${id}`, {
@@ -1023,6 +1027,7 @@ class ApiService {
     status?: "active" | "inactive"
     fullAccess?: boolean
     clientIds?: number[]
+    caseHandlerId?: number
   }): Promise<void> {
     await this.request<void>("/auth/register", {
       method: "POST",

--- a/lib/services/admin-service.ts
+++ b/lib/services/admin-service.ts
@@ -74,6 +74,7 @@ export const adminService = {
       avatar: undefined,
       fullAccess: dto.fullAccess ?? false,
       clientIds: dto.clientIds ?? [],
+      caseHandlerId: dto.caseHandlerId,
     };
   },
 
@@ -88,6 +89,7 @@ export const adminService = {
       phone: undefined,
       fullAccess: data.fullAccess,
       clientIds: data.clientIds,
+      caseHandlerId: data.caseHandlerId,
     });
   },
 
@@ -102,6 +104,7 @@ export const adminService = {
       status: data.status,
       fullAccess: data.fullAccess,
       clientIds: data.clientIds,
+      caseHandlerId: data.caseHandlerId,
     })
   },
 
@@ -143,5 +146,6 @@ function mapUserDto(dto: UserListItemDto): User {
     avatar: undefined,
     fullAccess: dto.fullAccess,
     clientIds: dto.clientIds,
+    caseHandlerId: dto.caseHandlerId,
   };
 }

--- a/lib/types/admin.ts
+++ b/lib/types/admin.ts
@@ -31,6 +31,7 @@ export interface User {
   password?: string;
   fullAccess?: boolean;
   clientIds?: number[];
+  caseHandlerId?: number;
 }
 
 export interface UserFilters {


### PR DESCRIPTION
## Summary
- allow selecting a case handler when creating or editing a user
- propagate caseHandlerId through API, services and types
- extend backend DTOs and auth controller to store case handler assignment

## Testing
- `pnpm test` *(fails: Cannot require() ES Module app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68b3624af610832ca5975fb84888a6d8