### PR TITLE
feat: add push notifications support

### DIFF
--- a/backend/AutomotiveClaimsApi.csproj
+++ b/backend/AutomotiveClaimsApi.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="MongoDB.Driver" Version="2.21.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.2" />
     <PackageReference Include="ClosedXML" Version="0.102.4" />
+    <PackageReference Include="WebPush" Version="1.0.12" />
   </ItemGroup>
 
 </Project>

--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -37,6 +37,8 @@ namespace AutomotiveClaimsApi.Controllers
         private readonly IConfiguration _config;
         private readonly IEventDocumentStore _eventDocumentStore;
         private readonly IMobileNotificationStore? _mobileNotificationStore;
+        private readonly IPushSubscriptionStore? _pushSubscriptionStore;
+        private readonly IPushNotificationService? _pushNotificationService;
 
         public ClaimsController(
             ApplicationDbContext context,
@@ -46,7 +48,9 @@ namespace AutomotiveClaimsApi.Controllers
             INotificationService? notificationService = null,
             IDocumentService? documentService = null,
             IEventDocumentStore? eventDocumentStore = null,
-            IMobileNotificationStore? mobileNotificationStore = null)
+            IMobileNotificationStore? mobileNotificationStore = null,
+            IPushSubscriptionStore? pushSubscriptionStore = null,
+            IPushNotificationService? pushNotificationService = null)
         {
             _context = context;
             _logger = logger;
@@ -56,6 +60,8 @@ namespace AutomotiveClaimsApi.Controllers
             _documentService = documentService ?? throw new ArgumentNullException(nameof(documentService));
             _eventDocumentStore = eventDocumentStore ?? throw new ArgumentNullException(nameof(eventDocumentStore));
             _mobileNotificationStore = mobileNotificationStore;
+            _pushSubscriptionStore = pushSubscriptionStore;
+            _pushNotificationService = pushNotificationService;
         }
 
         private static Guid EnsureClaimId(Guid? id)
@@ -443,19 +449,25 @@ namespace AutomotiveClaimsApi.Controllers
                     if (!isHandler && currentUser != null)
                     {
                         var claimIdentifier = existingEvent.ClaimNumber ?? existingEvent.SpartaNumber ?? existingEvent.Id.ToString();
-                        _mobileNotificationStore?.Add(new MobileNotificationDto
-                        {
-                            Title = "Nowa szkoda",
-                            Message = $"Dodano nowe zgłoszenie szkody {claimIdentifier}",
-                            Type = "success",
-                            ClaimId = claimIdentifier,
-                            ActionType = "new_claim"
-                        });
+                    _mobileNotificationStore?.Add(new MobileNotificationDto
+                    {
+                        Title = "Nowa szkoda",
+                        Message = $"Dodano nowe zgłoszenie szkody {claimIdentifier}",
+                        Type = "success",
+                        ClaimId = claimIdentifier,
+                        ActionType = "new_claim"
+                    });
 
-                        if (_notificationService != null)
-                        {
-                            await _notificationService.NotifyAsync(existingEvent, currentUser, ClaimNotificationEvent.ClaimCreated);
-                        }
+                    if (_pushSubscriptionStore != null && _pushNotificationService != null)
+                    {
+                        var subs = _pushSubscriptionStore.GetAll();
+                        await _pushNotificationService.SendAsync(subs, "Nowa szkoda", $"Dodano nowe zgłoszenie szkody {claimIdentifier}");
+                    }
+
+                    if (_notificationService != null)
+                    {
+                        await _notificationService.NotifyAsync(existingEvent, currentUser, ClaimNotificationEvent.ClaimCreated);
+                    }
                     }
 
                     await _eventDocumentStore.SaveAsync(existingEvent);
@@ -533,6 +545,12 @@ namespace AutomotiveClaimsApi.Controllers
                         ClaimId = claimIdentifier,
                         ActionType = "new_claim"
                     });
+
+                    if (_pushSubscriptionStore != null && _pushNotificationService != null)
+                    {
+                        var subs = _pushSubscriptionStore.GetAll();
+                        await _pushNotificationService.SendAsync(subs, "Nowa szkoda", $"Dodano nowe zgłoszenie szkody {claimIdentifier}");
+                    }
 
                     if (_notificationService != null)
                     {

--- a/backend/Controllers/PushSubscriptionsController.cs
+++ b/backend/Controllers/PushSubscriptionsController.cs
@@ -1,0 +1,35 @@
+using System.Security.Claims;
+using AutomotiveClaimsApi.DTOs;
+using AutomotiveClaimsApi.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AutomotiveClaimsApi.Controllers
+{
+    [ApiController]
+    [Route("api/push")]
+    public class PushSubscriptionsController : ControllerBase
+    {
+        private readonly IPushSubscriptionStore _store;
+        private readonly VapidOptions _vapid;
+
+        public PushSubscriptionsController(IPushSubscriptionStore store, VapidOptions vapid)
+        {
+            _store = store;
+            _vapid = vapid;
+        }
+
+        [HttpGet("public-key")]
+        public ActionResult<object> GetPublicKey()
+        {
+            return Ok(new { key = _vapid.PublicKey });
+        }
+
+        [HttpPost("subscribe")]
+        public IActionResult Subscribe([FromBody] PushSubscriptionDto subscription)
+        {
+            subscription.UserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            _store.Add(subscription);
+            return Ok();
+        }
+    }
+}

--- a/backend/DTOs/PushSubscriptionDto.cs
+++ b/backend/DTOs/PushSubscriptionDto.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class PushSubscriptionDto
+    {
+        public string Endpoint { get; set; } = string.Empty;
+        public string? P256DH { get; set; }
+        public string? Auth { get; set; }
+        public string? UserId { get; set; }
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -109,6 +109,10 @@ builder.Services.AddScoped<IDamageTypeService, DamageTypeService>();
 builder.Services.AddScoped<ICaseHandlerService, CaseHandlerService>();
 builder.Services.AddEventDocumentStore(builder.Configuration);
 builder.Services.AddSingleton<IMobileNotificationStore, InMemoryMobileNotificationStore>();
+var vapidOptions = builder.Configuration.GetSection("Vapid").Get<VapidOptions>() ?? new VapidOptions();
+builder.Services.AddSingleton(vapidOptions);
+builder.Services.AddSingleton<IPushSubscriptionStore, InMemoryPushSubscriptionStore>();
+builder.Services.AddSingleton<IPushNotificationService, PushNotificationService>();
 
 // Add background services
 builder.Services.AddHostedService<EmailBackgroundService>();

--- a/backend/Services/PushNotificationService.cs
+++ b/backend/Services/PushNotificationService.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+using AutomotiveClaimsApi.DTOs;
+using WebPush;
+
+namespace AutomotiveClaimsApi.Services
+{
+    public interface IPushNotificationService
+    {
+        Task SendAsync(IEnumerable<PushSubscriptionDto> subscriptions, string title, string message);
+    }
+
+    public class PushNotificationService : IPushNotificationService
+    {
+        private readonly VapidOptions _options;
+        private readonly WebPushClient _client = new();
+
+        public PushNotificationService(VapidOptions options)
+        {
+            _options = options;
+        }
+
+        public async Task SendAsync(IEnumerable<PushSubscriptionDto> subscriptions, string title, string message)
+        {
+            var payload = JsonSerializer.Serialize(new { title, message });
+            foreach (var sub in subscriptions)
+            {
+                try
+                {
+                    var pushSub = new PushSubscription(sub.Endpoint, sub.P256DH, sub.Auth);
+                    await _client.SendNotificationAsync(pushSub, payload, new VapidDetails(_options.Subject, _options.PublicKey, _options.PrivateKey));
+                }
+                catch
+                {
+                    // ignore errors sending individual notifications
+                }
+            }
+        }
+    }
+
+    public class VapidOptions
+    {
+        public string Subject { get; set; } = string.Empty;
+        public string PublicKey { get; set; } = string.Empty;
+        public string PrivateKey { get; set; } = string.Empty;
+    }
+}

--- a/backend/Services/PushSubscriptionStore.cs
+++ b/backend/Services/PushSubscriptionStore.cs
@@ -1,0 +1,27 @@
+using System.Collections.Concurrent;
+using AutomotiveClaimsApi.DTOs;
+
+namespace AutomotiveClaimsApi.Services
+{
+    public interface IPushSubscriptionStore
+    {
+        void Add(PushSubscriptionDto subscription);
+        IEnumerable<PushSubscriptionDto> GetAll(string? userId = null);
+    }
+
+    public class InMemoryPushSubscriptionStore : IPushSubscriptionStore
+    {
+        private readonly ConcurrentDictionary<string, PushSubscriptionDto> _subscriptions = new();
+
+        public void Add(PushSubscriptionDto subscription)
+        {
+            if (string.IsNullOrEmpty(subscription.Endpoint)) return;
+            _subscriptions[subscription.Endpoint] = subscription;
+        }
+
+        public IEnumerable<PushSubscriptionDto> GetAll(string? userId = null)
+        {
+            return _subscriptions.Values.Where(s => userId == null || s.UserId == null || s.UserId == userId);
+        }
+    }
+}

--- a/backend/appsettings.Development.json
+++ b/backend/appsettings.Development.json
@@ -39,5 +39,10 @@
     "BucketName": "automotive-claims-documents",
     "ProjectId": "automotive-claims",
     "CredentialsPath": ""
+  },
+  "Vapid": {
+    "Subject": "mailto:admin@example.com",
+    "PublicKey": "BBOgZqXtn2a1gS5G8Z2qxdjQbaO5j3WJ4SmrjV-KEYEXAMPLE",
+    "PrivateKey": "samplePrivateKey1234567890"
   }
 }

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -53,5 +53,10 @@
   },
   "EventDocumentStore": {
     "Provider": "None"
+  },
+  "Vapid": {
+    "Subject": "mailto:admin@example.com",
+    "PublicKey": "BBOgZqXtn2a1gS5G8Z2qxdjQbaO5j3WJ4SmrjV-KEYEXAMPLE",
+    "PrivateKey": "samplePrivateKey1234567890"
   }
 }

--- a/mobile/main.tsx
+++ b/mobile/main.tsx
@@ -3,6 +3,17 @@ import App from "./App.tsx";
 import "./styles/globals.css";
 import { NotificationsProvider } from "./hooks/useNotifications";
 
+function urlBase64ToUint8Array(base64String: string) {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
 // Request notification permission and register service worker
 if (typeof window !== "undefined") {
   if ("Notification" in window && Notification.permission === "default") {
@@ -24,6 +35,24 @@ if (typeof window !== "undefined") {
               });
             } catch {
               // ignore registration errors
+            }
+          }
+
+          if ("PushManager" in window && Notification.permission === "granted") {
+            try {
+              const res = await fetch("/api/push/public-key");
+              const data = await res.json();
+              const sub = await reg.pushManager.subscribe({
+                userVisibleOnly: true,
+                applicationServerKey: urlBase64ToUint8Array(data.key),
+              });
+              await fetch("/api/push/subscribe", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(sub),
+              });
+            } catch {
+              // ignore push registration errors
             }
           }
         })

--- a/public/mobile-sw.js
+++ b/public/mobile-sw.js
@@ -38,3 +38,27 @@ self.addEventListener('periodicsync', event => {
     event.waitUntil(fetchNotifications());
   }
 });
+
+self.addEventListener('push', event => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch {
+    data = {};
+  }
+  const title = data.title || 'Notification';
+  const options = { body: data.message || '' };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then(list => {
+      if (list.length > 0) {
+        return list[0].focus();
+      }
+      return clients.openWindow('/');
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- enable push subscription storage and delivery on backend
- register push notifications on mobile client and service worker
- add VAPID configuration and WebPush package
- send push alerts when new claims are created

## Testing
- `pnpm lint` *(fails: ESLint must be installed: pnpm install --save-dev eslint)*
- `pnpm test`
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e6c0d930832c864b7913dd3a8f72