### PR TITLE
Limit basic users to claims sidebar tab

### DIFF
--- a/app/claims/layout.tsx
+++ b/app/claims/layout.tsx
@@ -9,17 +9,11 @@ import { useAuth } from '@/hooks/use-auth'
 export default function ClaimsLayout({ children }: { children: ReactNode }) {
   const [activeTab, setActiveTab] = useState('claims')
   const { user, logout } = useAuth()
-  const isBasicUser =
-    user?.roles?.length === 1 && user.roles[0].toLowerCase() === 'user'
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {!isBasicUser && (
-        <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
-      )}
-      <div
-        className={`${isBasicUser ? '' : 'ml-16'} flex flex-col min-h-screen`}
-      >
+      <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
+      <div className="ml-16 flex flex-col min-h-screen">
         <Header onMenuClick={() => {}} user={user ?? undefined} onLogout={logout} />
         <main className="flex-1">
           {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,6 +39,12 @@ function HomePage({ user, onLogout }: PageProps) {
   }, [])
 
   useEffect(() => {
+    if (isBasicUser) {
+      setActiveTab("claims")
+    }
+  }, [isBasicUser])
+
+  useEffect(() => {
     async function loadTasks() {
       try {
         const data = await apiService.getNotes({ category: "task" })
@@ -121,12 +127,10 @@ function HomePage({ user, onLogout }: PageProps) {
     { title: "Filtry", icon: Filter, color: "bg-purple-600 hover:bg-purple-700" },
   ];
 
-  return (
-    <div className="min-h-screen bg-gray-50">
-      {!isBasicUser && (
+    return (
+      <div className="min-h-screen bg-gray-50">
         <Sidebar activeTab={activeTab} onTabChange={setActiveTab} />
-      )}
-      <div className={`${isBasicUser ? "" : "ml-16"} flex flex-col min-h-screen`}>
+        <div className="ml-16 flex flex-col min-h-screen">
         <Header onMenuClick={() => {}} user={user} onLogout={onLogout} />
         <main className="flex-1 px-4 md:px-6 lg:px-8">
           <div className="w-full">

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -55,6 +55,9 @@ const menuItems = [
 
 export function Sidebar(props: SidebarProps) {
   const { user } = useAuth()
+  const isBasicUser =
+    user?.roles?.length === 1 && user.roles[0].toLowerCase() === "user"
+
   return (
     <div className="fixed left-0 top-0 z-40 h-full w-16 bg-[#1a3a6c] border-r border-[#2a4a7c] flex flex-col">
       {/* Header */}
@@ -65,13 +68,17 @@ export function Sidebar(props: SidebarProps) {
       {/* Navigation */}
       <nav className="flex-1 p-2 space-y-2">
         {menuItems
-          .filter(
-            (item) =>
+          .filter((item) => {
+            if (isBasicUser) {
+              return item.id === "claims"
+            }
+            return (
               !item.roles ||
               item.roles.some((role) =>
                 user?.roles?.some((r) => r.toLowerCase() === role.toLowerCase())
               )
-          )
+            )
+          })
           .map((item) => {
             const Icon = item.icon
             const isActive = props.activeTab === item.id


### PR DESCRIPTION
## Summary
- Always display sidebar for basic users but restrict it to the "Szkody" (claims) tab
- Show sidebar across home and claims layouts and auto-select claims tab for basic users

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4eeb79f90832c911e941f6b93086f