### PR TITLE
Add pagination to claims list

### DIFF
--- a/components/mobile/claims-list.tsx
+++ b/components/mobile/claims-list.tsx
@@ -14,6 +14,14 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select"
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationLink,
+} from "@/components/ui/pagination"
 
 import {
   Search,
@@ -86,7 +94,6 @@ export function ClaimsListMobile({
   const pageSize = 50
   const [sortBy, setSortBy] = useState<string>("spartaNumber")
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc")
-  const loaderRef = useRef<HTMLDivElement | null>(null)
   const containerRef = useRef<HTMLDivElement | null>(null)
 
   const {
@@ -209,12 +216,12 @@ export function ClaimsListMobile({
             sortBy,
             sortOrder,
             reportFromDate: reportFilter?.from || undefined,
-            reportToDate: reportFilter?.to || undefined,
-            damageFromDate: damageFilter?.from || undefined,
-            damageToDate: damageFilter?.to || undefined,
-          },
-          { append: page > 1 },
-        )
+          reportToDate: reportFilter?.to || undefined,
+          damageFromDate: damageFilter?.from || undefined,
+          damageToDate: damageFilter?.to || undefined,
+        },
+        { append: false },
+      )
       } catch (err) {
         toast({
           title: "Błąd",
@@ -265,34 +272,7 @@ export function ClaimsListMobile({
     () => claims.reduce((sum, claim) => sum + (claim.totalClaim || 0), 0),
     [claims],
   )
-
-  useEffect(() => {
-
-    if (initialClaims?.length) return
-
-    const node = loaderRef.current
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (
-          entries[0].isIntersecting &&
-          !loading &&
-          claims.length < totalRecords
-        ) {
-          setPage((p) => p + 1)
-        }
-      },
-      { root: containerRef.current || undefined, rootMargin: "200px" },
-    )
-    if (node) {
-      observer.observe(node)
-    }
-    return () => {
-      if (node) {
-        observer.unobserve(node)
-      }
-    }
-
-  }, [loading, claims.length, totalRecords, initialClaims])
+  const totalPages = Math.ceil(totalRecords / pageSize)
 
   const handleSort = (field: string) => {
     setPage(1)
@@ -410,7 +390,7 @@ export function ClaimsListMobile({
   }
 
   // Loading state
-  if (loading) {
+  if (loading && claims.length === 0) {
     return (
       <div className="w-full h-full bg-white flex flex-col">
         <div className="flex items-center justify-between p-6 border-b border-gray-200">
@@ -726,14 +706,40 @@ export function ClaimsListMobile({
                 </div>
               ))}
             </div>
-            {loading && page > 1 && (
+            {loading && (
               <div className="flex justify-center py-4">
                 <Loader2 className="h-6 w-6 animate-spin text-[#1a3a6c]" />
               </div>
             )}
-            <div ref={loaderRef} className="h-1" />
           </div>
-
+          {claims.length > 0 && totalPages > 1 && (
+            <Pagination className="p-4 border-t">
+              <PaginationContent>
+                <PaginationItem>
+                  <PaginationPrevious
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    className={page <= 1 ? "pointer-events-none opacity-50" : ""}
+                  />
+                </PaginationItem>
+                {Array.from({ length: totalPages }).map((_, i) => (
+                  <PaginationItem key={i}>
+                    <PaginationLink
+                      isActive={page === i + 1}
+                      onClick={() => setPage(i + 1)}
+                    >
+                      {i + 1}
+                    </PaginationLink>
+                  </PaginationItem>
+                ))}
+                <PaginationItem>
+                  <PaginationNext
+                    onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                    className={page >= totalPages ? "pointer-events-none opacity-50" : ""}
+                  />
+                </PaginationItem>
+              </PaginationContent>
+            </Pagination>
+          )}
           {/* Empty State */}
           {claims.length === 0 && !loading && (
             <div className="flex-1 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- replace infinite scrolling with explicit page controls in desktop and mobile claims lists
- fetch new data per page and show bottom pagination navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f4fdb2c0832ca888fa970182673b