### PR TITLE
fix: avoid empty Select item values

### DIFF
--- a/app/settings/users/page.tsx
+++ b/app/settings/users/page.tsx
@@ -113,33 +113,33 @@ export default function UsersPage() {
           className="max-w-xs"
         />
         <Select
-          value={role ?? ""}
+          value={role ?? "all"}
           onValueChange={(v) => {
             setPage(1)
-            setRole(v || undefined)
+            setRole(v === "all" ? undefined : v)
           }}
         >
           <SelectTrigger className="w-[180px]">
             <SelectValue placeholder="Rola" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="">Wszystkie role</SelectItem>
+            <SelectItem value="all">Wszystkie role</SelectItem>
             <SelectItem value="user">Użytkownik</SelectItem>
             <SelectItem value="admin">Administrator</SelectItem>
           </SelectContent>
         </Select>
         <Select
-          value={status ?? ""}
+          value={status ?? "all"}
           onValueChange={(v) => {
             setPage(1)
-            setStatus(v || undefined)
+            setStatus(v === "all" ? undefined : v)
           }}
         >
           <SelectTrigger className="w-[180px]">
             <SelectValue placeholder="Status" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="">Wszystkie statusy</SelectItem>
+            <SelectItem value="all">Wszystkie statusy</SelectItem>
             <SelectItem value="active">Aktywny</SelectItem>
             <SelectItem value="inactive">Nieaktywny</SelectItem>
           </SelectContent>

--- a/components/admin/user-form-dialog.tsx
+++ b/components/admin/user-form-dialog.tsx
@@ -180,12 +180,15 @@ export function UserFormDialog({ open, onOpenChange, user, roles, onSave }: User
           )}
           <div>
             <Label>Likwidator</Label>
-            <Select value={caseHandlerId} onValueChange={setCaseHandlerId}>
+            <Select
+              value={caseHandlerId || "none"}
+              onValueChange={(v) => setCaseHandlerId(v === "none" ? "" : v)}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Wybierz likwidatora" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">Brak</SelectItem>
+                <SelectItem value="none">Brak</SelectItem>
                 {caseHandlers.map((h) => (
                   <SelectItem key={h.id} value={String(h.id)}>
                     {h.name}


### PR DESCRIPTION
## Summary
- prevent empty value in case handler select to satisfy Radix Select requirements
- use sentinel "all" for role/status filters to avoid invalid empty select items

## Testing
- `pnpm lint` (fails: asks for ESLint configuration)
- `pnpm test` (fails: 1 failing test)


------
https://chatgpt.com/codex/tasks/task_e_68b3914b3b54832cbd231964f015f56f