### PR TITLE
feat: remove hyphens from document categories

### DIFF
--- a/components/claim-form/index.tsx
+++ b/components/claim-form/index.tsx
@@ -101,7 +101,9 @@ export function ClaimForm({ initialData, mode }: ClaimFormProps) {
   const { createDamage } = useDamages(formData.id)
 
   const mapCategoryNameToCode = (name?: string | null) =>
-    requiredDocuments.find((d) => d.name === name)?.category || name || 'Inne dokumenty'
+    requiredDocuments.find((d) => d.name === name)?.category ||
+    name?.toLowerCase().replace(/\s+/g, '-') ||
+    'Inne dokumenty'
 
 
   const markDirty = () => setHasUnsavedChanges(true)

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -277,10 +277,14 @@ export const DocumentsSection = React.forwardRef<
   }, [eventId])
 
   const mapCategoryCodeToName = (code?: string) =>
-    requiredDocuments.find((d) => d.category === code)?.name || code || "Inne dokumenty"
+    requiredDocuments.find((d) => d.category === code)?.name ||
+    code?.replace(/-/g, " ") ||
+    "Inne dokumenty"
 
   const mapCategoryNameToCode = (name?: string | null) =>
-    requiredDocuments.find((d) => d.name === name)?.category || name || "Inne dokumenty"
+    requiredDocuments.find((d) => d.name === name)?.category ||
+    name?.toLowerCase().replace(/\s+/g, "-") ||
+    "Inne dokumenty"
 
   const loadDocuments = async () => {
     if (!eventId || !isGuid(eventId)) return


### PR DESCRIPTION
## Summary
- remove hyphens from document category display names
- normalize document category name to code mapping

## Testing
- `pnpm test`
- `pnpm lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b0564f84832ca0e5ab0d9a0ffaeb