### PR TITLE
feat: persist empty document categories

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -1155,6 +1155,7 @@ namespace AutomotiveClaimsApi.Controllers
             entity.StatementWithPerpetrator = dto.StatementWithPerpetrator;
             entity.PerpetratorFined = dto.PerpetratorFined;
             entity.ServicesCalled = dto.ServicesCalled;
+            entity.DocumentCategories = dto.DocumentCategories;
             entity.PoliceUnitDetails = dto.PoliceUnitDetails;
             entity.PropertyDamageSubject = dto.PropertyDamageSubject;
             entity.DamageListing = dto.DamageListing;
@@ -1975,6 +1976,7 @@ namespace AutomotiveClaimsApi.Controllers
             StatementWithPerpetrator = e.StatementWithPerpetrator ?? false,
             PerpetratorFined = e.PerpetratorFined ?? false,
             ServicesCalled = e.ServicesCalled?.Split(',', StringSplitOptions.RemoveEmptyEntries),
+            DocumentCategories = e.DocumentCategories?.Split(',', StringSplitOptions.RemoveEmptyEntries),
             PoliceUnitDetails = e.PoliceUnitDetails,
             PropertyDamageSubject = e.PropertyDamageSubject,
             DamageListing = e.DamageListing,

--- a/backend/DTOs/EventDto.cs
+++ b/backend/DTOs/EventDto.cs
@@ -53,6 +53,7 @@ namespace AutomotiveClaimsApi.DTOs
         public bool StatementWithPerpetrator { get; set; }
         public bool PerpetratorFined { get; set; }
         public string[]? ServicesCalled { get; set; }
+        public string[]? DocumentCategories { get; set; }
         public string? PoliceUnitDetails { get; set; }
         public string? PropertyDamageSubject { get; set; }
         public string? DamageListing { get; set; }

--- a/backend/DTOs/EventUpsertDto.cs
+++ b/backend/DTOs/EventUpsertDto.cs
@@ -133,6 +133,9 @@ namespace AutomotiveClaimsApi.DTOs
         [StringLength(500)]
         public string? ServicesCalled { get; set; }
 
+        [StringLength(2000)]
+        public string? DocumentCategories { get; set; }
+
         [StringLength(500)]
         public string? PoliceUnitDetails { get; set; }
 

--- a/backend/Migrations/20250601000001_AddDocumentCategoriesToEvents.cs
+++ b/backend/Migrations/20250601000001_AddDocumentCategoriesToEvents.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AutomotiveClaimsApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDocumentCategoriesToEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DocumentCategories",
+                table: "Events",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DocumentCategories",
+                table: "Events");
+        }
+    }
+}

--- a/backend/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/backend/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1054,6 +1054,9 @@ namespace AutomotiveClaimsApi.Migrations
                         .HasMaxLength(500)
                         .HasColumnType("character varying(500)");
 
+                    b.Property<string>("DocumentCategories")
+                        .HasColumnType("text");
+
                     b.Property<string>("SpartaNumber")
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)");

--- a/backend/Models/Event.cs
+++ b/backend/Models/Event.cs
@@ -138,6 +138,9 @@ namespace AutomotiveClaimsApi.Models
         [MaxLength(500)]
         public string? ServicesCalled { get; set; }
 
+        [Column(TypeName = "text")]
+        public string? DocumentCategories { get; set; }
+
         [MaxLength(500)]
         public string? PoliceUnitDetails { get; set; }
 

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -71,6 +71,7 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
     inspectionContactEmail,
     handlerId,
     caseHandlerId,
+    documentCategories,
     ...rest
   } = apiClaim
 
@@ -110,6 +111,9 @@ export const transformApiClaimToFrontend = (apiClaim: ClaimDto): Claim => {
     servicesCalled: Array.isArray(servicesCalled)
       ? servicesCalled
       : (servicesCalled?.split(",").filter(Boolean) ?? []),
+    documentCategories: Array.isArray(documentCategories)
+      ? documentCategories
+      : (documentCategories?.split(",").filter(Boolean) ?? []),
 
     damages: damages?.map((d: any) => ({
       id: d.id?.toString(),
@@ -199,6 +203,7 @@ export const transformFrontendClaimToApiPayload = (
     perpetrator,
     servicesCalled,
     documents,
+    documentCategories,
     insuranceCompanyId,
     leasingCompanyId,
     caseHandlerId,
@@ -313,6 +318,7 @@ export const transformFrontendClaimToApiPayload = (
       "eventTime",
     ),
     servicesCalled: servicesCalled?.join(","),
+    documentCategories: documentCategories?.join(","),
     ...(transportDamage
       ? {
           cargoDescription: transportDamage.cargoDescription,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -77,8 +77,13 @@ export interface EventDto extends EventListItemDto {
   /**
    * Comma-separated list of services that were called
    * e.g. "policja,pogotowie,straz".
-   */
+  */
   servicesCalled?: string
+
+  /**
+   * List of document category names to persist even when no files are present
+   */
+  documentCategories?: string[]
 
   propertyDamageSubject?: string
   damageListing?: string
@@ -200,8 +205,13 @@ export interface EventUpsertDto {
   /**
    * Comma-separated list of services that were called
    * e.g. "policja,pogotowie,straz".
-   */
+  */
   servicesCalled?: string
+
+  /**
+   * Comma-separated list of document category names to keep
+   */
+  documentCategories?: string
 
   propertyDamageSubject?: string
   damageListing?: string

--- a/types/index.ts
+++ b/types/index.ts
@@ -147,6 +147,8 @@ export interface Claim
   handlerPhone?: string
   documents?: UploadedFile[]
   pendingFiles?: UploadedFile[]
+  /** Names of document categories that should be displayed even if empty */
+  documentCategories?: string[]
   documentsSectionProps?: DocumentsSectionProps
   subcontractor?: SubcontractorInfo
 }


### PR DESCRIPTION
## Summary
- persist selected document categories in claims
- expose document category list in API and data models
- add database migration for document categories

## Testing
- `pnpm test`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f4781e34832c9016144a1d168fbb