### PR TITLE
Remove redundant NoContent check in claim updates

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -655,19 +655,6 @@ namespace AutomotiveClaimsApi.Controllers
                         _context.Entry(entity).State = EntityState.Detached;
                     }
 
-                    var existingDto = JsonSerializer.Deserialize<ClaimUpsertDto>(
-                        JsonSerializer.Serialize(MapEventToDto(existing)));
-                    var options = new JsonSerializerOptions
-                    {
-                        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-                    };
-                    var existingJson = JsonSerializer.Serialize(existingDto, options);
-                    var incomingJson = JsonSerializer.Serialize(eventDto, options);
-                    if (existingJson == incomingJson)
-                    {
-                        return NoContent();
-                    }
-
                     _context.Entry(existing).State = EntityState.Detached;
                 }
 


### PR DESCRIPTION
## Summary
- remove JSON equality comparison that returned `NoContent` in `ClaimsController`

## Testing
- `dotnet test` *(fails: command not found)*
- `wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb` *(fails: Proxy tunneling failed: ForbiddenUnable to establish SSL connection)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d02b8d08832c925c6ca4396a090c