### PR TITLE
Add authentication to mobile app

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Login } from "./components/Login";
 import { Dashboard } from "./components/Dashboard";
 import { ReportClaim } from "./components/ReportClaim";
 import { ActiveClaims, Claim } from "./components/ActiveClaims";
@@ -8,8 +9,10 @@ import { NotificationCenter } from "./components/NotificationCenter";
 import { NotificationToast } from "./components/NotificationToast";
 import { BottomNavigation } from "./components/BottomNavigation";
 import { Toaster } from "./components/ui/sonner";
+import { useAuth } from "../hooks/use-auth";
 
 export default function App() {
+  const { isAuthenticated, isLoading } = useAuth();
   const [activeSection, setActiveSection] = useState("dashboard");
   const [selectedClaim, setSelectedClaim] = useState<Claim | null>(null);
 
@@ -37,27 +40,25 @@ export default function App() {
     }
   };
 
+  if (isLoading) {
+    return <div className="p-4">Ładowanie...</div>;
+  }
+
+  if (!isAuthenticated) {
+    return <Login />;
+  }
+
   return (
     <div className="min-h-screen bg-background">
       {/* Główna zawartość */}
-      <div className="pb-16">
-        {renderCurrentSection()}
-      </div>
-      
+      <div className="pb-16">{renderCurrentSection()}</div>
+
       {/* Dolna nawigacja */}
-      <BottomNavigation 
-        activeSection={activeSection}
-        onNavigate={handleNavigate}
-      />
-      
+      <BottomNavigation activeSection={activeSection} onNavigate={handleNavigate} />
+
       {/* Toast notifications */}
-      <Toaster 
-        position="top-center"
-        expand={false}
-        richColors
-        closeButton
-      />
-      
+      <Toaster position="top-center" expand={false} richColors closeButton />
+
       {/* Komponent do zarządzania automatycznymi powiadomieniami */}
       <NotificationToast />
     </div>

--- a/mobile/components/ActiveClaims.tsx
+++ b/mobile/components/ActiveClaims.tsx
@@ -11,6 +11,7 @@ import {
 } from "./ui/dropdown-menu";
 import { ArrowLeft, Car, Home, Truck, Search, Eye, Bell, X } from "lucide-react";
 import { useNotifications } from "../hooks/useNotifications";
+import { authFetch } from "../../lib/auth-fetch";
 
 interface MobileEventDto {
   id: string;
@@ -63,8 +64,7 @@ export function ActiveClaims({ onNavigate }: ActiveClaimsProps) {
   useEffect(() => {
     const fetchClaims = async () => {
       try {
-        const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api";
-        const res = await fetch(`${apiUrl}/mobile/events`);
+        const res = await authFetch('/mobile/events');
         if (!res.ok) throw new Error("Failed to fetch events");
         const data: MobileEventDto[] = await res.json();
         const typeLabelMap: Record<number, string> = {

--- a/mobile/components/Login.tsx
+++ b/mobile/components/Login.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+import { Alert, AlertDescription } from "./ui/alert";
+import { useAuth } from "../../hooks/use-auth";
+
+export function Login() {
+  const { login } = useAuth();
+  const [credentials, setCredentials] = useState({ username: "", password: "" });
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setSubmitting(true);
+    try {
+      await login(credentials.username, credentials.password);
+    } catch {
+      setError("Nieprawidłowa nazwa użytkownika lub hasło");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#f5f7fa] p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle className="text-center">Logowanie</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="username">Nazwa użytkownika</Label>
+              <Input
+                id="username"
+                value={credentials.username}
+                onChange={(e) =>
+                  setCredentials({ ...credentials, username: e.target.value })
+                }
+                autoComplete="username"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Hasło</Label>
+              <Input
+                id="password"
+                type="password"
+                value={credentials.password}
+                onChange={(e) =>
+                  setCredentials({ ...credentials, password: e.target.value })
+                }
+                autoComplete="current-password"
+              />
+            </div>
+            <Button type="submit" className="w-full" disabled={submitting}>
+              {submitting ? "Logowanie..." : "Zaloguj się"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default Login;

--- a/mobile/components/Profile.tsx
+++ b/mobile/components/Profile.tsx
@@ -4,20 +4,22 @@ import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import { Badge } from "./ui/badge";
 import { Separator } from "./ui/separator";
 import { User, Phone, Mail, MapPin, Calendar, Settings, LogOut, Shield, List, CheckCircle } from "lucide-react";
+import { useAuth } from "../../hooks/use-auth";
 
 interface ProfileProps {
   onNavigate: (section: string) => void;
 }
 
 export function Profile({ onNavigate }: ProfileProps) {
+  const { user, logout } = useAuth();
   const mockUser = {
-    name: "Jan Kowalski",
-    email: "jan.kowalski@email.com",
+    name: user?.username || "Jan Kowalski",
+    email: user?.email || "jan.kowalski@email.com",
     phone: "+48 123 456 789",
     address: "ul. Przykładowa 15, 00-001 Warszawa",
     memberSince: "2022-03-15",
     claimsCount: 18,
-    status: "Premium"
+    status: user?.roles?.[0] || "Premium"
   };
 
   return (
@@ -129,9 +131,10 @@ export function Profile({ onNavigate }: ProfileProps) {
                 Pomoc i kontakt
               </Button>
               <Separator className="bg-[#dadce0]" />
-              <Button 
-                variant="ghost" 
+              <Button
+                variant="ghost"
                 className="w-full justify-start h-14 rounded-none text-[#ea4335] hover:bg-[#fce8e6] hover:text-[#ea4335]"
+                onClick={logout}
               >
                 <LogOut className="w-5 h-5 mr-4" />
                 Wyloguj się

--- a/mobile/components/ReportClaim.tsx
+++ b/mobile/components/ReportClaim.tsx
@@ -12,6 +12,7 @@ import { format } from "date-fns";
 import { pl } from "date-fns/locale";
 import { toast } from "sonner";
 import { useNotifications } from "../hooks/useNotifications";
+import { authFetch } from "../../lib/auth-fetch";
 
 interface ReportClaimProps {
   onNavigate: (section: string, claimId?: string) => void;
@@ -59,11 +60,9 @@ export function ReportClaim({ onNavigate }: ReportClaimProps) {
     e.preventDefault();
 
     try {
-      const apiUrl =
-        process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/api";
-      const response = await fetch(`${apiUrl}/mobile/claims`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+      const response = await authFetch('/mobile/claims', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           type: selectedType,
           date: date?.toISOString(),

--- a/mobile/hooks/useNotifications.tsx
+++ b/mobile/hooks/useNotifications.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { authFetch } from '../../lib/auth-fetch';
 
 export interface Notification {
   id: string;
@@ -27,11 +28,9 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
   const [notifications, setNotifications] = useState<Notification[]>([]);
 
   useEffect(() => {
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5200/api';
-
     const fetchNotifications = async () => {
       try {
-        const res = await fetch(`${apiUrl}/mobile/notifications`);
+        const res = await authFetch('/mobile/notifications');
         if (!res.ok) return;
         const data = await res.json();
         const parsed = data.map((n: any) => ({

--- a/mobile/main.tsx
+++ b/mobile/main.tsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./styles/globals.css";
 import { NotificationsProvider } from "./hooks/useNotifications";
+import { AuthProvider } from "../hooks/use-auth";
 
 function urlBase64ToUint8Array(base64String: string) {
   const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
@@ -67,7 +68,9 @@ if (typeof window !== "undefined") {
 }
 
 createRoot(document.getElementById("root")!).render(
-  <NotificationsProvider>
-    <App />
-  </NotificationsProvider>
+  <AuthProvider>
+    <NotificationsProvider>
+      <App />
+    </NotificationsProvider>
+  </AuthProvider>
 );


### PR DESCRIPTION
## Summary
- Integrate auth provider into mobile entry point and gate app with login screen
- Use authenticated fetch for claims, reports, and notifications
- Provide profile logout and basic login form

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fac73024832c899530de693afa23