### PR TITLE
Reduce event query timeout

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -376,6 +376,7 @@ namespace AutomotiveClaimsApi.Controllers
                 var statusEntity = await _context.ClaimStatuses.FirstOrDefaultAsync(cs => cs.Code == statusCode);
 
                 var existingEvent = await _context.Events
+                    .AsSplitQuery()
                     .Include(e => e.Participants).ThenInclude(p => p.Drivers)
                     .Include(e => e.Damages)
                     .Include(e => e.Appeals)


### PR DESCRIPTION
## Summary
- load existing event with split queries to prevent timeouts

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c44de95c832c9d5b72c92d54f77b