### PR TITLE
Fix undefined totalCount in claim list components

### DIFF
--- a/components/claims-list-desktop.tsx
+++ b/components/claims-list-desktop.tsx
@@ -145,7 +145,7 @@ export function ClaimsListDesktop({
   const isAdmin = user?.roles?.some((r) => r.toLowerCase() === "admin")
 
   const claims = initialClaims?.length ? initialClaims : fetchedClaims
-  const totalRecords = initialClaims?.length
+  const totalCount = initialClaims?.length
     ? initialTotalCount ?? initialClaims.length
     : fetchedTotalCount
 
@@ -358,7 +358,7 @@ export function ClaimsListDesktop({
     () => claims.reduce((sum, claim) => sum + (claim.totalClaim || 0), 0),
     [claims],
   )
-  const totalPages = Math.ceil(totalRecords / pageSize)
+  const totalPages = Math.ceil((totalCount || 0) / pageSize)
 
   const handleSort = (field: string) => {
     setPage(1)

--- a/components/mobile/claims-list.tsx
+++ b/components/mobile/claims-list.tsx
@@ -112,7 +112,7 @@ export function ClaimsListMobile({
   const isAdmin = user?.roles?.some((r) => r.toLowerCase() === "admin")
 
   const claims = initialClaims?.length ? initialClaims : fetchedClaims
-  const totalRecords = initialClaims?.length
+  const totalCount = initialClaims?.length
     ? initialTotalCount ?? initialClaims.length
     : fetchedTotalCount
 
@@ -319,7 +319,7 @@ export function ClaimsListMobile({
     () => claims.reduce((sum, claim) => sum + (claim.totalClaim || 0), 0),
     [claims],
   )
-  const totalPages = Math.ceil(totalRecords / pageSize)
+  const totalPages = Math.ceil((totalCount || 0) / pageSize)
 
   const handleSort = (field: string) => {
     setPage(1)


### PR DESCRIPTION
## Summary
- Define `totalCount` and use it consistently in claims list components
- Prevent runtime error when rendering claim lists

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b62788a8ec832cbafeba3ad554471a