### PR TITLE
Fix document counts in claim form sidebar

### DIFF
--- a/app/claims/[...params]/page.tsx
+++ b/app/claims/[...params]/page.tsx
@@ -339,7 +339,10 @@ export default function ClaimPage() {
                 (mode === "view"
                   ? claim?.notes?.length
                   : claimFormData.notes?.length) || 0,
-              dokumenty: uploadedFiles.length,
+              dokumenty:
+                mode === "view"
+                  ? claim?.documents?.length || 0
+                  : (claimFormData.documents?.length || 0) + uploadedFiles.length,
 
             }}
           />

--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -212,7 +212,8 @@ export default function EditClaimPage() {
             regres: claimFormData.recourses?.length || 0,
             ugody: claimFormData.settlements?.length || 0,
             notatki: claimFormData.notes?.length || 0,
-            dokumenty: uploadedFiles.length,
+            dokumenty:
+              (claimFormData.documents?.length || 0) + uploadedFiles.length,
           }}
 
         />

--- a/app/claims/new/page.tsx
+++ b/app/claims/new/page.tsx
@@ -516,7 +516,8 @@ export default function NewClaimPage() {
             regres: claimFormData.recourses?.length || 0,
             ugody: claimFormData.settlements?.length || 0,
             notatki: claimFormData.notes?.length || 0,
-            dokumenty: uploadedFiles.length,
+            dokumenty:
+              (claimFormData.documents?.length || 0) + uploadedFiles.length,
           }}
 
         />


### PR DESCRIPTION
## Summary
- include existing claim documents when displaying document count in sidebar
- handle view mode and uploads consistently for document count

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b62144320c832ca4680c809d16c6e8