### PR TITLE
fix: resolve missing hook file for notifications

### DIFF
--- a/mobile/hooks/useNotifications.ts
+++ b/mobile/hooks/useNotifications.ts
@@ -1,0 +1,1 @@
+export * from './useNotifications.tsx';


### PR DESCRIPTION
## Summary
- add TypeScript re-export for mobile notifications hook

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint must be installed: pnpm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68b4db665330832c9384bf7660881664