### PR TITLE
feat(mobile): add notifications nav item

### DIFF
--- a/app/mobile/layout.tsx
+++ b/app/mobile/layout.tsx
@@ -1,5 +1,10 @@
 import type { ReactNode } from "react";
+import type { Metadata } from "next";
 import "../../mobile/styles/globals.css";
+
+export const metadata: Metadata = {
+  manifest: "/mobile-manifest.json",
+};
 
 export default function MobileLayout({ children }: { children: ReactNode }) {
   return <>{children}</>;

--- a/mobile/components/BottomNavigation.tsx
+++ b/mobile/components/BottomNavigation.tsx
@@ -1,5 +1,6 @@
 import { Button } from "./ui/button";
-import { Home, Plus, List, User } from "lucide-react";
+import { Home, Plus, List, User, Bell } from "lucide-react";
+import { useNotifications } from "../hooks/useNotifications";
 
 interface BottomNavigationProps {
   activeSection: string;
@@ -7,6 +8,8 @@ interface BottomNavigationProps {
 }
 
 export function BottomNavigation({ activeSection, onNavigate }: BottomNavigationProps) {
+  const { unreadCount } = useNotifications();
+
   const navItems = [
     {
       id: "dashboard",
@@ -15,10 +18,16 @@ export function BottomNavigation({ activeSection, onNavigate }: BottomNavigation
       color: "#1a3a6c"
     },
     {
-      id: "report", 
+      id: "report",
       label: "Zgłoś",
       icon: Plus,
       color: "#059669"
+    },
+    {
+      id: "notifications",
+      label: "Powiad.",
+      icon: Bell,
+      color: "#3b82f6"
     },
     {
       id: "claims",
@@ -60,8 +69,13 @@ export function BottomNavigation({ activeSection, onNavigate }: BottomNavigation
             >
               <div className={`relative ${isActive ? 'scale-110' : 'scale-100'} transition-transform duration-200`}>
                 <Icon className={`w-6 h-6`} style={{ color: isActive ? item.color : '#64748b' }} />
+                {item.id === 'notifications' && unreadCount > 0 && (
+                  <div className="absolute -top-1 -right-1 w-4 h-4 bg-[#dc2626] rounded-full flex items-center justify-center">
+                    <span className="text-[10px] text-white font-medium">{Math.min(unreadCount, 9)}</span>
+                  </div>
+                )}
                 {isActive && (
-                  <div 
+                  <div
                     className="absolute -bottom-1 left-1/2 transform -translate-x-1/2 w-1 h-1 rounded-full"
                     style={{ backgroundColor: item.color }}
                   />

--- a/mobile/main.tsx
+++ b/mobile/main.tsx
@@ -10,9 +10,25 @@ if (typeof window !== "undefined") {
 
   if ("serviceWorker" in navigator) {
     window.addEventListener("load", () => {
-      navigator.serviceWorker.register("/mobile-sw.js").catch(() => {
-        // ignore registration errors
-      });
+      navigator.serviceWorker
+        .register("/mobile-sw.js")
+        .then(async (reg) => {
+          const interval = 30 * 1000;
+          // @ts-expect-error - periodicSync is experimental
+          if ("periodicSync" in reg) {
+            try {
+              // @ts-expect-error - register is not yet typed
+              await reg.periodicSync.register("fetch-notifications", {
+                minInterval: interval,
+              });
+            } catch {
+              // ignore registration errors
+            }
+          }
+        })
+        .catch(() => {
+          // ignore registration errors
+        });
     });
   }
 }

--- a/public/mobile-manifest.json
+++ b/public/mobile-manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "ClaimWork Mobile",
+  "short_name": "ClaimWork",
+  "start_url": "/mobile",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#1a3a6c",
+  "icons": [
+    {
+      "src": "/placeholder-logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/placeholder-logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/mobile-sw.js
+++ b/public/mobile-sw.js
@@ -25,3 +25,9 @@ self.addEventListener('activate', event => {
   fetchNotifications();
   setInterval(fetchNotifications, POLL_INTERVAL);
 });
+
+self.addEventListener('periodicsync', event => {
+  if (event.tag === 'fetch-notifications') {
+    event.waitUntil(fetchNotifications());
+  }
+});


### PR DESCRIPTION
## Summary
- add notifications entry to mobile bottom navigation
- display unread notification count badge
- register mobile PWA manifest and background notification polling

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b5ca6f88832c9d408e5287524380