### PR TITLE
Fix case handler ID mapping in claims

### DIFF
--- a/hooks/__tests__/use-claims.test.ts
+++ b/hooks/__tests__/use-claims.test.ts
@@ -18,7 +18,7 @@ test('includes dropdown selections in payload', () => {
   assert.equal(payload.damageType, 'DT')
   assert.equal(payload.insuranceCompanyId, 5)
   assert.equal(payload.clientId, 7)
-  assert.equal(payload.caseHandlerId, 9)
+  assert.equal(payload.handlerId, 9)
 })
 
 test('maps transportDamage fields', () => {

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -42,6 +42,8 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
     inspectionContactName,
     inspectionContactPhone,
     inspectionContactEmail,
+    handlerId,
+    caseHandlerId,
     ...rest
   } = apiClaim
 
@@ -70,7 +72,7 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
     objectTypeId: rest.objectTypeId,
     insuranceCompanyId: rest.insuranceCompanyId?.toString(),
     leasingCompanyId: rest.leasingCompanyId?.toString(),
-    caseHandlerId: rest.caseHandlerId?.toString(),
+    caseHandlerId: (caseHandlerId ?? handlerId)?.toString(),
     clientId: rest.clientId?.toString(),
     totalClaim: rest.totalClaim ?? 0,
     payout: rest.payout ?? 0,
@@ -268,7 +270,7 @@ export const transformFrontendClaimToApiPayload = (
     insuranceCompanyId: insuranceCompanyId ? parseInt(insuranceCompanyId, 10) : undefined,
     leasingCompanyId: leasingCompanyId ? parseInt(leasingCompanyId, 10) : undefined,
     clientId: clientId ? parseInt(clientId, 10) : undefined,
-    caseHandlerId: caseHandlerId ? parseInt(caseHandlerId, 10) : undefined,
+    handlerId: caseHandlerId ? parseInt(caseHandlerId, 10) : undefined,
     victimRegistrationNumber: injuredParty?.vehicleRegistration,
     perpetratorRegistrationNumber: perpetrator?.vehicleRegistration,
     riskType,
@@ -420,7 +422,9 @@ export function useClaims() {
           clientId: claim.clientId?.toString(),
           insuranceCompanyId: claim.insuranceCompanyId?.toString(),
           leasingCompanyId: claim.leasingCompanyId?.toString(),
-          caseHandlerId: claim.caseHandlerId?.toString(),
+          caseHandlerId: (claim as any).caseHandlerId
+            ? (claim as any).caseHandlerId.toString()
+            : claim.handlerId?.toString(),
         })) as Claim[]
 
         setClaims((prev) =>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -58,10 +58,10 @@ export interface EventListItemDto {
   reportDate?: string
   riskType?: string
   damageType?: string
-  leasingCompanyId?: number
-  leasingCompany?: string
-  caseHandlerId?: number
-  handler?: string
+    leasingCompanyId?: number
+    leasingCompany?: string
+    handlerId?: number
+    handler?: string
   objectTypeId?: number
   registeredById?: string
   registeredByName?: string
@@ -91,7 +91,7 @@ export interface EventDto extends EventListItemDto {
   perpetratorData?: string
 
   insuranceCompanyId?: number
-  caseHandlerId?: number
+  handlerId?: number
   riskType?: string
   damageType?: string
   subcontractorName?: string
@@ -188,7 +188,7 @@ export interface EventUpsertDto {
   insuranceCompany?: string
   leasingCompanyId?: number
   leasingCompany?: string
-  caseHandlerId?: number
+  handlerId?: number
   handler?: string
   damageDate?: string
   reportDate?: string


### PR DESCRIPTION
## Summary
- map backend `handlerId` to frontend `caseHandlerId`
- send `handlerId` in claim payloads
- update API DTO types and tests for handler ID

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4bf785804832ca369f3db3ceff5ad