### PR TITLE
feat: add claim status enums

### DIFF
--- a/backend/Common/ClaimStatusCode.cs
+++ b/backend/Common/ClaimStatusCode.cs
@@ -1,0 +1,14 @@
+namespace AutomotiveClaimsApi.Common
+{
+    public enum ClaimStatusCode
+    {
+        DoPrzydzielenia = 1,
+        NowaSzkoda = 2,
+        Zarejestrowana = 3,
+        WLikwidacji = 5,
+        CzescowoZlikwidowana = 6,
+        Regres = 8,
+        WOdwolaniu = 9,
+        Zamknieta = 10
+    }
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -4,12 +4,16 @@ import type { Settlement } from "@/lib/api/settlements"
 
 export type { Settlement } from "@/lib/api/settlements"
 
-export type ClaimStatus =
-  | "Złożone"
-  | "W trakcie analizy"
-  | "Zaakceptowane"
-  | "Odrzucone"
-  | "Częściowo zaakceptowane"
+export enum ClaimStatus {
+  DoPrzydzielenia = 1,
+  NowaSzkoda = 2,
+  Zarejestrowana = 3,
+  WLikwidacji = 5,
+  CzescowoZlikwidowana = 6,
+  Regres = 8,
+  WOdwolaniu = 9,
+  Zamknieta = 10,
+}
 
 export interface Note {
   id?: string

--- a/types/index.ts
+++ b/types/index.ts
@@ -4,7 +4,7 @@ import type { Settlement } from "@/lib/api/settlements"
 
 export type { Settlement } from "@/lib/api/settlements"
 
-export enum ClaimStatus {
+export enum ClaimStatusCode {
   DoPrzydzielenia = 1,
   NowaSzkoda = 2,
   Zarejestrowana = 3,
@@ -14,6 +14,13 @@ export enum ClaimStatus {
   WOdwolaniu = 9,
   Zamknieta = 10,
 }
+
+export type ClaimStatus =
+  | "Złożone"
+  | "W trakcie analizy"
+  | "Zaakceptowane"
+  | "Odrzucone"
+  | "Częściowo zaakceptowane"
 
 export interface Note {
   id?: string


### PR DESCRIPTION
## Summary
- add ClaimStatusCode enum in backend
- add ClaimStatus enum for frontend types

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68b37d533ce0832c893d1652efd5fc3c