### PR TITLE
Handle mobile web push notifications

### DIFF
--- a/mobile/components/NotificationCenter.tsx
+++ b/mobile/components/NotificationCenter.tsx
@@ -45,9 +45,9 @@ export function NotificationCenter({ onNavigate }: NotificationCenterProps) {
     }
   };
 
-  const handleNotificationClick = (notification: Notification) => {
+  const handleNotificationClick = async (notification: Notification) => {
     if (!notification.read) {
-      markAsRead(notification.id);
+      await markAsRead(notification.id);
     }
     
     if (notification.claimId) {

--- a/mobile/components/ReportClaim.tsx
+++ b/mobile/components/ReportClaim.tsx
@@ -80,7 +80,7 @@ export function ReportClaim({ onNavigate }: ReportClaimProps) {
 
       const { id: claimId } = await response.json();
 
-      addNotification({
+      await addNotification({
         title: 'Szkoda zgłoszona',
         message: `Pomyślnie utworzono zgłoszenie ${claimId}`,
         type: 'success',

--- a/mobile/hooks/useNotifications.tsx
+++ b/mobile/hooks/useNotifications.tsx
@@ -15,9 +15,9 @@ export interface Notification {
 interface NotificationsContextValue {
   notifications: Notification[];
   unreadCount: number;
-  markAsRead: (id: string) => void;
-  markAllAsRead: () => void;
-  addNotification: (notification: Omit<Notification, 'id' | 'timestamp' | 'read'>) => void;
+  markAsRead: (id: string) => Promise<void>;
+  markAllAsRead: () => Promise<void>;
+  addNotification: (notification: Omit<Notification, 'id' | 'timestamp' | 'read'>) => Promise<void>;
   removeNotification: (id: string) => void;
   getFormattedTime: (timestamp: Date) => string;
 }
@@ -48,33 +48,79 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
     return () => clearInterval(interval);
   }, []);
 
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
+
+    const handler = (event: MessageEvent) => {
+      const { type, notification } = event.data || {};
+      if (type === 'PUSH_NOTIFICATION' && notification) {
+        const parsed: Notification = {
+          id: notification.id || Date.now().toString(),
+          title: notification.title || '',
+          message: notification.message || '',
+          type: notification.type || 'info',
+          timestamp: new Date(notification.timestamp || Date.now()),
+          read: false,
+          claimId: notification.claimId,
+          actionType: notification.actionType,
+        };
+        setNotifications(prev =>
+          prev.some(n => n.id === parsed.id) ? prev : [parsed, ...prev]
+        );
+      }
+    };
+
+    navigator.serviceWorker.addEventListener('message', handler);
+    return () => navigator.serviceWorker.removeEventListener('message', handler);
+  }, []);
+
   const unreadCount = notifications.filter(n => !n.read).length;
 
-  const markAsRead = (notificationId: string) => {
-    setNotifications(prev => 
-      prev.map(notification => 
-        notification.id === notificationId 
+  const markAsRead = async (notificationId: string) => {
+    setNotifications(prev =>
+      prev.map(notification =>
+        notification.id === notificationId
           ? { ...notification, read: true }
           : notification
       )
     );
+    try {
+      await authFetch(`/mobile/notifications/${notificationId}/read`, { method: 'POST' });
+    } catch (err) {
+      console.error('Failed to mark notification as read', err);
+    }
   };
 
-  const markAllAsRead = () => {
-    setNotifications(prev => 
+  const markAllAsRead = async () => {
+    setNotifications(prev =>
       prev.map(notification => ({ ...notification, read: true }))
     );
+    try {
+      await authFetch('/mobile/notifications/read-all', { method: 'POST' });
+    } catch (err) {
+      console.error('Failed to mark all notifications as read', err);
+    }
   };
 
-  const addNotification = (notification: Omit<Notification, 'id' | 'timestamp' | 'read'>) => {
-    const newNotification: Notification = {
-      ...notification,
-      id: Date.now().toString(),
-      timestamp: new Date(),
-      read: false
-    };
-    
-    setNotifications(prev => [newNotification, ...prev]);
+  const addNotification = async (
+    notification: Omit<Notification, 'id' | 'timestamp' | 'read'>
+  ) => {
+    try {
+      const res = await authFetch('/mobile/notifications', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(notification)
+      });
+      if (!res.ok) return;
+      const saved = await res.json();
+      const parsed: Notification = {
+        ...saved,
+        timestamp: new Date(saved.timestamp)
+      };
+      setNotifications(prev => [parsed, ...prev]);
+    } catch (err) {
+      console.error('Failed to add notification', err);
+    }
   };
 
   const removeNotification = (notificationId: string) => {

--- a/mobile/main.tsx
+++ b/mobile/main.tsx
@@ -15,6 +15,13 @@ function urlBase64ToUint8Array(base64String: string) {
   return outputArray;
 }
 
+function getApiBaseUrl() {
+  if (typeof window === "undefined") return "/api";
+  return window.location.origin.includes("localhost")
+    ? "http://localhost:5200/api"
+    : "/api";
+}
+
 // Request notification permission and register service worker
 if (typeof window !== "undefined") {
   window.addEventListener("load", async () => {
@@ -41,7 +48,8 @@ if (typeof window !== "undefined") {
 
           if ("PushManager" in window && Notification.permission === "granted") {
             try {
-              const res = await fetch("/api/push/public-key");
+              const baseUrl = getApiBaseUrl();
+              const res = await fetch(`${baseUrl}/push/public-key`);
               const data = await res.json();
               let sub = await reg.pushManager.getSubscription();
               if (!sub) {
@@ -50,7 +58,7 @@ if (typeof window !== "undefined") {
                   applicationServerKey: urlBase64ToUint8Array(data.key),
                 });
               }
-              await fetch("/api/push/subscribe", {
+              await fetch(`${baseUrl}/push/subscribe`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(sub),


### PR DESCRIPTION
## Summary
- Persist mobile notifications by posting new items to the backend
- Mark notifications and all-read state via backend API
- Await read status updates when interacting with notifications
- Dynamically resolve API base URL when registering for push, ensuring VAPID subscriptions reach the backend

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint must be installed: pnpm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cbb619e0832ca582cf825e068a5b