### PR TITLE
Limit document categories to Other Documents

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -398,6 +398,9 @@ export const DocumentsSection = React.forwardRef<
       })
     }
 
+    // Display only the "Inne dokumenty" category
+    categories = categories.filter((c) => c === "Inne dokumenty")
+
     return categories
   }, [
     requiredDocuments,


### PR DESCRIPTION
## Summary
- ensure only the "Inne dokumenty" (Other Documents) category is displayed in the documents section

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5cc6a97d8832cbbdd88e67c901c7a