### PR TITLE
feat: add registration date filter

### DIFF
--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -25,6 +25,8 @@ export default function UsersPage() {
   const [searchTerm, setSearchTerm] = useState("")
   const [statusFilter, setStatusFilter] = useState<string>("all")
   const [roleFilter, setRoleFilter] = useState<string>("all")
+  const [registrationFrom, setRegistrationFrom] = useState("")
+  const [registrationTo, setRegistrationTo] = useState("")
   const [sortBy, setSortBy] = useState<UserFilters["sortBy"]>("name")
   const [sortOrder, setSortOrder] = useState<UserFilters["sortOrder"]>("asc")
   const [userDialogOpen, setUserDialogOpen] = useState(false)
@@ -45,9 +47,19 @@ export default function UsersPage() {
     if (searchTerm) baseFilters.search = searchTerm
     if (statusFilter !== "all") baseFilters.status = statusFilter as User["status"]
     if (roleFilter !== "all") baseFilters.roleId = roleFilter
+    if (registrationFrom) baseFilters.registrationFromDate = registrationFrom
+    if (registrationTo) baseFilters.registrationToDate = registrationTo
 
     return baseFilters
-  }, [searchTerm, statusFilter, roleFilter, sortBy, sortOrder])
+  }, [
+    searchTerm,
+    statusFilter,
+    roleFilter,
+    sortBy,
+    sortOrder,
+    registrationFrom,
+    registrationTo,
+  ])
 
   useEffect(() => {
     adminService.getUsers(filters).then(setUsers)
@@ -144,7 +156,11 @@ export default function UsersPage() {
             <Filter className="h-4 w-4" />
             Filtry i wyszukiwanie
           </CardTitle>
-          {(searchTerm || statusFilter !== "all" || roleFilter !== "all") && (
+          {(searchTerm ||
+            statusFilter !== "all" ||
+            roleFilter !== "all" ||
+            registrationFrom ||
+            registrationTo) && (
             <Button
               variant="ghost"
               size="icon"
@@ -152,6 +168,8 @@ export default function UsersPage() {
                 setSearchTerm("")
                 setStatusFilter("all")
                 setRoleFilter("all")
+                setRegistrationFrom("")
+                setRegistrationTo("")
               }}
               aria-label="Wyczyść filtry"
             >
@@ -196,6 +214,20 @@ export default function UsersPage() {
                 ))}
               </SelectContent>
             </Select>
+            <Input
+              type="date"
+              value={registrationFrom}
+              onChange={(e) => setRegistrationFrom(e.target.value)}
+              className="w-full md:w-[180px]"
+              placeholder="Data od"
+            />
+            <Input
+              type="date"
+              value={registrationTo}
+              onChange={(e) => setRegistrationTo(e.target.value)}
+              className="w-full md:w-[180px]"
+              placeholder="Data do"
+            />
           </div>
         </CardContent>
       </Card>

--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -289,7 +289,10 @@ namespace AutomotiveClaimsApi.Controllers
 
         [Authorize]
         [HttpGet("users")]
-        public async Task<ActionResult<IEnumerable<UserListItemDto>>> GetUsers([FromQuery] string? search)
+        public async Task<ActionResult<IEnumerable<UserListItemDto>>> GetUsers(
+            [FromQuery] string? search,
+            [FromQuery] DateTime? registrationFromDate = null,
+            [FromQuery] DateTime? registrationToDate = null)
         {
             var query = _userManager.Users.AsQueryable();
             if (!string.IsNullOrWhiteSpace(search))
@@ -297,6 +300,18 @@ namespace AutomotiveClaimsApi.Controllers
                 query = query.Where(u =>
                     u.UserName!.Contains(search) ||
                     (u.Email != null && u.Email.Contains(search)));
+            }
+
+            if (registrationFromDate.HasValue)
+            {
+                var from = registrationFromDate.Value.Date;
+                query = query.Where(u => u.CreatedAt.Date >= from);
+            }
+
+            if (registrationToDate.HasValue)
+            {
+                var to = registrationToDate.Value.Date;
+                query = query.Where(u => u.CreatedAt.Date <= to);
             }
 
             var users = await query.ToListAsync();

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1071,6 +1071,8 @@ class ApiService {
       pageSize?: number
       sortBy?: string
       sortOrder?: "asc" | "desc"
+      registrationFromDate?: string
+      registrationToDate?: string
     } = {},
   ): Promise<{ items: UserListItemDto[]; totalCount: number }> {
     const searchParams = new URLSearchParams()

--- a/lib/services/admin-service.ts
+++ b/lib/services/admin-service.ts
@@ -55,6 +55,8 @@ export const adminService = {
                 ? "lastLogin"
                 : undefined,
       sortOrder: filters.sortOrder,
+      registrationFromDate: filters.registrationFromDate,
+      registrationToDate: filters.registrationToDate,
     });
 
     return items.map(mapUserDto);

--- a/lib/types/admin.ts
+++ b/lib/types/admin.ts
@@ -40,6 +40,8 @@ export interface UserFilters {
   roleId?: string;
   sortBy?: 'name' | 'email' | 'createdAt' | 'lastLogin';
   sortOrder?: 'asc' | 'desc';
+  registrationFromDate?: string;
+  registrationToDate?: string;
 }
 
 export interface RoleFilters {


### PR DESCRIPTION
## Summary
- add registration date range inputs on user management page
- plumb registration date range through filters, services and API
- support registration date filtering on backend

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d021d080832cb0d1486b72085e5e