### PR TITLE
Improve attachment search in documents section

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -251,7 +251,11 @@ export const DocumentsSection = React.forwardRef<
     }
     if (searchQuery.trim()) {
       const q = searchQuery.toLowerCase()
-      docs = docs.filter((d) => d.fileName.toLowerCase().includes(q))
+      docs = docs.filter(
+        (d) =>
+          d.fileName.toLowerCase().includes(q) ||
+          d.originalFileName.toLowerCase().includes(q),
+      )
     }
     return docs
   }, [allDocuments, hiddenCategories, showRequiredOnly, requiredDocuments, searchQuery])


### PR DESCRIPTION
## Summary
- search documents by both fileName and originalFileName to match attachment names

## Testing
- `pnpm lint` *(fails: ESLint must be installed: Forbidden 403)*
- `pnpm test` *(fails: hooks/__tests__/use-damages.test.ts 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b4db85e034832c86285d10d214d44a