### PR TITLE
Show full participant info in claim summary

### DIFF
--- a/components/claim-form/communication-claim-summary.tsx
+++ b/components/claim-form/communication-claim-summary.tsx
@@ -134,6 +134,19 @@ const getStatusIcon = (status: string) => {
   }
 }
 
+const getDriverRoleLabel = (role?: string) => {
+  switch (role) {
+    case "kierowca":
+      return "Kierowca"
+    case "wlasciciel":
+      return "Właściciel"
+    case "wspol_wlasciciel":
+      return "Współwłaściciel"
+    default:
+      return role || ""
+  }
+}
+
 const CommunicationClaimSummary = ({
   claimFormData,
   notes,
@@ -193,50 +206,77 @@ const CommunicationClaimSummary = ({
           </div>
         </div>
         <div className="p-4 space-y-3">
-          {showPersonalInfo && (
-            <>
-              <InfoCard label="Imię i nazwisko" value={participantName} />
-              <InfoCard label="Adres" value={participant.address} />
-              <InfoCard label="Miasto" value={participant.city} />
-              <InfoCard label="Kod pocztowy" value={participant.postalCode} />
-              <InfoCard label="Kraj" value={participant.country} />
-              <InfoCard label="Telefon" value={participant.phone} />
-            </>
-          )}
-          <InfoCard label="Rejestracja" value={participant.vehicleRegistration} />
-          <InfoCard label="VIN" value={participant.vehicleVin} />
-          <InfoCard label="Rodzaj pojazdu" value={participant.vehicleType} />
-          <InfoCard label="Marka" value={participant.vehicleBrand} />
-          <InfoCard label="Model" value={participant.vehicleModel} />
-          {participant.vehicleYear && (
-            <InfoCard label="Rok" value={participant.vehicleYear.toString()} />
-          )}
-          <InfoCard label="Ubezpieczyciel" value={participant.insuranceCompany} />
-          <InfoCard label="Nr polisy" value={participant.policyNumber} />
+          {showPersonalInfo &&
+            [
+              { label: "Imię i nazwisko", value: participantName },
+              { label: "Adres", value: participant.address },
+              { label: "Miasto", value: participant.city },
+              { label: "Kod pocztowy", value: participant.postalCode },
+              { label: "Kraj", value: participant.country },
+              { label: "Telefon", value: participant.phone },
+              { label: "E-mail", value: participant.email },
+            ]
+              .filter((info) => info.value)
+              .map((info) => (
+                <InfoCard key={info.label} label={info.label} value={info.value as string} />
+              ))}
+          {[
+            { label: "Rejestracja", value: participant.vehicleRegistration },
+            { label: "VIN", value: participant.vehicleVin },
+            { label: "Rodzaj pojazdu", value: participant.vehicleType },
+            { label: "Marka", value: participant.vehicleBrand },
+            { label: "Model", value: participant.vehicleModel },
+            {
+              label: "Rok",
+              value: participant.vehicleYear ? participant.vehicleYear.toString() : undefined,
+            },
+            { label: "Ubezpieczyciel", value: participant.insuranceCompany },
+            { label: "Nr polisy", value: participant.policyNumber },
+          ]
+            .filter((info) => info.value)
+            .map((info) => (
+              <InfoCard key={info.label} label={info.label} value={info.value as string} />
+            ))}
 
           {participant.drivers && participant.drivers.length > 0 && (
             <div className="space-y-3 pt-4 border-t border-gray-200">
-              <h4 className="text-sm font-semibold text-gray-900">Kierowcy</h4>
-              {participant.drivers.map((driver, index) => (
-                <div
-                  key={driver.id || index}
-                  className="bg-gray-50 rounded-lg p-3 space-y-2 border border-gray-200"
-                >
-                  <InfoCard
-                    label="Imię i nazwisko"
-                    value=
-                      {driver.name ||
-                        [driver.firstName, driver.lastName]
-                          .filter(Boolean)
-                          .join(" ")}
-                  />
-                  {driver.licenseNumber && (
-                    <InfoCard label="Nr prawa jazdy" value={driver.licenseNumber} />
-                  )}
-                  {driver.phone && <InfoCard label="Telefon" value={driver.phone} />}
-                  {driver.email && <InfoCard label="E-mail" value={driver.email} />}
-                </div>
-              ))}
+              <h4 className="text-sm font-semibold text-gray-900">Dane osobowe uczestnika</h4>
+              {participant.drivers.map((driver, index) => {
+                const firstName = driver.firstName || driver.name?.split(" ")[0]
+                const lastName =
+                  driver.lastName || driver.name?.split(" ").slice(1).join(" ")
+
+                return (
+                  <div
+                    key={driver.id || index}
+                    className="bg-gray-50 rounded-lg p-3 space-y-2 border border-gray-200"
+                  >
+                    <h5 className="text-sm font-medium text-gray-700">
+                      Osoba {index + 1}
+                    </h5>
+                    {[{ label: "Rola", value: getDriverRoleLabel(driver.role) },
+                      { label: "Imię", value: firstName },
+                      { label: "Nazwisko", value: lastName },
+                      { label: "Numer identyfikacyjny", value: driver.personalId },
+                      { label: "Nr prawa jazdy", value: driver.licenseNumber },
+                      { label: "Telefon", value: driver.phone },
+                      { label: "E-mail", value: driver.email },
+                      { label: "Adres", value: driver.address },
+                      { label: "Miasto", value: driver.city },
+                      { label: "Kod pocztowy", value: driver.postalCode },
+                      { label: "Kraj", value: driver.country },
+                    ]
+                      .filter((info) => info.value)
+                      .map((info) => (
+                        <InfoCard
+                          key={info.label}
+                          label={info.label}
+                          value={info.value as string}
+                        />
+                      ))}
+                  </div>
+                )
+              })}
             </div>
           )}
         </div>
@@ -347,7 +387,6 @@ const CommunicationClaimSummary = ({
             "Sprawca",
             <AlertTriangle className="h-4 w-4 text-red-600" />,
             "bg-gradient-to-r from-red-50 to-red-100",
-            false,
           )}
         </div>
       </div>

--- a/hooks/use-claims.ts
+++ b/hooks/use-claims.ts
@@ -266,7 +266,7 @@ export const transformFrontendClaimToApiPayload = (
 
       id: d.id && isGuid(d.id) ? d.id : undefined,
 
-      name: d.name,
+      name: d.name || [d.firstName, d.lastName].filter(Boolean).join(" "),
       licenseNumber: d.licenseNumber,
       firstName: d.firstName,
       lastName: d.lastName,


### PR DESCRIPTION
## Summary
- translate driver roles and display them in claim summary
- list full personal data for each participant driver including role, identification and contact details

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60767ea1c832cb428bff3b0544861