### PR TITLE
Limit document categories to Other Documents

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -358,7 +358,9 @@ export const DocumentsSection = React.forwardRef<
   const documentCategories = React.useMemo(() => {
 
     const categoriesFromRequired = requiredDocuments.map((d) => d.name)
-    const categoriesFromDocuments = [...new Set(visibleDocuments.map((d) => d.documentType))]
+    const categoriesFromDocuments = [
+      ...new Set(visibleDocuments.map((d) => d.documentType)),
+    ].filter((c) => c === "Inne dokumenty")
     let categories = [
       ...new Set(["Inne dokumenty", ...categoriesFromRequired, ...categoriesFromDocuments]),
     ].filter((c) => !hiddenCategories.includes(c))


### PR DESCRIPTION
## Summary
- show only the "Inne dokumenty" category from uploaded documents while still displaying newly added required document categories

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cc6a97d8832cbbdd88e67c901c7a