### PR TITLE
feat: add medium damage level

### DIFF
--- a/components/claim-form/communication-claim-summary.tsx
+++ b/components/claim-form/communication-claim-summary.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { DamageDiagram } from "@/components/damage-diagram"
+import { DamageDiagram, DamageLevel } from "@/components/damage-diagram"
 import { DocumentsSection } from "../documents-section"
 import {
   AlertTriangle,
@@ -32,6 +32,19 @@ interface ClaimStatus {
 interface RiskType {
   value: string
   label: string
+}
+
+const getDamageLevelName = (level: DamageLevel): string => {
+  switch (level) {
+    case DamageLevel.LIGHT:
+      return "Lekkie"
+    case DamageLevel.MEDIUM:
+      return "Średnie"
+    case DamageLevel.HEAVY:
+      return "Duże"
+    default:
+      return "Brak"
+  }
 }
 
 interface CommunicationClaimSummaryProps {
@@ -374,7 +387,9 @@ const CommunicationClaimSummary = ({
                         className="text-sm text-gray-900 p-2 bg-white rounded border"
                       >
                         <span className="font-medium">{damage.description}</span>
-                        <span className="text-gray-600 ml-2">- {damage.detail}</span>
+                        <span className="text-gray-600 ml-2">
+                          - {getDamageLevelName(damage.level ?? DamageLevel.LIGHT)}
+                        </span>
                       </div>
                     ))
                   ) : (
@@ -385,7 +400,12 @@ const CommunicationClaimSummary = ({
             </div>
             <div>
               <DamageDiagram
-                damagedParts={(claimFormData.damages || []).map((d) => d.description)}
+                damageData={Object.fromEntries(
+                  (claimFormData.damages || []).map((d) => [
+                    d.description,
+                    d.level ?? DamageLevel.LIGHT,
+                  ]),
+                )}
                 onPartClick={() => {}}
               />
             </div>

--- a/components/damage-diagram.tsx
+++ b/components/damage-diagram.tsx
@@ -13,7 +13,8 @@ export enum VehicleType {
 export enum DamageLevel {
   NONE = 0,
   LIGHT = 1,
-  HEAVY = 2,
+  MEDIUM = 2,
+  HEAVY = 3,
 }
 
 interface DamageDiagramProps {
@@ -87,6 +88,9 @@ export function DamageDiagram({
             newLevel = DamageLevel.LIGHT
             break
           case DamageLevel.LIGHT:
+            newLevel = DamageLevel.MEDIUM
+            break
+          case DamageLevel.MEDIUM:
             newLevel = DamageLevel.HEAVY
             break
           case DamageLevel.HEAVY:
@@ -109,6 +113,12 @@ export function DamageDiagram({
           svgElement.style.stroke = "#f59e0b"
           svgElement.style.strokeWidth = "2"
           svgElement.style.opacity = "0.8"
+          break
+        case DamageLevel.MEDIUM:
+          svgElement.style.fill = "#fb923c" // Orange for medium damage
+          svgElement.style.stroke = "#f97316"
+          svgElement.style.strokeWidth = "3"
+          svgElement.style.opacity = "0.85"
           break
         case DamageLevel.HEAVY:
           svgElement.style.fill = "#dc2626" // Red for heavy damage
@@ -150,6 +160,8 @@ export function DamageDiagram({
     switch (level) {
       case DamageLevel.LIGHT:
         return "Lekkie"
+      case DamageLevel.MEDIUM:
+        return "Średnie"
       case DamageLevel.HEAVY:
         return "Duże"
       default:
@@ -272,6 +284,7 @@ export function DamageDiagram({
   const getDamagedPartsByLevel = () => {
     const partsByLevel = {
       [DamageLevel.LIGHT]: [] as string[],
+      [DamageLevel.MEDIUM]: [] as string[],
       [DamageLevel.HEAVY]: [] as string[],
     }
 
@@ -309,6 +322,10 @@ export function DamageDiagram({
               <span className="text-sm text-gray-600">Lekkie uszkodzenia</span>
             </div>
             <div className="flex items-center gap-2">
+              <div className="w-4 h-4 border-2 border-orange-500 bg-orange-400 rounded"></div>
+              <span className="text-sm text-gray-600">Średnie uszkodzenia</span>
+            </div>
+            <div className="flex items-center gap-2">
               <div className="w-4 h-4 border-2 border-red-700 bg-red-600 rounded"></div>
               <span className="text-sm text-gray-600">Duże uszkodzenia</span>
             </div>
@@ -333,7 +350,9 @@ export function DamageDiagram({
                               className={`w-3 h-3 rounded border-2 ${
                                   damageLevel === DamageLevel.LIGHT
                                       ? "bg-yellow-400 border-amber-600"
-                                      : "bg-red-600 border-red-700"
+                                      : damageLevel === DamageLevel.MEDIUM
+                                          ? "bg-orange-400 border-orange-500"
+                                          : "bg-red-600 border-red-700"
                               }`}
                           ></div>
                           <span className="text-sm font-medium text-gray-700">

--- a/hooks/use-damages.ts
+++ b/hooks/use-damages.ts
@@ -3,6 +3,7 @@
 import { useCallback } from "react"
 import { API_ENDPOINTS, generateId } from "@/lib/constants"
 import { authFetch } from "@/lib/auth-fetch"
+import { DamageLevel } from "@/components/damage-diagram"
 
 export interface Damage {
   id?: string
@@ -14,6 +15,7 @@ export interface Damage {
   estimatedCost?: number
   actualCost?: number
   isSaved?: boolean
+  level?: DamageLevel
 }
 
 export interface DamageInit {
@@ -24,6 +26,7 @@ export function createDamageDraft(params: Partial<Damage> = {}): Damage {
   return {
     description: "",
     isSaved: false,
+    level: DamageLevel.LIGHT,
     ...params,
   }
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,6 +1,7 @@
 import type React from "react"
 import type { ClaimDto, DocumentDto } from "@/lib/api"
 import type { Settlement } from "@/lib/api/settlements"
+import type { DamageLevel } from "@/components/damage-diagram"
 
 export type { Settlement } from "@/lib/api/settlements"
 
@@ -212,6 +213,7 @@ export interface DamageItem {
   description: string
   detail: string
   isSaved?: boolean
+  level?: DamageLevel
 }
 
 export interface Decision {


### PR DESCRIPTION
## Summary
- support medium severity in damage diagram
- update legend and damage list for three-level damage scale
- track per-part damage levels in claim forms

## Testing
- `npm test` *(fails: Cannot require() ES Module /workspace/claimWork/app/api/appeals/route.ts in a cycle)*

------
https://chatgpt.com/codex/tasks/task_e_68b38b1dc7b4832c9ae4074cbdabf4bd