### PR TITLE
Set claim status to 'Nowa szkoda' when handler is assigned

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -745,6 +745,7 @@ namespace AutomotiveClaimsApi.Controllers
                     _context.Entry(existing).State = EntityState.Detached;
                 }
 
+                var originalHandlerId = existing.HandlerId;
                 var originalStatus = existing.Status;
 
                 await UpsertClaimAsync(existing, eventDto);
@@ -760,6 +761,18 @@ namespace AutomotiveClaimsApi.Controllers
                 {
                     existing.Handler = currentUser.UserName;
                     existing.HandlerEmail = currentUser.Email;
+                }
+
+                if (!originalHandlerId.HasValue && existing.HandlerId.HasValue)
+                {
+                    var statusEntity = await _context.ClaimStatuses.FindAsync((int)ClaimStatusCode.New);
+                    if (statusEntity != null)
+                    {
+                        existing.ClaimStatusId = statusEntity.Id;
+                        existing.Status = statusEntity.Name;
+                        eventDto.Status = statusEntity.Name;
+                        eventDto.ClaimStatusId = statusEntity.Id;
+                    }
                 }
 
                 await _context.SaveChangesAsync();


### PR DESCRIPTION
## Summary
- update claim status to 'Nowa szkoda' when a handler is assigned during claim update
- persist new status ID and name so downstream notifications reflect the change

## Testing
- `npm test` *(fails: ERR_REQUIRE_CYCLE_MODULE)*
- `dotnet test` *(fails: command not found)*
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fd818da4832cb38e4745d8e425dd