### PR TITLE
feat: add unassigned email section

### DIFF
--- a/components/email/unassigned-list.tsx
+++ b/components/email/unassigned-list.tsx
@@ -37,7 +37,7 @@ export function UnassignedEmailList() {
     try {
       const success = await emailService.assignEmailToClaim(
         assigningEmail.id,
-        selectedClaim,
+        [selectedClaim],
       )
       if (success) {
         setEmails((prev) => prev.filter((e) => e.id !== assigningEmail.id))

--- a/lib/email-service.ts
+++ b/lib/email-service.ts
@@ -159,7 +159,7 @@ class EmailService {
       case EmailFolder.Important:
         return emails.filter((e) => e.isImportant)
       case EmailFolder.Unassigned:
-        return emails.filter((e) => !e.claimIds || e.claimIds.length === 0)
+        return emails.filter((e) => !e.eventId)
       default:
         return emails
     }
@@ -175,7 +175,7 @@ class EmailService {
 
   async getUnassignedEmails(): Promise<EmailDto[]> {
     const emails = await this.getAllEmails()
-    return emails.filter((e) => !e.claimIds || e.claimIds.length === 0)
+    return emails.filter((e) => !e.eventId)
   }
 
   async getEmailsByClaimId(claimId: string): Promise<EmailDto[]> {


### PR DESCRIPTION
## Summary
- show emails without an event and fetch unassigned messages
- allow assigning unassigned emails to a claim
- expose an "Nieprzypisane" tab in the email section

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d231ab64832cbf57081daad6ff1e