### PR TITLE
Defer claim ID generation to first save

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -28,7 +28,6 @@ import { ClaimMainContent } from "@/components/claim-form/claim-main-content"
 import { useClaimForm } from "@/hooks/use-claim-form"
 import { useClaims, transformApiClaimToFrontend } from "@/hooks/use-claims"
 import { useAuth } from "@/hooks/use-auth"
-import { generateId } from "@/lib/constants"
 import type { Claim, UploadedFile, RequiredDocument } from "@/types"
 import { getRequiredDocumentsByObjectType } from "@/lib/required-documents"
 
@@ -164,7 +163,6 @@ export default function ClaimPage() {
       if (mode === "new") {
         const newClaimData = {
           ...claimFormData,
-          id: generateId(),
           claimNumber: `PL${new Date().getFullYear()}${String(Date.now()).slice(-8)}`,
           registeredById: user?.id,
         } as Claim

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -1366,7 +1366,7 @@ export const ClaimMainContent = ({
           <Card className="overflow-hidden shadow-sm border-gray-200 rounded-xl">
             <FormHeader icon={HandHeart} title="Ugoda" />
             <CardContent className="p-0 bg-white">
-              <SettlementsSection eventId={eventId || ""} />
+              {eventId && <SettlementsSection eventId={eventId} />}
             </CardContent>
           </Card>
         </div>

--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -18,7 +18,7 @@ import type { Settlement } from "@/lib/api/settlements"
 import type { DocumentDto } from "@/lib/api"
 
 interface SettlementsSectionProps {
-  eventId: string
+  eventId?: string
 }
 
 interface SettlementFormData {
@@ -45,6 +45,8 @@ const initialFormData: SettlementFormData = {
 
 export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId }) => {
   const { toast } = useToast()
+
+  if (!eventId) return null
 
   const [settlements, setSettlements] = useState<Settlement[]>([])
   const [isListLoading, setIsListLoading] = useState(false)

--- a/hooks/use-claim-form.ts
+++ b/hooks/use-claim-form.ts
@@ -4,28 +4,11 @@ import { useState, useCallback } from "react"
 import { initialClaimFormData, emptyDriver, generateId } from "@/lib/constants"
 import type { Claim, ParticipantInfo, DriverInfo } from "@/types"
 
-// Global claim identifier handling
-let globalClaimId: string | null = null
-
-const generateClaimId = () =>
-  typeof crypto !== "undefined" && "randomUUID" in crypto
-    ? crypto.randomUUID()
-    : generateId()
-
-const createNewClaimId = () => {
-  globalClaimId = generateClaimId()
-  return globalClaimId
-}
-
-export const getGlobalClaimId = () => {
-  return globalClaimId || createNewClaimId()
-}
-
 export function useClaimForm(initialData?: Partial<Claim>) {
   const [claimFormData, setClaimFormData] = useState<Partial<Claim>>({
     ...initialClaimFormData,
 
-    id: initialData?.id ?? generateId(),
+    id: initialData?.id,
 
     ...initialData,
   })
@@ -143,8 +126,7 @@ export function useClaimForm(initialData?: Partial<Claim>) {
   }, [])
 
   const resetForm = useCallback(() => {
-    const newId = createNewClaimId()
-    setClaimFormData({ ...initialClaimFormData, id: newId })
+    setClaimFormData({ ...initialClaimFormData })
   }, [])
 
   return {

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -9,7 +9,6 @@ import {
   type ParticipantUpsertDto,
 } from "@/lib/api"
 import type { Claim, ParticipantInfo, DriverInfo, Note } from "@/types"
-import { generateId } from "@/lib/constants"
 
 const toIso = (value?: string, field?: string): string | undefined => {
   if (!value) return undefined
@@ -471,10 +470,6 @@ export function useClaims() {
     try {
       setError(null)
       const payload = transformFrontendClaimToApiPayload(claimData)
-
-      if (!payload.id) {
-        payload.id = generateId()
-      }
 
       const newApiClaim = await apiService.createClaim(payload)
       const newClaim = transformApiClaimToFrontend(newApiClaim)


### PR DESCRIPTION
## Summary
- Generate new claim IDs on the server when missing
- Stop pre-initializing claim IDs on the frontend and create ID on first save
- Allow subsequent saves to update existing claims
- Clarify server-side claim ID generation and drop client-side form ID resets
- Split claim reload query into separate SQL statements to avoid timeout on save
- Render settlements section only when claim ID is available so modules don't fetch without an event ID

## Testing
- `npm test` *(fails: ModuleLoader.importSyncForRequire ...)*
- `npm run lint` *(interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d6a1f5dc832cb24ae755d7c3c118