### PR TITLE
Remove download all button from documents section

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -11,7 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
-import { AlertTriangle, User, Wrench, Car, X, MessageSquare, Clock, FileCheck, FileText, Mail, Plus, CheckCircle, Trash2, Save, Calendar, Phone, Paperclip, DollarSign, Gavel, ArrowUpDown, HandHeart, Users, CreditCard, Shield, UserCheck, Download, Edit } from 'lucide-react'
+import { AlertTriangle, User, Wrench, Car, X, MessageSquare, Clock, FileCheck, FileText, Mail, Plus, CheckCircle, Trash2, Save, Calendar, Phone, Paperclip, DollarSign, Gavel, ArrowUpDown, HandHeart, Users, CreditCard, Shield, UserCheck, Edit } from 'lucide-react'
 import { DamageDiagram, DamageLevel } from "@/components/damage-diagram"
 import { ParticipantForm } from "./participant-form"
 import { DocumentsSection } from "../documents-section"
@@ -1311,13 +1311,6 @@ export const ClaimMainContent = ({
         <div className="space-y-4">
           <Card className="overflow-hidden shadow-sm border-gray-200 rounded-xl">
             <FormHeader icon={Paperclip} title="Dokumenty">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => documentsSectionRef.current?.downloadAll()}
-              >
-                <Download className="mr-2 h-4 w-4" /> Pobierz wszystkie
-              </Button>
             </FormHeader>
             <CardContent className="p-0 bg-white">
               <DocumentsSection

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -1490,14 +1490,6 @@ export const DocumentsSection = React.forwardRef<
           <Button
             variant="outline"
             size="sm"
-            onClick={() => handleDownloadAll()}
-            disabled={visibleDocuments.length === 0}
-          >
-            <Download className="mr-2 h-4 w-4" /> Pobierz wszystkie
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
             onClick={() => handleDownloadSelected()}
             disabled={selectedDocumentIds.length === 0}
           >


### PR DESCRIPTION
## Summary
- remove 'Download all' button from Documents section header and actions
- clean up unused icon import

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm add -D eslint` *(fails: GET https://registry.npmjs.org/eslint: Forbidden - 403)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4dcabbeec832c81870ccf3224faf0