### PR TITLE
Ensure email attachments stored in cloud are sent correctly

### DIFF
--- a/backend/Services/EmailService.cs
+++ b/backend/Services/EmailService.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Text.RegularExpressions;
+using System.Net.Http;
 
 namespace AutomotiveClaimsApi.Services
 {
@@ -29,13 +30,15 @@ namespace AutomotiveClaimsApi.Services
         private readonly ILogger<EmailService> _logger;
         private readonly string _attachmentsPath;
         private readonly IConfiguration _config;
+        private readonly IGoogleCloudStorageService? _cloudStorage;
 
         public EmailService(
             ApplicationDbContext context,
             IOptions<SmtpSettings> smtpSettings,
             ILogger<EmailService> logger,
             IWebHostEnvironment environment,
-            IConfiguration config)
+            IConfiguration config,
+            IGoogleCloudStorageService? cloudStorage = null)
         {
             _context = context;
             _smtpSettings = smtpSettings.Value;
@@ -46,6 +49,7 @@ namespace AutomotiveClaimsApi.Services
                 Directory.CreateDirectory(_attachmentsPath);
             }
             _config = config;
+            _cloudStorage = cloudStorage;
         }
 
         public async Task<EmailDto> CreateEmailAsync(CreateEmailDto createEmailDto)
@@ -349,7 +353,7 @@ namespace AutomotiveClaimsApi.Services
             {
                 try
                 {
-                    var message = BuildMimeMessage(email);
+                    var message = await BuildMimeMessageAsync(email);
 
                     using var client = new SmtpClient();
                     await client.ConnectAsync(_smtpSettings.Host, _smtpSettings.Port, SecureSocketOptions.StartTls);
@@ -377,7 +381,7 @@ namespace AutomotiveClaimsApi.Services
             return processed;
         }
 
-        private MimeMessage BuildMimeMessage(Email email)
+        private async Task<MimeMessage> BuildMimeMessageAsync(Email email)
         {
             var message = new MimeMessage();
             message.From.Add(new MailboxAddress(_smtpSettings.FromName, _smtpSettings.FromEmail));
@@ -395,6 +399,7 @@ namespace AutomotiveClaimsApi.Services
             else
                 bodyBuilder.TextBody = email.Body;
 
+            using var httpClient = new HttpClient();
             foreach (var attachment in email.Attachments)
             {
                 if (!string.IsNullOrEmpty(attachment.FilePath))
@@ -403,6 +408,31 @@ namespace AutomotiveClaimsApi.Services
                     if (File.Exists(fullPath))
                     {
                         bodyBuilder.Attachments.Add(fullPath);
+                    }
+                }
+                else if (!string.IsNullOrEmpty(attachment.CloudUrl))
+                {
+                    try
+                    {
+                        if (_cloudStorage != null && Uri.TryCreate(attachment.CloudUrl, UriKind.Absolute, out var uri) &&
+                            (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+                        {
+                            await using var stream = await _cloudStorage.GetFileStreamAsync(attachment.CloudUrl);
+                            using var ms = new MemoryStream();
+                            await stream.CopyToAsync(ms);
+                            var fileName = attachment.FileName ?? Path.GetFileName(uri.LocalPath);
+                            bodyBuilder.Attachments.Add(fileName, ms.ToArray());
+                        }
+                        else
+                        {
+                            var data = await httpClient.GetByteArrayAsync(attachment.CloudUrl);
+                            var fileName = attachment.FileName ?? Path.GetFileName(attachment.CloudUrl);
+                            bodyBuilder.Attachments.Add(fileName, data);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Error downloading attachment from {Url}", attachment.CloudUrl);
                     }
                 }
             }

--- a/emailservice/EmailClient.cs
+++ b/emailservice/EmailClient.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
@@ -13,6 +14,7 @@ using MimeKit;
 using EmailService.Data;
 using EmailService.Models;
 using EmailService.Storage;
+using Google.Cloud.Storage.V1;
 
 
 namespace EmailService;
@@ -198,11 +200,41 @@ public class EmailClient
                 else
                     bodyBuilder.TextBody = email.Body;
 
+                using var httpClient = new HttpClient();
                 foreach (var attachment in email.Attachments)
                 {
                     if (!string.IsNullOrEmpty(attachment.FilePath) && File.Exists(attachment.FilePath))
                     {
                         bodyBuilder.Attachments.Add(attachment.FilePath);
+                    }
+                    else if (!string.IsNullOrEmpty(attachment.CloudUrl))
+                    {
+                        try
+                        {
+                            if (attachment.CloudUrl.Contains("storage.googleapis.com"))
+                            {
+                                var uri = new Uri(attachment.CloudUrl);
+                                var parts = uri.AbsolutePath.TrimStart('/').Split('/', 2);
+                                if (parts.Length == 2)
+                                {
+                                    var storageClient = StorageClient.Create();
+                                    using var ms = new MemoryStream();
+                                    await storageClient.DownloadObjectAsync(parts[0], parts[1], ms);
+                                    var fileName = attachment.FileName ?? Path.GetFileName(uri.LocalPath);
+                                    bodyBuilder.Attachments.Add(fileName, ms.ToArray());
+                                }
+                            }
+                            else
+                            {
+                                var data = await httpClient.GetByteArrayAsync(attachment.CloudUrl);
+                                var fileName = attachment.FileName ?? Path.GetFileName(attachment.CloudUrl);
+                                bodyBuilder.Attachments.Add(fileName, data);
+                            }
+                        }
+                        catch
+                        {
+                            // Ignore failures to download attachments
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Fetch attachment binaries from Google Cloud Storage when cloud URLs are present
- Fallback to HTTP download for non-Google cloud attachment URLs

## Testing
- `pnpm test`
- `dotnet build emailservice` *(fails: command not found)*
- `dotnet build backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b60ec8b110832cb5bfd9ee588b7fa9