### PR TITLE
chore: remove category hint from required documents card

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -1835,9 +1835,6 @@ export const DocumentsSection = React.forwardRef<
               <CardTitle>Wymagane dokumenty</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="mb-4 text-sm text-gray-500">
-                Dodaj kategorię, aby móc załączyć odpowiednie pliki.
-              </p>
               <div className="relative mb-4">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
                 <Input


### PR DESCRIPTION
## Summary
- remove redundant note prompting to add category before uploading documents

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4d5a0823c832cace258980e387fa2