### PR TITLE
Fix risk filter options

### DIFF
--- a/components/claims-list-desktop.tsx
+++ b/components/claims-list-desktop.tsx
@@ -178,12 +178,16 @@ export function ClaimsListDesktop({
     const loadRiskTypes = async () => {
       try {
         const responses = await Promise.all(
-          [1, 2, 3].map((type) =>
-            dictionaryService.getRiskTypes(String(type)),
-          ),
+          [1, 2, 3].map(async (type) => {
+            const data = await dictionaryService.getRiskTypes(String(type))
+            return (data.items ?? []).map((item) => ({
+              ...item,
+              claimObjectTypeId: type,
+            }))
+          }),
         )
 
-        const allItems = responses.flatMap((data) => data.items ?? [])
+        const allItems = responses.flat()
 
         setRiskTypes(
           allItems as {

--- a/components/mobile/claims-list.tsx
+++ b/components/mobile/claims-list.tsx
@@ -145,12 +145,16 @@ export function ClaimsListMobile({
     const loadRiskTypes = async () => {
       try {
         const responses = await Promise.all(
-          [1, 2, 3].map((type) =>
-            dictionaryService.getRiskTypes(String(type)),
-          ),
+          [1, 2, 3].map(async (type) => {
+            const data = await dictionaryService.getRiskTypes(String(type))
+            return (data.items ?? []).map((item) => ({
+              ...item,
+              claimObjectTypeId: type,
+            }))
+          }),
         )
 
-        const allItems = responses.flatMap((data) => data.items ?? [])
+        const allItems = responses.flat()
 
         setRiskTypes(
           allItems as {


### PR DESCRIPTION
## Summary
- ensure risk filter options include claim object type so dropdown shows all risk types on desktop and mobile

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c7909c08832c8ecf51173deaa90f