### PR TITLE
feat: create claim draft on initialization

### DIFF
--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -115,6 +115,7 @@ export default function NewClaimPage() {
       if (id) {
         setClaimId(id)
         setClaimFormData((prev) => ({ ...prev, id }))
+        setIsPersisted(true)
       }
     }
     init()


### PR DESCRIPTION
## Summary
- create draft claim on initialization and persist it to database
- finalize draft when creating claim
- mark initialized claims as persisted on the client so subsequent saves update the draft

## Testing
- `pnpm test`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b3c5d614832cb8c170711c3c010e