### PR TITLE
feat(mobile): show decisions settlements appeals in claim view

### DIFF
--- a/mobile/components/ClaimDetails.tsx
+++ b/mobile/components/ClaimDetails.tsx
@@ -9,10 +9,8 @@ import {
   Calendar,
   Car,
   Clock,
-  DollarSign,
   FileText,
   CheckCircle,
-  Handshake,
   Home,
   Mail,
   MapPin,
@@ -21,6 +19,12 @@ import {
   User,
 } from "lucide-react";
 import { Claim } from "./ActiveClaims";
+import {
+  DecisionsSummary,
+  SettlementsSummary,
+  AppealsSummary,
+  NotesSummary,
+} from "./ClaimRelatedSectionsSummary";
 
 interface ClaimDetailsProps {
   onNavigate: (section: string, claim?: Claim) => void;
@@ -132,12 +136,52 @@ export function ClaimDetails({ onNavigate, claim }: ClaimDetailsProps) {
         completed: false
       }
     ],
-    settlement: {
-      number: "UG-2024-001",
-      decision: "Zaakceptowana",
-      date: "2024-09-02",
-      amount: "7,500 PLN"
-    }
+    decisions: [
+      {
+        id: "dec1",
+        decisionDate: "2024-09-02",
+        status: "Zaakceptowana",
+        amount: 7500,
+        currency: "PLN",
+        documents: [
+          {
+            id: "dec-doc1",
+            fileName: "decyzja.pdf",
+            downloadUrl: "/docs/decyzja.pdf",
+          },
+        ],
+      },
+    ],
+    settlements: [
+      {
+        id: "set1",
+        settlementNumber: "UG-2024-001",
+        status: "Zaakceptowana",
+        settlementDate: "2024-09-02",
+        settlementAmount: 7500,
+        currency: "PLN",
+        documents: [],
+      },
+    ],
+    appeals: [
+      {
+        id: "app1",
+        appealNumber: "OD-2024-001",
+        submissionDate: "2024-09-10",
+        status: "W toku",
+        documents: [],
+      },
+    ],
+    notes: [
+      {
+        id: "note1",
+        type: "note",
+        title: "Kontrola dokumentów",
+        description: "Sprawdzić kompletność dokumentów.",
+        user: "Anna Nowak",
+        createdAt: "2024-09-01",
+      },
+    ],
   };
 
   const [documents, setDocuments] = useState(claimData.documents);
@@ -167,17 +211,6 @@ export function ClaimDetails({ onNavigate, claim }: ClaimDetailsProps) {
       case 'oczekuje': return 'bg-[#fef3c7] text-[#d97706] border-[#d97706]/20';
       case 'zakończona': return 'bg-[#d1fae5] text-[#059669] border-[#059669]/20';
       default: return 'bg-[#f1f5f9] text-[#64748b] border-[#e2e8f0]';
-    }
-  };
-
-  const getDecisionColor = (decision: string) => {
-    switch (decision) {
-      case 'Zaakceptowana':
-        return 'bg-[#d1fae5] text-[#059669] border-[#059669]/20';
-      case 'Odrzucona':
-        return 'bg-[#fee2e2] text-[#dc2626] border-[#dc2626]/20';
-      default:
-        return 'bg-[#e1e7ef] text-[#1a3a6c] border-[#1a3a6c]/20';
     }
   };
 
@@ -344,40 +377,10 @@ export function ClaimDetails({ onNavigate, claim }: ClaimDetailsProps) {
           </CardContent>
         </Card>
 
-        {/* Decyzja ugody */}
-        {claimData.settlement && (
-          <Card className="shadow-sm border-[#e2e8f0] bg-white">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-[#1e293b] flex items-center gap-2">
-                <Handshake className="w-5 h-5 text-[#1a3a6c]" />
-                Decyzja ugody
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <div className="flex items-center gap-2 text-sm text-[#64748b]">
-                <FileText className="w-4 h-4" />
-                <span>Numer ugody:</span>
-                <span className="font-medium text-[#1e293b]">{claimData.settlement.number}</span>
-              </div>
-              <div className="flex items-center gap-2 text-sm text-[#64748b]">
-                <Calendar className="w-4 h-4" />
-                <span>Data decyzji:</span>
-                <span className="font-medium text-[#1e293b]">{claimData.settlement.date}</span>
-              </div>
-              <div className="flex items-center gap-2 text-sm text-[#64748b]">
-                <DollarSign className="w-4 h-4" />
-                <span>Kwota ugody:</span>
-                <span className="font-medium text-[#1e293b]">{claimData.settlement.amount}</span>
-              </div>
-              <div className="flex items-center gap-2 text-sm text-[#64748b]">
-                <span>Status:</span>
-                <Badge className={`${getDecisionColor(claimData.settlement.decision)} font-medium px-2 py-1`}>
-                  {claimData.settlement.decision}
-                </Badge>
-              </div>
-            </CardContent>
-          </Card>
-        )}
+        <DecisionsSummary decisions={claimData.decisions} />
+        <SettlementsSummary settlements={claimData.settlements} />
+        <AppealsSummary appeals={claimData.appeals} />
+        <NotesSummary notes={claimData.notes} />
 
         {/* Dane kontaktowe */}
         <Card className="shadow-sm border-[#e2e8f0] bg-white">

--- a/mobile/components/ClaimRelatedSectionsSummary.tsx
+++ b/mobile/components/ClaimRelatedSectionsSummary.tsx
@@ -1,0 +1,251 @@
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Gavel, Handshake, Shield, MessageSquare } from "lucide-react";
+import type { Decision, Settlement, Appeal, Note } from "../../types";
+
+interface DecisionsSummaryProps {
+  decisions?: Decision[];
+}
+
+export function DecisionsSummary({ decisions }: DecisionsSummaryProps) {
+  if (!decisions || decisions.length === 0) return null;
+  return (
+    <Card className="shadow-sm border-[#e2e8f0] bg-white">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-[#1e293b] flex items-center gap-2">
+          <Gavel className="w-5 h-5 text-[#1a3a6c]" />
+          Decyzje
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {decisions.map((decision, idx) => (
+          <div key={decision.id || idx} className="p-3 bg-[#f8fafc] rounded-lg space-y-2">
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <div>
+                <span className="text-xs text-[#64748b] block">Data decyzji</span>
+                <span className="font-medium text-[#1e293b]">{decision.decisionDate || '-'}</span>
+              </div>
+              {decision.status && (
+                <div>
+                  <span className="text-xs text-[#64748b] block">Status</span>
+                  <span className="font-medium text-[#1e293b]">{decision.status}</span>
+                </div>
+              )}
+              {typeof decision.amount !== 'undefined' && (
+                <div>
+                  <span className="text-xs text-[#64748b] block">Kwota</span>
+                  <span className="font-medium text-[#1e293b]">
+                    {decision.amount} {decision.currency || ''}
+                  </span>
+                </div>
+              )}
+            </div>
+            {decision.documents && decision.documents.length > 0 && (
+              <div className="text-sm">
+                <span className="text-xs text-[#64748b] block mb-1">Dokumenty</span>
+                <ul className="list-disc pl-5 space-y-1">
+                  {decision.documents.map((doc) => (
+                    <li key={doc.id}>
+                      <a
+                        href={doc.downloadUrl ?? doc.filePath ?? '#'}
+                        className="text-[#1a3a6c] underline"
+                      >
+                        {doc.fileName || doc.originalFileName || 'Dokument'}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface SettlementsSummaryProps {
+  settlements?: Settlement[];
+}
+
+export function SettlementsSummary({ settlements }: SettlementsSummaryProps) {
+  if (!settlements || settlements.length === 0) return null;
+  return (
+    <Card className="shadow-sm border-[#e2e8f0] bg-white">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-[#1e293b] flex items-center gap-2">
+          <Handshake className="w-5 h-5 text-[#1a3a6c]" />
+          Ugody
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {settlements.map((s, idx) => (
+          <div key={s.id || idx} className="p-3 bg-[#f8fafc] rounded-lg space-y-2">
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              {s.settlementNumber && (
+                <div>
+                  <span className="text-xs text-[#64748b] block">Numer</span>
+                  <span className="font-medium text-[#1e293b]">{s.settlementNumber}</span>
+                </div>
+              )}
+              {s.status && (
+                <div>
+                  <span className="text-xs text-[#64748b] block">Status</span>
+                  <span className="font-medium text-[#1e293b]">{s.status}</span>
+                </div>
+              )}
+              {s.settlementDate && (
+                <div>
+                  <span className="text-xs text-[#64748b] block">Data</span>
+                  <span className="font-medium text-[#1e293b]">{s.settlementDate}</span>
+                </div>
+              )}
+              {(typeof s.settlementAmount !== 'undefined' || typeof s.amount !== 'undefined') && (
+                <div>
+                  <span className="text-xs text-[#64748b] block">Kwota</span>
+                  <span className="font-medium text-[#1e293b]">
+                    {(s.settlementAmount ?? s.amount) ?? ''} {s.currency || ''}
+                  </span>
+                </div>
+              )}
+            </div>
+            {s.documents && s.documents.length > 0 && (
+              <div className="text-sm">
+                <span className="text-xs text-[#64748b] block mb-1">Dokumenty</span>
+                <ul className="list-disc pl-5 space-y-1">
+                  {s.documents.map((doc) => (
+                    <li key={doc.id}>
+                      <a
+                        href={doc.downloadUrl ?? doc.filePath ?? '#'}
+                        className="text-[#1a3a6c] underline"
+                      >
+                        {doc.fileName || doc.originalFileName || 'Dokument'}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface AppealsSummaryProps {
+  appeals?: Appeal[];
+}
+
+export function AppealsSummary({ appeals }: AppealsSummaryProps) {
+  if (!appeals || appeals.length === 0) return null;
+  return (
+    <Card className="shadow-sm border-[#e2e8f0] bg-white">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-[#1e293b] flex items-center gap-2">
+          <Shield className="w-5 h-5 text-[#1a3a6c]" />
+          Odwołania
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {appeals.map((a, idx) => (
+          <div key={a.id || idx} className="p-3 bg-[#f8fafc] rounded-lg space-y-2">
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              {a.appealNumber && (
+                <div>
+                  <span className="text-xs text-[#64748b] block">Numer</span>
+                  <span className="font-medium text-[#1e293b]">{a.appealNumber}</span>
+                </div>
+              )}
+              {a.status && (
+                <div>
+                  <span className="text-xs text-[#64748b] block">Status</span>
+                  <span className="font-medium text-[#1e293b]">{a.status}</span>
+                </div>
+              )}
+              {a.submissionDate && (
+                <div>
+                  <span className="text-xs text-[#64748b] block">Data złożenia</span>
+                  <span className="font-medium text-[#1e293b]">{a.submissionDate}</span>
+                </div>
+              )}
+              {a.decisionDate && (
+                <div>
+                  <span className="text-xs text-[#64748b] block">Data decyzji</span>
+                  <span className="font-medium text-[#1e293b]">{a.decisionDate}</span>
+                </div>
+              )}
+              {typeof a.appealAmount !== 'undefined' && (
+                <div>
+                  <span className="text-xs text-[#64748b] block">Kwota</span>
+                  <span className="font-medium text-[#1e293b]">{a.appealAmount}</span>
+                </div>
+              )}
+            </div>
+            {a.documents && a.documents.length > 0 && (
+              <div className="text-sm">
+                <span className="text-xs text-[#64748b] block mb-1">Dokumenty</span>
+                <ul className="list-disc pl-5 space-y-1">
+                  {a.documents.map((doc) => (
+                    <li key={doc.id}>
+                      <a
+                        href={doc.downloadUrl ?? doc.filePath ?? '#'}
+                        className="text-[#1a3a6c] underline"
+                      >
+                        {doc.fileName || doc.originalFileName || 'Dokument'}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface NotesSummaryProps {
+  notes?: Note[];
+}
+
+export function NotesSummary({ notes }: NotesSummaryProps) {
+  if (!notes || notes.length === 0) return null;
+  return (
+    <Card className="shadow-sm border-[#e2e8f0] bg-white">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-[#1e293b] flex items-center gap-2">
+          <MessageSquare className="w-5 h-5 text-[#1a3a6c]" />
+          Notatki
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {notes.map((note) => (
+          <div key={note.id} className="border-l-4 border-blue-500 pl-4 py-2 bg-[#f8fafc] rounded-r-lg">
+            {note.title && (
+              <h4 className="font-medium text-[#1e293b] text-sm">{note.title}</h4>
+            )}
+            <p className="text-sm text-[#64748b]">{note.description}</p>
+            <div className="flex items-center space-x-4 text-xs text-[#64748b] mt-2">
+              {note.user && <span>{note.user}</span>}
+              {note.createdAt && (
+                <span>{new Date(note.createdAt).toLocaleDateString('pl-PL')}</span>
+              )}
+              {note.dueDate && (
+                <span>Termin: {new Date(note.dueDate).toLocaleDateString('pl-PL')}</span>
+              )}
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default {
+  DecisionsSummary,
+  SettlementsSummary,
+  AppealsSummary,
+  NotesSummary,
+};
+


### PR DESCRIPTION
## Summary
- add mobile summary components for decisions, settlements, appeals and notes
- surface these sections on the mobile claim details screen
- remove non-mobile claim summary components

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint must be installed: pnpm install --save-dev eslint)*
- `pnpm add -D eslint` *(fails: ERR_PNPM_FETCH_403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e3ce76e4832c95c32821dbbf7950