### PR TITLE
Fix AddRReports ChangeTracker enumeration issue

### DIFF
--- a/backend/Data/ApplicationDbContext.cs
+++ b/backend/Data/ApplicationDbContext.cs
@@ -66,9 +66,13 @@ namespace AutomotiveClaimsApi.Data
 
         private void AddRReports()
         {
+            // Materialize the tracked entries before adding new entities to avoid
+            // modifying the collection while it's being iterated, which causes a
+            // "Collection was modified" exception.
             var entries = ChangeTracker.Entries()
                 .Where(e => e.Entity is not RReport &&
-                            (e.State == EntityState.Added || e.State == EntityState.Modified));
+                            (e.State == EntityState.Added || e.State == EntityState.Modified))
+                .ToList();
 
             foreach (var entry in entries)
             {


### PR DESCRIPTION
## Summary
- avoid modifying ChangeTracker during AddRReports by materializing entries

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e16564a0832cb74124aea097b185