### PR TITLE
Remove category requirement hint

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -1885,9 +1885,6 @@ export const DocumentsSection = React.forwardRef<
               <CardTitle>Wymagane dokumenty</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="mb-4 text-sm text-gray-500">
-                Dodaj kategorię, aby móc załączyć odpowiednie pliki.
-              </p>
               <Button
                 className="mb-4"
                 onClick={handleAddSelectedRequired}


### PR DESCRIPTION
## Summary
- remove message instructing users to add a category before attaching files

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint must be installed: pnpm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68b6056ff548832c9fe0c42d7c3bbbb0