### PR TITLE
Prevent duplicate claim initialization

### DIFF
--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -69,6 +69,7 @@ export default function NewClaimPage() {
   const [activeClaimSection, setActiveClaimSection] = useState("teczka-szkodowa")
   const [isSaving, setIsSaving] = useState(false)
   const contentRef = useRef<HTMLDivElement>(null)
+  const hasInitialized = useRef(false)
   
   // Repair schedules and details state
   const [repairSchedules, setRepairSchedules] = useState<RepairSchedule[]>([])
@@ -110,6 +111,9 @@ export default function NewClaimPage() {
 
 
   useEffect(() => {
+    if (hasInitialized.current) return
+    hasInitialized.current = true
+
     const init = async () => {
       const id = await initializeClaim()
       if (id) {


### PR DESCRIPTION
## Summary
- avoid double API call to `/claims/initialize` by guarding effect with `hasInitialized` ref

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e330c41c832ca9285d3778dadbcd