### PR TITLE
Wrap mobile page with notifications provider

### DIFF
--- a/app/mobile/page.tsx
+++ b/app/mobile/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { NotificationsProvider } from "../../mobile/hooks/useNotifications";
 
 const MobileApp = dynamic(() => import("../../mobile/App"), { ssr: false });
 
 export default function MobilePage() {
-  return <MobileApp />;
+  return (
+    <NotificationsProvider>
+      <MobileApp />
+    </NotificationsProvider>
+  );
 }


### PR DESCRIPTION
## Summary
- Wrap mobile page in NotificationsProvider to enable notifications hook

## Testing
- `pnpm lint` *(fails: ESLint must be installed; registry access denied)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4dc6293e8832c98ca3bafaf6334a2