### PR TITLE
Align injured participant layout with perpetrator in claim summary

### DIFF
--- a/components/claim-form/communication-claim-summary.tsx
+++ b/components/claim-form/communication-claim-summary.tsx
@@ -286,109 +286,103 @@ const CommunicationClaimSummary = ({
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
-        {/* Left Column - DANE SZKODY I ZDARZENIA */}
-        <div className="space-y-4">
-          <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
-            <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
-              <div className="flex items-center space-x-2">
-                <FileText className="h-4 w-4 text-blue-600" />
-                <h3 className="text-sm font-semibold text-gray-900">Dane szkody i zdarzenia</h3>
-              </div>
-            </div>
-            <div className="p-4 space-y-3">
-              <div className="grid grid-cols-2 gap-3">
-                <InfoCard label="Nr szkody Sparta" value={claimFormData.spartaNumber} />
-                <InfoCard label="Nr szkody TU" value={claimFormData.insurerClaimNumber} />
-              </div>
-
-              <div className="grid grid-cols-2 gap-3">
-                <InfoCard label="Status" value={getStatusLabel(claimFormData.claimStatusId)} />
-                <InfoCard label="Likwidator" value={claimFormData.handler} />
-              </div>
-
-              {(claimFormData.handlerEmail || claimFormData.handlerPhone) && (
-                <div className="grid grid-cols-2 gap-3">
-                  {claimFormData.handlerEmail && (
-                    <InfoCard label="E-mail" value={claimFormData.handlerEmail} />
-                  )}
-                  {claimFormData.handlerPhone && (
-                    <InfoCard label="Telefon" value={claimFormData.handlerPhone} />
-                  )}
-                </div>
-              )}
-
-              <InfoCard label="Rodzaj szkody" value={claimFormData.damageType} />
-              <InfoCard label="Ryzyko szkody" value={getRiskTypeLabel(claimFormData.riskType)} />
-
-              <div className="grid grid-cols-2 gap-3">
-                <InfoCard label="Data zdarzenia" value={claimFormData.damageDate} />
-                <InfoCard label="Godzina zdarzenia" value={claimFormData.eventTime} />
-              </div>
-
-              <div className="grid grid-cols-2 gap-3">
-                <InfoCard label="Data zgłoszenia" value={claimFormData.reportDate} />
-                <InfoCard label="Data zgłoszenia do TU" value={claimFormData.reportDateToInsurer} />
-              </div>
-
-              <InfoCard
-                icon={<MapPin className="h-4 w-4" />}
-                label="Miejsce zdarzenia"
-                value={claimFormData.eventLocation}
-              />
-
-              {claimFormData.eventDescription && (
-                <div className="bg-gray-50 rounded-lg p-3">
-                  <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
-                    Opis zdarzenia
-                  </span>
-                  <p className="text-sm text-gray-900 leading-relaxed">{claimFormData.eventDescription}</p>
-                </div>
-              )}
-
-              <div className="grid grid-cols-2 gap-3">
-                <InfoCard label="Klient" value={claimFormData.client} />
-                <InfoCard label="TU" value={claimFormData.insuranceCompany} />
-              </div>
-
-              {claimFormData.leasingCompany && (
-                <InfoCard label="Firma leasingowa" value={claimFormData.leasingCompany} />
-              )}
-
-              <div className="grid grid-cols-2 gap-3">
-                <InfoCard label="Obszar" value={claimFormData.area} />
-                <InfoCard label="Kanał zgłoszenia" value={claimFormData.reportingChannel} />
-              </div>
-
-              {claimFormData.comments && (
-                <div className="bg-gray-50 rounded-lg p-3">
-                  <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
-                    Uwagi
-                  </span>
-                  <p className="text-sm text-gray-900 leading-relaxed">{claimFormData.comments}</p>
-                </div>
-              )}
-            </div>
+      {/* DANE SZKODY I ZDARZENIA */}
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="px-4 py-3 bg-gradient-to-r from-blue-50 to-blue-100 border-b border-gray-200">
+          <div className="flex items-center space-x-2">
+            <FileText className="h-4 w-4 text-blue-600" />
+            <h3 className="text-sm font-semibold text-gray-900">Dane szkody i zdarzenia</h3>
+          </div>
+        </div>
+        <div className="p-4 space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Nr szkody Sparta" value={claimFormData.spartaNumber} />
+            <InfoCard label="Nr szkody TU" value={claimFormData.insurerClaimNumber} />
           </div>
 
-          {/* POSZKODOWANY Section */}
-          {renderParticipantDetails(
-            claimFormData.injuredParty,
-            "Poszkodowany",
-            <User className="h-4 w-4 text-blue-600" />,
-            "bg-gradient-to-r from-blue-50 to-blue-100",
-          )}
-        </div>
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Status" value={getStatusLabel(claimFormData.claimStatusId)} />
+            <InfoCard label="Likwidator" value={claimFormData.handler} />
+          </div>
 
-        {/* Right Column - SPRAWCA */}
-        <div className="space-y-4">
-          {renderParticipantDetails(
-            claimFormData.perpetrator,
-            "Sprawca",
-            <AlertTriangle className="h-4 w-4 text-red-600" />,
-            "bg-gradient-to-r from-red-50 to-red-100",
+          {(claimFormData.handlerEmail || claimFormData.handlerPhone) && (
+            <div className="grid grid-cols-2 gap-3">
+              {claimFormData.handlerEmail && (
+                <InfoCard label="E-mail" value={claimFormData.handlerEmail} />
+              )}
+              {claimFormData.handlerPhone && (
+                <InfoCard label="Telefon" value={claimFormData.handlerPhone} />
+              )}
+            </div>
+          )}
+
+          <InfoCard label="Rodzaj szkody" value={claimFormData.damageType} />
+          <InfoCard label="Ryzyko szkody" value={getRiskTypeLabel(claimFormData.riskType)} />
+
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Data zdarzenia" value={claimFormData.damageDate} />
+            <InfoCard label="Godzina zdarzenia" value={claimFormData.eventTime} />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Data zgłoszenia" value={claimFormData.reportDate} />
+            <InfoCard label="Data zgłoszenia do TU" value={claimFormData.reportDateToInsurer} />
+          </div>
+
+          <InfoCard
+            icon={<MapPin className="h-4 w-4" />}
+            label="Miejsce zdarzenia"
+            value={claimFormData.eventLocation}
+          />
+
+          {claimFormData.eventDescription && (
+            <div className="bg-gray-50 rounded-lg p-3">
+              <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
+                Opis zdarzenia
+              </span>
+              <p className="text-sm text-gray-900 leading-relaxed">{claimFormData.eventDescription}</p>
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Klient" value={claimFormData.client} />
+            <InfoCard label="TU" value={claimFormData.insuranceCompany} />
+          </div>
+
+          {claimFormData.leasingCompany && (
+            <InfoCard label="Firma leasingowa" value={claimFormData.leasingCompany} />
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
+            <InfoCard label="Obszar" value={claimFormData.area} />
+            <InfoCard label="Kanał zgłoszenia" value={claimFormData.reportingChannel} />
+          </div>
+
+          {claimFormData.comments && (
+            <div className="bg-gray-50 rounded-lg p-3">
+              <span className="text-xs font-medium text-gray-500 uppercase tracking-wide block mb-1">
+                Uwagi
+              </span>
+              <p className="text-sm text-gray-900 leading-relaxed">{claimFormData.comments}</p>
+            </div>
           )}
         </div>
+      </div>
+
+      {/* Participants */}
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+        {renderParticipantDetails(
+          claimFormData.injuredParty,
+          "Poszkodowany",
+          <User className="h-4 w-4 text-blue-600" />,
+          "bg-gradient-to-r from-blue-50 to-blue-100",
+        )}
+        {renderParticipantDetails(
+          claimFormData.perpetrator,
+          "Sprawca",
+          <AlertTriangle className="h-4 w-4 text-red-600" />,
+          "bg-gradient-to-r from-red-50 to-red-100",
+        )}
       </div>
 
       {/* Full Width Sections */}


### PR DESCRIPTION
## Summary
- Show claim and event details as a standalone section
- Display injured and perpetrator participants side-by-side with matching layouts

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b610b404b4832caa243e385c687453