### PR TITLE
Ensure new claims created by handlers receive 'New' status

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -364,16 +364,19 @@ namespace AutomotiveClaimsApi.Controllers
                 }
 
                 CaseHandler? handler = null;
+                var hasAssignedHandler = false;
                 if (eventDto.HandlerId.HasValue)
                 {
                     handler = await _context.CaseHandlers.FindAsync(eventDto.HandlerId.Value);
+                    hasAssignedHandler = true;
                 }
                 else if (currentUser?.CaseHandlerId != null)
                 {
                     handler = await _context.CaseHandlers.FindAsync(currentUser.CaseHandlerId.Value);
+                    hasAssignedHandler = true;
                 }
 
-                var statusId = (handler != null || isHandler)
+                var statusId = (hasAssignedHandler || isHandler)
                     ? (int)ClaimStatusCode.New
                     : (int)ClaimStatusCode.ToAssign;
                 var statusEntity = await _context.ClaimStatuses.FindAsync(statusId);


### PR DESCRIPTION
## Summary
- set claim status to **New** when a handler is associated via request or current user

## Testing
- `dotnet test` *(fails: /usr/bin/dotnet: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d3c89f80832ca4eadd51fdd294b0