### PR TITLE
feat: add handler and date range filters

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -83,6 +83,10 @@ namespace AutomotiveClaimsApi.Controllers
             [FromQuery] DateTime? reportToDate = null,
             [FromQuery] DateTime? damageFromDate = null,
             [FromQuery] DateTime? damageToDate = null,
+            [FromQuery] DateTime? registrationFromDate = null,
+            [FromQuery] DateTime? registrationToDate = null,
+            [FromQuery] DateTime? reportToInsurerFromDate = null,
+            [FromQuery] DateTime? reportToInsurerToDate = null,
             [FromQuery] DateTime? fromDate = null,
             [FromQuery] DateTime? toDate = null,
             [FromQuery] int page = 1,
@@ -195,6 +199,30 @@ namespace AutomotiveClaimsApi.Controllers
                 {
                     var to = damageToDate.Value.Date;
                     query = query.Where(e => e.DamageDate.HasValue && e.DamageDate.Value.Date <= to);
+                }
+
+                if (registrationFromDate.HasValue)
+                {
+                    var from = registrationFromDate.Value.Date;
+                    query = query.Where(e => e.CreatedAt.Date >= from);
+                }
+
+                if (registrationToDate.HasValue)
+                {
+                    var to = registrationToDate.Value.Date;
+                    query = query.Where(e => e.CreatedAt.Date <= to);
+                }
+
+                if (reportToInsurerFromDate.HasValue)
+                {
+                    var from = reportToInsurerFromDate.Value.Date;
+                    query = query.Where(e => e.ReportDateToInsurer.HasValue && e.ReportDateToInsurer.Value.Date >= from);
+                }
+
+                if (reportToInsurerToDate.HasValue)
+                {
+                    var to = reportToInsurerToDate.Value.Date;
+                    query = query.Where(e => e.ReportDateToInsurer.HasValue && e.ReportDateToInsurer.Value.Date <= to);
                 }
 
                 if (fromDate.HasValue)

--- a/components/handler-dropdown.tsx
+++ b/components/handler-dropdown.tsx
@@ -22,6 +22,7 @@ interface HandlerDropdownProps {
   selectedHandlerId?: string
   onHandlerSelected?: (event: HandlerSelectionEvent) => void
   className?: string
+  showDetails?: boolean
 }
 
 interface DropdownPosition {
@@ -34,6 +35,7 @@ export default function HandlerDropdown({
   selectedHandlerId,
   onHandlerSelected,
   className = "",
+  showDetails = true,
 }: HandlerDropdownProps) {
 
 
@@ -258,7 +260,7 @@ export default function HandlerDropdown({
       {renderDropdownPortal()}
 
       {/* Szczegóły (opcjonalne) */}
-      {selectedHandler && (
+      {showDetails && selectedHandler && (
         <Card className="mt-6 border-gray-200 shadow-sm">
           <CardContent className="p-6">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">

--- a/components/mobile/claims-list.tsx
+++ b/components/mobile/claims-list.tsx
@@ -14,6 +14,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select"
+import HandlerDropdown from "@/components/handler-dropdown"
 
 import {
   Search,
@@ -73,11 +74,16 @@ export function ClaimsListMobile({
     { id: number; code: string; name: string; claimObjectTypeId?: number }[]
   >([])
   const [filterRegistration, setFilterRegistration] = useState("")
-  const [filterHandler, setFilterHandler] = useState("")
+  const [filterHandlerId, setFilterHandlerId] = useState("")
   const [substituteOptions, setSubstituteOptions] = useState<{ id: string; name: string }[]>([])
   const [selectedSubstituteId, setSelectedSubstituteId] = useState("")
+  type DateFilterType =
+    | "reportDate"
+    | "damageDate"
+    | "registrationDate"
+    | "insurerReportDate"
   const [dateFilters, setDateFilters] = useState<
-    { type: "reportDate" | "damageDate"; from: string; to: string }
+    { type: DateFilterType; from: string; to: string }[]
   >([])
   const [showFilters, setShowFilters] = useState(false)
   const [showMyClaims, setShowMyClaims] = useState(false)
@@ -189,6 +195,12 @@ export function ClaimsListMobile({
       try {
         const reportFilter = dateFilters.find((f) => f.type === "reportDate")
         const damageFilter = dateFilters.find((f) => f.type === "damageDate")
+        const registrationFilter = dateFilters.find(
+          (f) => f.type === "registrationDate",
+        )
+        const insurerReportFilter = dateFilters.find(
+          (f) => f.type === "insurerReportDate",
+        )
         await fetchClaims(
           {
             page,
@@ -197,11 +209,12 @@ export function ClaimsListMobile({
             status: filterStatus !== "all" ? filterStatus : undefined,
             riskType: filterRisk !== "all" ? filterRisk : undefined,
             brand: filterRegistration || undefined,
-            handler: filterHandler || undefined,
             caseHandlerId: showMyClaims
               ? user?.caseHandlerId
               : selectedSubstituteId
               ? parseInt(selectedSubstituteId, 10)
+              : filterHandlerId
+              ? parseInt(filterHandlerId, 10)
               : undefined,
             registeredById:
               showMyClaims && !user?.caseHandlerId ? user?.id : undefined,
@@ -212,6 +225,10 @@ export function ClaimsListMobile({
             reportToDate: reportFilter?.to || undefined,
             damageFromDate: damageFilter?.from || undefined,
             damageToDate: damageFilter?.to || undefined,
+            registrationFromDate: registrationFilter?.from || undefined,
+            registrationToDate: registrationFilter?.to || undefined,
+            reportToInsurerFromDate: insurerReportFilter?.from || undefined,
+            reportToInsurerToDate: insurerReportFilter?.to || undefined,
           },
           { append: page > 1 },
         )
@@ -233,7 +250,7 @@ export function ClaimsListMobile({
     filterStatus,
     filterRisk,
     filterRegistration,
-    filterHandler,
+    filterHandlerId,
     selectedSubstituteId,
     showMyClaims,
     user?.caseHandlerId,
@@ -355,6 +372,12 @@ export function ClaimsListMobile({
       setPage(1)
       const reportFilter = dateFilters.find((f) => f.type === "reportDate")
       const damageFilter = dateFilters.find((f) => f.type === "damageDate")
+      const registrationFilter = dateFilters.find(
+        (f) => f.type === "registrationDate",
+      )
+      const insurerReportFilter = dateFilters.find(
+        (f) => f.type === "insurerReportDate",
+      )
       await fetchClaims(
         {
           page: 1,
@@ -363,11 +386,12 @@ export function ClaimsListMobile({
           status: filterStatus !== "all" ? filterStatus : undefined,
           riskType: filterRisk !== "all" ? filterRisk : undefined,
           brand: filterRegistration || undefined,
-          handler: filterHandler || undefined,
           caseHandlerId: showMyClaims
             ? user?.caseHandlerId
             : selectedSubstituteId
             ? parseInt(selectedSubstituteId, 10)
+            : filterHandlerId
+            ? parseInt(filterHandlerId, 10)
             : undefined,
           registeredById:
             showMyClaims && !user?.caseHandlerId ? user?.id : undefined,
@@ -378,6 +402,10 @@ export function ClaimsListMobile({
           reportToDate: reportFilter?.to || undefined,
           damageFromDate: damageFilter?.from || undefined,
           damageToDate: damageFilter?.to || undefined,
+          registrationFromDate: registrationFilter?.from || undefined,
+          registrationToDate: registrationFilter?.to || undefined,
+          reportToInsurerFromDate: insurerReportFilter?.from || undefined,
+          reportToInsurerToDate: insurerReportFilter?.to || undefined,
         },
         { append: false },
       )
@@ -586,19 +614,24 @@ export function ClaimsListMobile({
                 onChange={(e) => setFilterRegistration(e.target.value)}
                 className="h-9 text-sm"
               />
-              <Input
-                placeholder="Filtruj po opiekunie..."
-                value={filterHandler}
-                onChange={(e) => setFilterHandler(e.target.value)}
-                className="h-9 text-sm"
-              />
+              <div className="w-48">
+                <HandlerDropdown
+                  selectedHandlerId={filterHandlerId}
+                  onHandlerSelected={(e) => {
+                    setFilterHandlerId(e.handlerId)
+                    setPage(1)
+                  }}
+                  showDetails={false}
+                  className="h-9"
+                />
+              </div>
               <Select
                 value=""
                 onValueChange={(value) => {
                   if (!dateFilters.find((f) => f.type === value)) {
                     setDateFilters((prev) => [
                       ...prev,
-                      { type: value as "reportDate" | "damageDate", from: "", to: "" },
+                      { type: value as DateFilterType, from: "", to: "" },
                     ])
                   }
                 }}
@@ -609,13 +642,21 @@ export function ClaimsListMobile({
                 <SelectContent>
                   <SelectItem value="reportDate">Data zgłoszenia</SelectItem>
                   <SelectItem value="damageDate">Data szkody</SelectItem>
+                  <SelectItem value="registrationDate">Data rejestracji</SelectItem>
+                  <SelectItem value="insurerReportDate">Data zgłoszenia do TU</SelectItem>
                 </SelectContent>
               </Select>
             </div>
             {dateFilters.map((f) => (
               <div key={f.type} className="flex items-center gap-2 flex-wrap">
                 <span className="text-sm w-32">
-                  {f.type === "reportDate" ? "Data zgłoszenia" : "Data szkody"}
+                  {f.type === "reportDate"
+                    ? "Data zgłoszenia"
+                    : f.type === "damageDate"
+                    ? "Data szkody"
+                    : f.type === "registrationDate"
+                    ? "Data rejestracji"
+                    : "Data zgłoszenia do TU"}
                 </span>
                 <Input
                   type="date"

--- a/mobile/components/ActiveClaims.tsx
+++ b/mobile/components/ActiveClaims.tsx
@@ -3,7 +3,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
 import { Input } from "./ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
 import { ArrowLeft, Car, Home, Truck, Search, Eye, Bell } from "lucide-react";
 import { useNotifications } from "../hooks/useNotifications";
 
@@ -45,8 +50,8 @@ interface ActiveClaimsProps {
 export function ActiveClaims({ onNavigate }: ActiveClaimsProps) {
   const { unreadCount } = useNotifications();
   const [searchTerm, setSearchTerm] = useState("");
-  const [filterType, setFilterType] = useState("all");
-  const [filterStatus, setFilterStatus] = useState("all");
+  const [filterTypes, setFilterTypes] = useState<string[]>([]);
+  const [filterStatuses, setFilterStatuses] = useState<string[]>([]);
   const [claims, setClaims] = useState<Claim[]>([]);
 
   useEffect(() => {
@@ -104,11 +109,23 @@ export function ActiveClaims({ onNavigate }: ActiveClaimsProps) {
     return '#059669';
   };
 
+  const toggleType = (value: string) => {
+    setFilterTypes((prev) =>
+      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]
+    );
+  };
+
+  const toggleStatus = (value: string) => {
+    setFilterStatuses((prev) =>
+      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]
+    );
+  };
+
   const filteredClaims = claims.filter(claim => {
     const matchesSearch = claim.id.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          claim.description.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesType = filterType === 'all' || claim.type === filterType;
-    const matchesStatus = filterStatus === 'all' || claim.status === filterStatus;
+    const matchesType = filterTypes.length === 0 || filterTypes.includes(claim.type);
+    const matchesStatus = filterStatuses.length === 0 || filterStatuses.includes(claim.status);
     
     return matchesSearch && matchesType && matchesStatus;
   });
@@ -162,29 +179,67 @@ export function ActiveClaims({ onNavigate }: ActiveClaimsProps) {
             </div>
             
             <div className="flex gap-3">
-              <Select value={filterType} onValueChange={setFilterType}>
-                <SelectTrigger className="flex-1 h-12 border-[#e2e8f0] bg-[#f8fafc] focus:bg-white focus:border-[#1a3a6c]">
-                  <SelectValue placeholder="Typ szkody" />
-                </SelectTrigger>
-                <SelectContent className="border-[#e2e8f0]">
-                  <SelectItem value="all">Wszystkie typy</SelectItem>
-                  <SelectItem value="komunikacyjna">Komunikacyjna</SelectItem>
-                  <SelectItem value="mienie">Mienie</SelectItem>
-                  <SelectItem value="transport">Transport</SelectItem>
-                </SelectContent>
-              </Select>
-              
-              <Select value={filterStatus} onValueChange={setFilterStatus}>
-                <SelectTrigger className="flex-1 h-12 border-[#e2e8f0] bg-[#f8fafc] focus:bg-white focus:border-[#1a3a6c]">
-                  <SelectValue placeholder="Status" />
-                </SelectTrigger>
-                <SelectContent className="border-[#e2e8f0]">
-                  <SelectItem value="all">Wszystkie statusy</SelectItem>
-                  <SelectItem value="oczekuje">Oczekuje</SelectItem>
-                  <SelectItem value="w trakcie">W trakcie</SelectItem>
-                  <SelectItem value="zakończona">Zakończona</SelectItem>
-                </SelectContent>
-              </Select>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="flex-1 h-12 border-[#e2e8f0] bg-[#f8fafc] justify-between"
+                  >
+                    {filterTypes.length ? filterTypes.join(", ") : "Typ szkody"}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="border-[#e2e8f0]">
+                  <DropdownMenuCheckboxItem
+                    checked={filterTypes.includes("komunikacyjna")}
+                    onCheckedChange={() => toggleType("komunikacyjna")}
+                  >
+                    Komunikacyjna
+                  </DropdownMenuCheckboxItem>
+                  <DropdownMenuCheckboxItem
+                    checked={filterTypes.includes("mienie")}
+                    onCheckedChange={() => toggleType("mienie")}
+                  >
+                    Mienie
+                  </DropdownMenuCheckboxItem>
+                  <DropdownMenuCheckboxItem
+                    checked={filterTypes.includes("transport")}
+                    onCheckedChange={() => toggleType("transport")}
+                  >
+                    Transport
+                  </DropdownMenuCheckboxItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="flex-1 h-12 border-[#e2e8f0] bg-[#f8fafc] justify-between"
+                  >
+                    {filterStatuses.length ? filterStatuses.join(", ") : "Status"}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="border-[#e2e8f0]">
+                  <DropdownMenuCheckboxItem
+                    checked={filterStatuses.includes("oczekuje")}
+                    onCheckedChange={() => toggleStatus("oczekuje")}
+                  >
+                    Oczekuje
+                  </DropdownMenuCheckboxItem>
+                  <DropdownMenuCheckboxItem
+                    checked={filterStatuses.includes("w trakcie")}
+                    onCheckedChange={() => toggleStatus("w trakcie")}
+                  >
+                    W trakcie
+                  </DropdownMenuCheckboxItem>
+                  <DropdownMenuCheckboxItem
+                    checked={filterStatuses.includes("zakończona")}
+                    onCheckedChange={() => toggleStatus("zakończona")}
+                  >
+                    Zakończona
+                  </DropdownMenuCheckboxItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- allow filtering claims by selected handler using case handler dropdown
- add date-range filters for registration and insurer notification
- support new query params in backend and reusable handler dropdown without details

## Testing
- `pnpm lint` *(fails: ESLint must be installed: pnpm install --save-dev eslint)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b55da09ba8832c93776d19a224214b