### PR TITLE
Ensure new claims use create endpoint

### DIFF
--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -115,7 +115,6 @@ export default function NewClaimPage() {
       if (id) {
         setClaimId(id)
         setClaimFormData((prev) => ({ ...prev, id }))
-        setIsPersisted(true)
       }
     }
     init()


### PR DESCRIPTION
## Summary
- Avoid marking initialized claims as persisted so the first save uses the create endpoint

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4b9df2a98832cad8efa42683d48d7