### PR TITLE
Fix infinite scroll trigger on claims list

### DIFF
--- a/components/claims-list-desktop.tsx
+++ b/components/claims-list-desktop.tsx
@@ -825,7 +825,7 @@ export function ClaimsListDesktop({
                 <Loader2 className="h-6 w-6 animate-spin text-[#1a3a6c]" />
               </div>
             )}
-            <div ref={loaderRef} />
+            <div ref={loaderRef} className="h-1" />
           </div>
 
           {/* Empty State */}

--- a/components/mobile/claims-list.tsx
+++ b/components/mobile/claims-list.tsx
@@ -726,7 +726,7 @@ export function ClaimsListMobile({
                 <Loader2 className="h-6 w-6 animate-spin text-[#1a3a6c]" />
               </div>
             )}
-            <div ref={loaderRef} />
+            <div ref={loaderRef} className="h-1" />
           </div>
 
           {/* Empty State */}


### PR DESCRIPTION
## Summary
- ensure loader sentinel has height so IntersectionObserver triggers for infinite scroll on claims list (desktop and mobile)

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint must be installed and registry requires auth)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dcdd3fac832cb9001c344806bd43