### PR TITLE
feat(backend): store mobile notifications in memory

### DIFF
--- a/backend/Controllers/MobileNotificationsController.cs
+++ b/backend/Controllers/MobileNotificationsController.cs
@@ -1,9 +1,9 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using AutomotiveClaimsApi.DTOs;
+using AutomotiveClaimsApi.Services;
 
 namespace AutomotiveClaimsApi.Controllers
 {
@@ -11,72 +11,19 @@ namespace AutomotiveClaimsApi.Controllers
     [Route("api/mobile/notifications")]
     public class MobileNotificationsController : ControllerBase
     {
+        private readonly IMobileNotificationStore _store;
+
+        public MobileNotificationsController(IMobileNotificationStore store)
+        {
+            _store = store;
+        }
+
         [HttpGet]
         public ActionResult<IEnumerable<MobileNotificationDto>> Get()
         {
-            var notifications = new List<MobileNotificationDto>
-            {
-                new MobileNotificationDto
-                {
-                    Id = "1",
-                    Title = "Aktualizacja statusu",
-                    Message = "Szkoda SK-2024-001 przeszła do etapu realizacji naprawy",
-                    Type = "info",
-                    Timestamp = DateTime.UtcNow.AddMinutes(-30),
-                    Read = false,
-                    ClaimId = "SK-2024-001",
-                    ActionType = "status_update",
-                    RecipientId = "user-1"
-                },
-                new MobileNotificationDto
-                {
-                    Id = "2",
-                    Title = "Nowa szkoda",
-                    Message = "Otrzymano nowe zgłoszenie szkody komunikacyjnej",
-                    Type = "success",
-                    Timestamp = DateTime.UtcNow.AddHours(-2),
-                    Read = false,
-                    ActionType = "new_claim",
-                    RecipientId = "user-2"
-                },
-                new MobileNotificationDto
-                {
-                    Id = "3",
-                    Title = "Przypomnienie",
-                    Message = "Szkoda SK-2024-002 oczekuje na Twoją reakcję",
-                    Type = "warning",
-                    Timestamp = DateTime.UtcNow.AddHours(-4),
-                    Read = false,
-                    ClaimId = "SK-2024-002",
-                    ActionType = "reminder",
-                    RecipientId = "user-1"
-                },
-                new MobileNotificationDto
-                {
-                    Id = "4",
-                    Title = "Szkoda zakończona",
-                    Message = "Pomyślnie zakończono realizację szkody SK-2024-004",
-                    Type = "success",
-                    Timestamp = DateTime.UtcNow.AddHours(-8),
-                    Read = true,
-                    ClaimId = "SK-2024-004",
-                    ActionType = "status_update",
-                    RecipientId = "user-1"
-                },
-                new MobileNotificationDto
-                {
-                    Id = "5",
-                    Title = "Konserwacja systemu",
-                    Message = "Planowana konserwacja systemu w niedzielę 15.09 od 2:00 do 6:00",
-                    Type = "info",
-                    Timestamp = DateTime.UtcNow.AddDays(-1),
-                    Read = true,
-                    ActionType = "system",
-                    RecipientId = null
-                }
-            };
-
+            var notifications = _store.GetAll();
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
             if (User.IsInRole("Admin") || User.IsInRole("ClaimHandler"))
             {
                 return Ok(notifications);
@@ -89,6 +36,27 @@ namespace AutomotiveClaimsApi.Controllers
 
             var filtered = notifications.Where(n => n.RecipientId == null || n.RecipientId == userId);
             return Ok(filtered);
+        }
+
+        [HttpPost]
+        public IActionResult Create([FromBody] MobileNotificationDto notification)
+        {
+            _store.Add(notification);
+            return CreatedAtAction(nameof(Get), new { id = notification.Id }, notification);
+        }
+
+        [HttpPost("{id}/read")]
+        public IActionResult MarkAsRead(string id)
+        {
+            return _store.MarkAsRead(id) ? NoContent() : NotFound();
+        }
+
+        [HttpPost("read-all")]
+        public IActionResult MarkAllAsRead()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            _store.MarkAllAsRead(userId);
+            return NoContent();
         }
     }
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -108,6 +108,7 @@ builder.Services.AddScoped<IRiskTypeService, RiskTypeService>();
 builder.Services.AddScoped<IDamageTypeService, DamageTypeService>();
 builder.Services.AddScoped<ICaseHandlerService, CaseHandlerService>();
 builder.Services.AddEventDocumentStore(builder.Configuration);
+builder.Services.AddSingleton<IMobileNotificationStore, InMemoryMobileNotificationStore>();
 
 // Add background services
 builder.Services.AddHostedService<EmailBackgroundService>();

--- a/backend/Services/MobileNotificationStore.cs
+++ b/backend/Services/MobileNotificationStore.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using AutomotiveClaimsApi.DTOs;
+
+namespace AutomotiveClaimsApi.Services
+{
+    public interface IMobileNotificationStore
+    {
+        IEnumerable<MobileNotificationDto> GetAll();
+        void Add(MobileNotificationDto notification);
+        bool MarkAsRead(string id);
+        void MarkAllAsRead(string? userId);
+    }
+
+    public class InMemoryMobileNotificationStore : IMobileNotificationStore
+    {
+        private readonly ConcurrentDictionary<string, MobileNotificationDto> _notifications = new();
+
+        public InMemoryMobileNotificationStore()
+        {
+            var now = DateTime.UtcNow;
+            Add(new MobileNotificationDto
+            {
+                Title = "Aktualizacja statusu",
+                Message = "Szkoda SK-2024-001 przeszła do etapu realizacji naprawy",
+                Type = "info",
+                Timestamp = now.AddMinutes(-30),
+                Read = false,
+                ClaimId = "SK-2024-001",
+                ActionType = "status_update",
+                RecipientId = "user-1"
+            });
+
+            Add(new MobileNotificationDto
+            {
+                Title = "Nowa szkoda",
+                Message = "Otrzymano nowe zgłoszenie szkody komunikacyjnej",
+                Type = "success",
+                Timestamp = now.AddHours(-2),
+                Read = false,
+                ActionType = "new_claim",
+                RecipientId = "user-2"
+            });
+        }
+
+        public IEnumerable<MobileNotificationDto> GetAll() =>
+            _notifications.Values.OrderByDescending(n => n.Timestamp);
+
+        public void Add(MobileNotificationDto notification)
+        {
+            if (string.IsNullOrEmpty(notification.Id))
+            {
+                notification.Id = Guid.NewGuid().ToString();
+            }
+
+            if (notification.Timestamp == default)
+            {
+                notification.Timestamp = DateTime.UtcNow;
+            }
+
+            _notifications[notification.Id] = notification;
+        }
+
+        public bool MarkAsRead(string id)
+        {
+            if (_notifications.TryGetValue(id, out var notification))
+            {
+                notification.Read = true;
+                return true;
+            }
+            return false;
+        }
+
+        public void MarkAllAsRead(string? userId)
+        {
+            foreach (var notification in _notifications.Values)
+            {
+                if (userId == null || notification.RecipientId == null || notification.RecipientId == userId)
+                {
+                    notification.Read = true;
+                }
+            }
+        }
+    }
+}
+

--- a/mobile/main.tsx
+++ b/mobile/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./styles/globals.css";
+import { NotificationsProvider } from "./hooks/useNotifications";
 
 // Request notification permission and register service worker
 if (typeof window !== "undefined") {
@@ -33,4 +34,8 @@ if (typeof window !== "undefined") {
   }
 }
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <NotificationsProvider>
+    <App />
+  </NotificationsProvider>
+);


### PR DESCRIPTION
## Summary
- add in-memory store for mobile notifications with sample data
- expose CRUD endpoints in MobileNotificationsController
- register notification store service

## Testing
- `pnpm test`
- `dotnet test backend/AutomotiveClaimsApi.Tests` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d31e7cd8832c80f06d81cde6f162