### PR TITLE
feat: add policy search module to claim creation

### DIFF
--- a/app/claims/create/page.tsx
+++ b/app/claims/create/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import ClientDropdown from "@/components/client-dropdown";
 import { Button } from "@/components/ui/button";
+import PolicySearch from "@/components/policy-search";
 import type { ClientSelectionEvent } from "@/types/client";
 
 interface ClaimType {
@@ -61,7 +62,9 @@ export default function CreateClaimPage() {
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-50">
-      <form onSubmit={handleSubmit} className="w-full max-w-3xl space-y-6">
+      <div className="w-full max-w-3xl space-y-6">
+      <PolicySearch />
+      <form onSubmit={handleSubmit} className="space-y-6">
         <div className="bg-white rounded-lg shadow-sm border border-neutral-200">
           <div className="p-6 border-b border-neutral-200">
             <h2 className="text-lg text-neutral-900 flex items-center">
@@ -145,6 +148,7 @@ export default function CreateClaimPage() {
           </Button>
         </div>
       </form>
+      </div>
     </div>
   );
 }

--- a/components/policy-search.tsx
+++ b/components/policy-search.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { apiService, type PolicyDto } from "@/lib/api";
+
+export default function PolicySearch() {
+  const [policyNumber, setPolicyNumber] = useState("");
+  const [registrationNumber, setRegistrationNumber] = useState("");
+  const [policies, setPolicies] = useState<PolicyDto[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleSearch = async () => {
+    setLoading(true);
+    try {
+      const results = await apiService.searchPolicies({
+        policyNumber: policyNumber || undefined,
+        registrationNumber: registrationNumber || undefined,
+      });
+      setPolicies(results);
+    } catch (e) {
+      console.error(e);
+      setPolicies([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-neutral-200">
+      <div className="p-6 border-b border-neutral-200">
+        <h2 className="text-lg text-neutral-900">Wyszukaj polisę</h2>
+      </div>
+      <div className="p-6 space-y-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Input
+            placeholder="Numer polisy"
+            value={policyNumber}
+            onChange={(e) => setPolicyNumber(e.target.value)}
+          />
+          <Input
+            placeholder="Numer rejestracyjny"
+            value={registrationNumber}
+            onChange={(e) => setRegistrationNumber(e.target.value)}
+          />
+        </div>
+        <div className="flex justify-end">
+          <Button type="button" onClick={handleSearch} disabled={loading}>
+            {loading ? "Szukam..." : "Szukaj"}
+          </Button>
+        </div>
+      </div>
+      {policies.length > 0 && (
+        <div className="p-6 border-t border-neutral-200">
+          <ul className="space-y-2">
+            {policies.map((p) => (
+              <li key={p.id} className="text-sm">
+                {p.policyNumber} - {p.registrationNumber}
+                {p.clientName ? ` (${p.clientName})` : ""}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -323,6 +323,14 @@ export interface UpdateClientDto {
   isActive?: boolean
 }
 
+export interface PolicyDto {
+  id: number
+  policyNumber: string
+  registrationNumber: string
+  clientId?: number
+  clientName?: string
+}
+
 export interface RiskTypeDto {
   id: number
   code: string
@@ -1222,6 +1230,15 @@ class ApiService {
 
   async getEventByClaimNumber(claimNumber: string): Promise<EventDto> {
     return this.request<EventDto>(`/events/by-claim/${claimNumber}`)
+  }
+
+  // Policies API
+  async searchPolicies(params: { policyNumber?: string; registrationNumber?: string }): Promise<PolicyDto[]> {
+    const search = new URLSearchParams()
+    if (params.policyNumber) search.set('policyNumber', params.policyNumber)
+    if (params.registrationNumber) search.set('registrationNumber', params.registrationNumber)
+    const query = search.toString()
+    return this.request<PolicyDto[]>(`/policies${query ? `?${query}` : ''}`)
   }
 
   // Clients API

--- a/types/policy.ts
+++ b/types/policy.ts
@@ -1,0 +1,8 @@
+export interface Policy {
+  id: number;
+  policyNumber: string;
+  registrationNumber: string;
+  clientId?: number;
+  clientName?: string;
+}
+


### PR DESCRIPTION
## Summary
- add policy search component for looking up policies by number or registration
- expose PolicyDto and searchPolicies API helper
- wire policy search into claim creation page

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm add -D eslint` *(fails: GET https://registry.npmjs.org/eslint: Forbidden - 403)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8a852ce1c832ca1ca2d665a220b44