### PR TITLE
Fix duplicate 'Inne dokumenty' categories

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -278,13 +278,13 @@ export const DocumentsSection = React.forwardRef<
 
   const mapCategoryCodeToName = (code?: string) =>
     requiredDocuments.find((d) => d.category === code)?.name ||
-    code?.replace(/-/g, " ") ||
-    "Inne dokumenty"
+    (code
+      ? code.replace(/-/g, " ").replace(/^./, (c) => c.toUpperCase())
+      : "Inne dokumenty")
 
   const mapCategoryNameToCode = (name?: string | null) =>
     requiredDocuments.find((d) => d.name === name)?.category ||
-    name?.toLowerCase().replace(/\s+/g, "-") ||
-    "Inne dokumenty"
+    (name ? name.toLowerCase().replace(/\s+/g, "-") : "inne-dokumenty")
 
   const loadDocuments = async () => {
     if (!eventId || !isGuid(eventId)) return


### PR DESCRIPTION
## Summary
- Normalize category code->name mapping to capitalize display names
- Return a consistent default code for unspecified categories

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Couldn't configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b75e8830832cbdf4aea1daaa4475