### PR TITLE
fix: make claims search panel sticky

### DIFF
--- a/components/claims-list-desktop.tsx
+++ b/components/claims-list-desktop.tsx
@@ -489,7 +489,7 @@ export function ClaimsListDesktop({
       )}
 
       {/* Search and Filters */}
-      <div className="p-6 pb-4 flex-shrink-0">
+      <div className="p-6 pb-4 flex-shrink-0 sticky top-0 z-20 bg-white">
         <div className="flex flex-col sm:flex-row gap-3">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-2.5 h-4 w-4 text-gray-400" />

--- a/components/mobile/claims-list.tsx
+++ b/components/mobile/claims-list.tsx
@@ -482,7 +482,7 @@ export function ClaimsListMobile({
       )}
 
       {/* Search and Filters */}
-      <div className="p-6 pb-4 flex-shrink-0">
+      <div className="p-6 pb-4 flex-shrink-0 sticky top-0 z-20 bg-white">
         <div className="flex flex-col sm:flex-row gap-3">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-2.5 h-4 w-4 text-gray-400" />


### PR DESCRIPTION
## Summary
- keep desktop claims list search and filters visible by making panel sticky
- make mobile claims list search panel sticky for consistent UX

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b55b955984832c980e0fd7b43577c7