### PR TITLE
Persist damage severity categories

### DIFF
--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -9,6 +9,33 @@ import {
   type ParticipantUpsertDto,
 } from "@/lib/api"
 import type { Claim, ParticipantInfo, DriverInfo, Note } from "@/types"
+import { DamageLevel } from "@/components/damage-diagram"
+
+const severityToLevel = (severity?: string): DamageLevel => {
+  switch (severity?.toLowerCase()) {
+    case "light":
+      return DamageLevel.LIGHT
+    case "medium":
+      return DamageLevel.MEDIUM
+    case "heavy":
+      return DamageLevel.HEAVY
+    default:
+      return DamageLevel.NONE
+  }
+}
+
+const levelToSeverity = (level?: DamageLevel): string | undefined => {
+  switch (level) {
+    case DamageLevel.LIGHT:
+      return "light"
+    case DamageLevel.MEDIUM:
+      return "medium"
+    case DamageLevel.HEAVY:
+      return "heavy"
+    default:
+      return undefined
+  }
+}
 
 const toIso = (value?: string, field?: string): string | undefined => {
   if (!value) return undefined
@@ -89,6 +116,7 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
       eventId: d.eventId?.toString(),
       description: d.description,
       detail: d.detail,
+      level: severityToLevel(d.severity),
     })) || [],
     notes:
       notes?.map((n: any) => ({
@@ -309,6 +337,9 @@ export const transformFrontendClaimToApiPayload = (
       eventId: d.eventId,
       description: d.description,
       detail: d.detail,
+      ...(d.level !== undefined
+        ? { severity: levelToSeverity(d.level) }
+        : {}),
     })),
     ...(Array.isArray(notes) && notes.length > 0
       ? {


### PR DESCRIPTION
## Summary
- convert severity strings to DamageLevel and vice versa for claim data
- include severity in damage API requests and responses

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4cdb4787c832cb48ba82226d7c1fb