### PR TITLE
Defer claim ID generation to first save

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -28,7 +28,6 @@ import { ClaimMainContent } from "@/components/claim-form/claim-main-content"
 import { useClaimForm } from "@/hooks/use-claim-form"
 import { useClaims, transformApiClaimToFrontend } from "@/hooks/use-claims"
 import { useAuth } from "@/hooks/use-auth"
-import { generateId } from "@/lib/constants"
 import type { Claim, UploadedFile, RequiredDocument } from "@/types"
 import { getRequiredDocumentsByObjectType } from "@/lib/required-documents"
 
@@ -164,7 +163,6 @@ export default function ClaimPage() {
       if (mode === "new") {
         const newClaimData = {
           ...claimFormData,
-          id: generateId(),
           claimNumber: `PL${new Date().getFullYear()}${String(Date.now()).slice(-8)}`,
           registeredById: user?.id,
         } as Claim

--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -49,7 +49,10 @@ interface RepairSchedule {
   status: "draft" | "submitted" | "approved" | "completed"
   createdAt?: string
   updatedAt?: string
+  isPersisted?: boolean
 }
+
+type LocalRepairDetail = RepairDetail & { isPersisted?: boolean }
 
 export default function NewClaimPage() {
   const router = useRouter()
@@ -57,16 +60,16 @@ export default function NewClaimPage() {
   const claimObjectTypeParam = searchParams.get("claimObjectType") || "1"
   const [claimObjectType, setClaimObjectType] = useState(claimObjectTypeParam)
   const { toast } = useToast()
-  const { createClaim, deleteClaim, initializeClaim } = useClaims()
+  const { createClaim, updateClaim, deleteClaim } = useClaims()
   const { user } = useAuth()
-  const [claimId, setClaimId] = useState<string>("")
+  const [claimId, setClaimId] = useState<string | null>(null)
   const [activeClaimSection, setActiveClaimSection] = useState("teczka-szkodowa")
   const [isSaving, setIsSaving] = useState(false)
   const contentRef = useRef<HTMLDivElement>(null)
   
   // Repair schedules and details state
   const [repairSchedules, setRepairSchedules] = useState<RepairSchedule[]>([])
-  const [repairDetails, setRepairDetails] = useState<RepairDetail[]>([])
+  const [repairDetails, setRepairDetails] = useState<LocalRepairDetail[]>([])
   const [isAddingSchedule, setIsAddingSchedule] = useState(false)
   const [isAddingRepairDetail, setIsAddingRepairDetail] = useState(false)
   const [scheduleFormData, setScheduleFormData] = useState<Partial<RepairSchedule>>({})
@@ -85,6 +88,8 @@ export default function NewClaimPage() {
     },
   ])
 
+  const [pendingFiles, setPendingFiles] = useState<UploadedFile[]>([])
+
   const [requiredDocuments, setRequiredDocuments] = useState<RequiredDocument[]>(() =>
     getRequiredDocumentsByObjectType(claimObjectTypeParam)
   )
@@ -97,17 +102,8 @@ export default function NewClaimPage() {
     handleDriverChange,
     handleAddDriver,
     handleRemoveDriver,
-    resetForm,
   } = useClaimForm()
 
-  useEffect(() => {
-    initializeClaim().then((id) => {
-      if (id) {
-        setClaimId(id)
-        setClaimFormData((prev) => ({ ...prev, id }))
-      }
-    })
-  }, [initializeClaim, setClaimFormData])
 
   useEffect(() => {
     if (user) {
@@ -228,6 +224,7 @@ export default function NewClaimPage() {
       id: generateId(),
       eventId: claimId,
       createdAt: new Date().toISOString(),
+      isPersisted: false,
     } as RepairSchedule
 
     setRepairSchedules(prev => [...prev, newSchedule])
@@ -241,13 +238,14 @@ export default function NewClaimPage() {
   }
 
   const handleSaveRepairDetail = () => {
-    const newDetail: RepairDetail = {
+    const newDetail: LocalRepairDetail = {
       ...repairDetailFormData,
       id: generateId(),
       eventId: claimId,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
-    } as RepairDetail
+      isPersisted: false,
+    } as LocalRepairDetail
 
     setRepairDetails(prev => [...prev, newDetail])
     setIsAddingRepairDetail(false)
@@ -308,91 +306,134 @@ export default function NewClaimPage() {
 
     const savedScheduleIds: string[] = []
     const savedDetailIds: string[] = []
-    let createdClaimId: string | null = null
+    const isUpdate = Boolean(claimId)
+    let savedClaimId = claimId
 
     try {
-      const currentClaimId = claimId || claimFormData.id
-      if (!currentClaimId) {
-        throw new Error("Brak zainicjalizowanego ID szkody")
-      }
-      const newClaimData = {
+      const claimPayload = {
         ...claimFormData,
-        id: currentClaimId,
         claimNumber:
           claimFormData.claimNumber ||
           `PL${new Date().getFullYear()}${String(Date.now()).slice(-8)}`,
         registeredById: user?.id,
       } as Claim
 
-      const createdClaim = await createClaim(newClaimData)
-
-      if (!createdClaim) {
-        throw new Error("Nie udało się utworzyć szkody")
+      let savedClaim: Claim | null
+      if (isUpdate && savedClaimId) {
+        savedClaim = await updateClaim(savedClaimId, claimPayload)
+      } else {
+        savedClaim = await createClaim(claimPayload)
       }
-      createdClaimId = createdClaim.id
+
+      if (!savedClaim || !savedClaim.id) {
+        throw new Error("Nie udało się zapisać szkody")
+      }
+
+      savedClaimId = savedClaim.id
+      setClaimId(savedClaimId)
+      setClaimFormData(savedClaim)
 
       // Save repair schedules sequentially
       for (const schedule of repairSchedules) {
-        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/repair-schedules`, {
-          method: "POST",
-          credentials: "omit",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ ...schedule, claimId: currentClaimId }),
-        })
-        if (!response.ok) {
-          throw new Error("Nie udało się zapisać harmonogramu naprawy")
+        const { id, isPersisted, eventId, createdAt, updatedAt, ...payload } = schedule
+        if (isPersisted && id) {
+          const response = await fetch(
+            `${process.env.NEXT_PUBLIC_API_URL}/repair-schedules/${id}`,
+            {
+              method: "PUT",
+              credentials: "omit",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload),
+            },
+          )
+          if (!response.ok) {
+            throw new Error("Nie udało się zaktualizować harmonogramu naprawy")
+          }
+        } else {
+          const response = await fetch(
+            `${process.env.NEXT_PUBLIC_API_URL}/repair-schedules`,
+            {
+              method: "POST",
+              credentials: "omit",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ ...payload, claimId: savedClaimId }),
+            },
+          )
+          if (!response.ok) {
+            throw new Error("Nie udało się zapisać harmonogramu naprawy")
+          }
+          const saved = await response.json()
+          if (saved?.id) {
+            schedule.id = saved.id
+            schedule.isPersisted = true
+            savedScheduleIds.push(saved.id)
+          }
         }
-        const saved = await response.json()
-        if (saved?.id) savedScheduleIds.push(saved.id)
       }
+      setRepairSchedules([...repairSchedules])
 
       // Save repair details sequentially
       for (const detail of repairDetails) {
-        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/repair-details`, {
-          method: "POST",
-          credentials: "omit",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ ...detail, claimId: currentClaimId }),
-        })
-        if (!response.ok) {
-          throw new Error("Nie udało się zapisać szczegółów naprawy")
+        const { id, isPersisted, eventId, createdAt, updatedAt, ...payload } = detail
+        if (isPersisted && id) {
+          const response = await fetch(
+            `${process.env.NEXT_PUBLIC_API_URL}/repair-details/${id}`,
+            {
+              method: "PUT",
+              credentials: "omit",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload),
+            },
+          )
+          if (!response.ok) {
+            throw new Error("Nie udało się zaktualizować szczegółów naprawy")
+          }
+        } else {
+          const response = await fetch(
+            `${process.env.NEXT_PUBLIC_API_URL}/repair-details`,
+            {
+              method: "POST",
+              credentials: "omit",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ ...payload, claimId: savedClaimId }),
+            },
+          )
+          if (!response.ok) {
+            throw new Error("Nie udało się zapisać szczegółów naprawy")
+          }
+          const saved = await response.json()
+          if (saved?.id) {
+            detail.id = saved.id
+            detail.isPersisted = true
+            savedDetailIds.push(saved.id)
+          }
         }
-        const saved = await response.json()
-        if (saved?.id) savedDetailIds.push(saved.id)
       }
+      setRepairDetails([...repairDetails])
 
       toast({
-        title: "Szkoda dodana",
-        description: `Nowa szkoda ${createdClaim.spartaNumber} została pomyślnie dodana.`,
+        title: isUpdate ? "Szkoda zaktualizowana" : "Szkoda dodana",
+        description: `Szkoda ${savedClaim.spartaNumber || savedClaim.claimNumber} została pomyślnie zapisana.`,
       })
 
       if (exitAfterSave) {
         router.push("/claims")
-      } else {
-        resetForm()
-        setRepairSchedules([])
-        setRepairDetails([])
       }
     } catch (error) {
-      // rollback
       for (const id of savedDetailIds) {
         await fetch(`${process.env.NEXT_PUBLIC_API_URL}/repair-details/${id}`, {
           method: "DELETE",
           credentials: "omit",
-        }).catch(
-          () => {},
-        )
+        }).catch(() => {})
       }
       for (const id of savedScheduleIds) {
         await fetch(`${process.env.NEXT_PUBLIC_API_URL}/repair-schedules/${id}`, {
           method: "DELETE",
           credentials: "omit",
-        }).catch(
-          () => {},
-        )
+        }).catch(() => {})
       }
-      if (createdClaimId) {
-        await deleteClaim(createdClaimId)
+      if (!isUpdate && savedClaimId) {
+        await deleteClaim(savedClaimId)
       }
       console.error("Error saving claim:", error)
       toast({
@@ -445,6 +486,8 @@ export default function NewClaimPage() {
               handleRemoveDriver={handleRemoveDriver}
               uploadedFiles={uploadedFiles}
               setUploadedFiles={setUploadedFiles}
+              pendingFiles={pendingFiles}
+              setPendingFiles={setPendingFiles}
               requiredDocuments={requiredDocuments}
               setRequiredDocuments={setRequiredDocuments}
               initialClaimObjectType={claimObjectType}

--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -83,6 +83,8 @@ interface ClaimMainContentProps {
   handleRemoveDriver: (party: "injuredParty" | "perpetrator", driverIndex: number) => void
   uploadedFiles: UploadedFile[]
   setUploadedFiles: React.Dispatch<React.SetStateAction<UploadedFile[]>>
+  pendingFiles?: UploadedFile[]
+  setPendingFiles?: React.Dispatch<React.SetStateAction<UploadedFile[]>>
   requiredDocuments: RequiredDocument[]
   setRequiredDocuments: React.Dispatch<React.SetStateAction<RequiredDocument[]>>
   initialClaimObjectType?: string
@@ -190,6 +192,8 @@ export const ClaimMainContent = ({
   handleRemoveDriver,
   uploadedFiles = [],
   setUploadedFiles,
+  pendingFiles = [],
+  setPendingFiles,
   requiredDocuments = [],
   setRequiredDocuments,
   initialClaimObjectType = "1",
@@ -1291,17 +1295,17 @@ export const ClaimMainContent = ({
               </Button>
             </FormHeader>
             <CardContent className="p-0 bg-white">
-              {eventId && (
-                <DocumentsSection
-                  uploadedFiles={uploadedFiles}
-                  setUploadedFiles={setUploadedFiles}
-                  requiredDocuments={requiredDocuments}
-                  setRequiredDocuments={setRequiredDocuments}
-                  eventId={eventId}
-                  storageKey={`main-documents-${eventId}`}
-                  ref={documentsSectionRef}
-                />
-              )}
+              <DocumentsSection
+                uploadedFiles={uploadedFiles}
+                setUploadedFiles={setUploadedFiles}
+                requiredDocuments={requiredDocuments}
+                setRequiredDocuments={setRequiredDocuments}
+                eventId={eventId}
+                storageKey={`main-documents-${eventId || 'new'}`}
+                pendingFiles={pendingFiles}
+                setPendingFiles={setPendingFiles}
+                ref={documentsSectionRef}
+              />
             </CardContent>
           </Card>
         </div>
@@ -1366,7 +1370,7 @@ export const ClaimMainContent = ({
           <Card className="overflow-hidden shadow-sm border-gray-200 rounded-xl">
             <FormHeader icon={HandHeart} title="Ugoda" />
             <CardContent className="p-0 bg-white">
-              <SettlementsSection eventId={eventId || ""} />
+              {eventId && <SettlementsSection eventId={eventId} />}
             </CardContent>
           </Card>
         </div>

--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -18,7 +18,7 @@ import type { Settlement } from "@/lib/api/settlements"
 import type { DocumentDto } from "@/lib/api"
 
 interface SettlementsSectionProps {
-  eventId: string
+  eventId?: string
 }
 
 interface SettlementFormData {
@@ -45,6 +45,8 @@ const initialFormData: SettlementFormData = {
 
 export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId }) => {
   const { toast } = useToast()
+
+  if (!eventId) return null
 
   const [settlements, setSettlements] = useState<Settlement[]>([])
   const [isListLoading, setIsListLoading] = useState(false)

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -608,6 +608,22 @@ export const DocumentsSection = React.forwardRef<
     if (e.target) e.target.value = ""
   }
 
+  useEffect(() => {
+    if (!eventId || !isGuid(eventId) || pendingFiles.length === 0) return
+
+    const uploadPending = async () => {
+      for (const file of pendingFiles) {
+        if (!file.file) continue
+        const dt = new DataTransfer()
+        dt.items.add(file.file)
+        await handleFileUpload(dt.files, file.category || "Inne dokumenty")
+      }
+      setPendingFiles?.([])
+    }
+
+    uploadPending()
+  }, [eventId, pendingFiles])
+
   const handleFileDelete = async (documentId: string | number) => {
 
     const isPending = pendingFiles.some((f) => f.id === documentId)

--- a/hooks/use-claim-form.ts
+++ b/hooks/use-claim-form.ts
@@ -4,28 +4,11 @@ import { useState, useCallback } from "react"
 import { initialClaimFormData, emptyDriver, generateId } from "@/lib/constants"
 import type { Claim, ParticipantInfo, DriverInfo } from "@/types"
 
-// Global claim identifier handling
-let globalClaimId: string | null = null
-
-const generateClaimId = () =>
-  typeof crypto !== "undefined" && "randomUUID" in crypto
-    ? crypto.randomUUID()
-    : generateId()
-
-const createNewClaimId = () => {
-  globalClaimId = generateClaimId()
-  return globalClaimId
-}
-
-export const getGlobalClaimId = () => {
-  return globalClaimId || createNewClaimId()
-}
-
 export function useClaimForm(initialData?: Partial<Claim>) {
   const [claimFormData, setClaimFormData] = useState<Partial<Claim>>({
     ...initialClaimFormData,
 
-    id: initialData?.id ?? generateId(),
+    id: initialData?.id,
 
     ...initialData,
   })
@@ -143,8 +126,7 @@ export function useClaimForm(initialData?: Partial<Claim>) {
   }, [])
 
   const resetForm = useCallback(() => {
-    const newId = createNewClaimId()
-    setClaimFormData({ ...initialClaimFormData, id: newId })
+    setClaimFormData({ ...initialClaimFormData })
   }, [])
 
   return {

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -9,7 +9,6 @@ import {
   type ParticipantUpsertDto,
 } from "@/lib/api"
 import type { Claim, ParticipantInfo, DriverInfo, Note } from "@/types"
-import { generateId } from "@/lib/constants"
 
 const toIso = (value?: string, field?: string): string | undefined => {
   if (!value) return undefined
@@ -471,10 +470,6 @@ export function useClaims() {
     try {
       setError(null)
       const payload = transformFrontendClaimToApiPayload(claimData)
-
-      if (!payload.id) {
-        payload.id = generateId()
-      }
 
       const newApiClaim = await apiService.createClaim(payload)
       const newClaim = transformApiClaimToFrontend(newApiClaim)


### PR DESCRIPTION
## Summary
- Generate new claim IDs on the server when missing
- Stop pre-initializing claim IDs on the frontend and create ID on first save
- Allow subsequent saves to update existing claims
- Clarify server-side claim ID generation and drop client-side form ID resets
- Split claim reload query into separate SQL statements to avoid timeout on save
- Render settlements section only when claim ID is available so modules don't fetch without an event ID
- Update repair schedule/detail saving to update existing records instead of duplicating them
- Queue document uploads until an event ID exists and pass the ID to all claim sections
- Render documents section even before an event ID is assigned so uploads can be queued

## Testing
- `npm test` *(fails: ModuleLoader.importSyncForRequire ...)*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d6a1f5dc832cb24ae755d7c3c118