### PR TITLE
fix: mark leave components as client

### DIFF
--- a/components/leaves/LeaveRequestDetails.tsx
+++ b/components/leaves/LeaveRequestDetails.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 import { LeaveRequest } from "@/types/leave";
 import { Button } from "@/components/ui/button";

--- a/components/leaves/ManagerLeavesTable.tsx
+++ b/components/leaves/ManagerLeavesTable.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { LeaveRequest } from "@/types/leave";

--- a/components/leaves/RejectReasonDialog.tsx
+++ b/components/leaves/RejectReasonDialog.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 import {
   AlertDialog,


### PR DESCRIPTION
## Summary
- add `use client` to leave management components

## Testing
- `pnpm lint` *(fails: ELIFECYCLE, prompts for ESLint setup)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b2b357d8832c80d0b55cf7d38868