### PR TITLE
fix: make mobile notifications use environment API base

### DIFF
--- a/public/mobile-sw.js
+++ b/public/mobile-sw.js
@@ -1,15 +1,22 @@
 const POLL_INTERVAL = 30000;
 const seenIds = new Set();
 
+// Determine the API base URL. When developing locally the API runs on
+// a different port, while in production it is served from the same
+// origin under the `/api` path.
+const API_BASE_URL = self.location.origin.includes("localhost")
+  ? "http://localhost:5200/api"
+  : "/api";
+
 async function fetchNotifications() {
   try {
-    const res = await fetch('/api/mobile/notifications');
+    const res = await fetch(`${API_BASE_URL}/mobile/notifications`);
     if (!res.ok) return;
     const items = await res.json();
     for (const n of items) {
       if (!seenIds.has(n.id)) {
-        self.registration.showNotification(n.title || 'Notification', {
-          body: n.message || '',
+        self.registration.showNotification(n.title || "Notification", {
+          body: n.message || "",
         });
         seenIds.add(n.id);
       }


### PR DESCRIPTION
## Summary
- use environment-aware API URL in mobile service worker so notifications can be fetched in local and production builds

## Testing
- `npm test` *(fails: hooks/__tests__/use-damages.test.ts)*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c1a6ec38832c87359689a29ec880