### PR TITLE
fix document count in sidebar

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -339,8 +339,7 @@ export default function ClaimPage() {
                 (mode === "view"
                   ? claim?.notes?.length
                   : claimFormData.notes?.length) || 0,
-              dokumenty:
-                (mode === "view" ? claim?.documents?.length : uploadedFiles.length) || 0,
+              dokumenty: uploadedFiles.length,
 
             }}
           />

--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -512,7 +512,7 @@ export default function NewClaimPage() {
             regres: claimFormData.recourses?.length || 0,
             ugody: claimFormData.settlements?.length || 0,
             notatki: claimFormData.notes?.length || 0,
-            dokumenty: uploadedFiles.length + pendingFiles.length,
+            dokumenty: uploadedFiles.length,
           }}
 
         />


### PR DESCRIPTION
## Summary
- prevent double counting pending files in new claim document sidebar
- rely on uploadedFiles for document count in claim form sidebar

## Testing
- `pnpm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e5bd3010832cbdf8b45483b437b9