### PR TITLE
feat: show document attachment count in sidebar

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -339,6 +339,8 @@ export default function ClaimPage() {
                 (mode === "view"
                   ? claim?.notes?.length
                   : claimFormData.notes?.length) || 0,
+              dokumenty:
+                (mode === "view" ? claim?.documents?.length : uploadedFiles.length) || 0,
 
             }}
           />

--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -212,6 +212,7 @@ export default function EditClaimPage() {
             regres: claimFormData.recourses?.length || 0,
             ugody: claimFormData.settlements?.length || 0,
             notatki: claimFormData.notes?.length || 0,
+            dokumenty: uploadedFiles.length,
           }}
 
         />

--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -512,6 +512,7 @@ export default function NewClaimPage() {
             regres: claimFormData.recourses?.length || 0,
             ugody: claimFormData.settlements?.length || 0,
             notatki: claimFormData.notes?.length || 0,
+            dokumenty: uploadedFiles.length + pendingFiles.length,
           }}
 
         />


### PR DESCRIPTION
## Summary
- show number of attached documents as a badge on claim form menu

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c9c93dfc832c84137432bcbf1d03