### PR TITLE
feat: add KMZ document preview

### DIFF
--- a/components/claim-form/appeals-section.tsx
+++ b/components/claim-form/appeals-section.tsx
@@ -356,6 +356,7 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
     if (["jpg", "jpeg", "png", "gif", "bmp"].includes(ext || "")) return "image"
     if (ext === "xls" || ext === "xlsx") return "excel"
     if (ext === "doc" || ext === "docx") return "docx"
+    if (ext === "kmz") return "kmz"
     return "other"
   }
 
@@ -500,7 +501,7 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
   const isPreviewable = (fileName?: string) => {
     if (!fileName) return false
     const fileType = getFileType(fileName)
-    return ["pdf", "image", "excel", "docx"].includes(fileType)
+    return ["pdf", "image", "excel", "docx", "kmz"].includes(fileType)
   }
 
   const getStatusBadge = (status: Appeal["status"]) => {

--- a/components/claim-form/client-claims-section.tsx
+++ b/components/claim-form/client-claims-section.tsx
@@ -408,6 +408,7 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
       "docx",
       "xls",
       "xlsx",
+      "kmz",
     ].includes(extension || "")
   }
 
@@ -425,6 +426,8 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
       fileType = "pdf"
     } else if (["jpg", "jpeg", "png", "gif"].includes(extension || "")) {
       fileType = "image"
+    } else if (extension === "kmz") {
+      fileType = "kmz"
     } else if (extension === "xls" || extension === "xlsx") {
       fileType = "excel"
       url = urlPath
@@ -459,6 +462,8 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
           fileType = "pdf"
         } else if (["jpg", "jpeg", "png", "gif"].includes(extension || "")) {
           fileType = "image"
+        } else if (extension === "kmz") {
+          fileType = "kmz"
         } else if (extension === "xls" || extension === "xlsx") {
           fileType = "excel"
           url = urlPath

--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -527,12 +527,13 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
     const extension = fileName.split("?")[0].split(".").pop()?.toLowerCase()
     if (["pdf"].includes(extension || "")) return "pdf"
     if (["jpg", "jpeg", "png", "gif", "bmp"].includes(extension || "")) return "image"
+    if (extension === "kmz") return "kmz"
     return "other"
   }
 
   const isPreviewable = (fileName: string): boolean => {
     const fileType = getFileType(fileName)
-    return ["pdf", "image"].includes(fileType)
+    return ["pdf", "image", "kmz"].includes(fileType)
   }
 
   const getStatusBadgeVariant = (status: string) => {

--- a/components/claim-form/recourse-section.tsx
+++ b/components/claim-form/recourse-section.tsx
@@ -501,6 +501,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
       "docx",
       "xls",
       "xlsx",
+      "kmz",
     ].includes(ext || "")
   }
 
@@ -514,6 +515,7 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
     if (ext === "pdf") return "pdf"
     if (["jpg", "jpeg", "png", "gif", "bmp"].includes(ext || "")) return "image"
     if (ext === "xls" || ext === "xlsx") return "excel"
+    if (ext === "kmz") return "kmz"
     return "other"
   }
 

--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -326,6 +326,7 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
       "docx",
       "xls",
       "xlsx",
+      "kmz",
     ].includes(ext || "")
   }, [])
 
@@ -356,6 +357,9 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
       setPreviewFileType("excel")
       setPreviewUrl(url)
       window.URL.revokeObjectURL(objectUrl)
+    } else if (ext === "kmz") {
+      setPreviewFileType("kmz")
+      setPreviewUrl(objectUrl)
     } else {
       setPreviewFileType("other")
       setPreviewUrl(objectUrl)
@@ -390,6 +394,9 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
             setPreviewFileType("excel")
             setPreviewUrl(url)
             window.URL.revokeObjectURL(objectUrl)
+          } else if (ext === "kmz") {
+            setPreviewFileType("kmz")
+            setPreviewUrl(objectUrl)
           } else {
             setPreviewFileType("other")
             setPreviewUrl(objectUrl)

--- a/components/document-preview.tsx
+++ b/components/document-preview.tsx
@@ -5,8 +5,9 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Button } from "@/components/ui/button"
 import { ChevronLeft, ChevronRight, Download, FileText } from "lucide-react"
 import { renderAsync } from "docx-preview"
+import { KmzPreview } from "@/components/kmz-preview"
 
-export type FileType = "pdf" | "image" | "excel" | "docx" | "other"
+export type FileType = "pdf" | "image" | "excel" | "docx" | "kmz" | "other"
 
 interface DocumentPreviewProps {
   isOpen: boolean
@@ -68,6 +69,8 @@ export function DocumentPreview({
             />
           ) : fileType === "docx" ? (
             <div ref={docxRef} className="w-full h-[70vh] overflow-auto bg-white" />
+          ) : fileType === "kmz" ? (
+            <KmzPreview url={url} />
           ) : (
             <div className="text-center p-8">
               <FileText className="h-12 w-12 text-gray-400 mx-auto mb-4" />

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -20,6 +20,7 @@ import { File, Search, Eye, Download, Upload, X, Trash2, Grid, List, Wand, Plus,
 import type { DocumentsSectionProps, UploadedFile, DocumentsSectionRef } from "@/types"
 import JSZip from "jszip"
 import { saveAs } from "file-saver"
+import { KmzPreview } from "@/components/kmz-preview"
 
 // Categories that have dedicated sections elsewhere and therefore should
 // not appear in the generic documents section for a claim folder.
@@ -233,7 +234,8 @@ export const DocumentsSection = React.forwardRef<
         file.type === "image" ||
         file.type === "pdf" ||
         file.type === "video" ||
-        file.type === "doc",
+        file.type === "doc" ||
+        file.type === "kmz",
       previewUrl,
       downloadUrl,
       documentType: file.category || "Inne dokumenty",
@@ -247,6 +249,7 @@ export const DocumentsSection = React.forwardRef<
   ): UploadedFile["type"] => {
     if (contentType.includes("pdf")) return "pdf"
     if (contentType.includes("image")) return "image"
+    if (contentType.includes("vnd.google-earth.kmz")) return "kmz"
     if (
       contentType.includes("msword") ||
       contentType.includes("wordprocessingml") ||
@@ -445,6 +448,8 @@ export const DocumentsSection = React.forwardRef<
             ? "image"
             : file.type.includes("pdf")
             ? "pdf"
+            : file.type.includes("vnd.google-earth.kmz")
+            ? "kmz"
             : file.type.includes("msword") ||
               file.type.includes("wordprocessingml") ||
               file.type.includes("ms-excel") ||
@@ -2090,6 +2095,8 @@ export const DocumentsSection = React.forwardRef<
                       Twoja przeglądarka nie obsługuje odtwarzania wideo.
                     </video>
                   </div>
+                ) : previewDocument.contentType?.includes("vnd.google-earth.kmz") ? (
+                  <KmzPreview url={previewDocument.previewUrl || previewDocument.downloadUrl} />
                 ) : previewDocument.contentType?.startsWith("application/pdf") ? (
                   <object
                     data={previewDocument.previewUrl || previewDocument.downloadUrl}

--- a/components/email/email-inbox.tsx
+++ b/components/email/email-inbox.tsx
@@ -1043,6 +1043,8 @@ export default function EmailInbox({ claimId, claimNumber, claimInsuranceNumber 
             ? ("image" as FileType)
             : previewedAttachment?.contentType === "application/pdf"
             ? ("pdf" as FileType)
+            : previewedAttachment?.contentType === "application/vnd.google-earth.kmz"
+            ? ("kmz" as FileType)
             : ("other" as FileType)
         }
         onDownload={() => previewedAttachment && downloadAttachment(previewedAttachment)}

--- a/components/kmz-preview.tsx
+++ b/components/kmz-preview.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import JSZip from "jszip"
+import * as toGeoJSON from "@mapbox/togeojson"
+import L from "leaflet"
+import "leaflet/dist/leaflet.css"
+
+interface KmzPreviewProps {
+  url: string
+}
+
+export function KmzPreview({ url }: KmzPreviewProps) {
+  const mapRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    let map: L.Map | null = null
+    async function load() {
+      if (!mapRef.current) return
+      try {
+        const response = await fetch(url)
+        const arrayBuffer = await response.arrayBuffer()
+        const zip = await JSZip.loadAsync(arrayBuffer)
+        const kmlFileName = Object.keys(zip.files).find((n) => n.endsWith(".kml"))
+        if (!kmlFileName) return
+        const kmlText = await zip.files[kmlFileName].async("text")
+        const dom = new DOMParser().parseFromString(kmlText, "application/xml")
+        const geojson = toGeoJSON.kml(dom)
+        map = L.map(mapRef.current)
+        const layer = L.geoJSON(geojson)
+        const bounds = layer.getBounds()
+        map.fitBounds(bounds)
+        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+          attribution: "&copy; OpenStreetMap contributors",
+        }).addTo(map)
+        layer.addTo(map)
+      } catch (e) {
+        console.error("Error loading KMZ", e)
+      }
+    }
+    load()
+    return () => {
+      if (map) map.remove()
+    }
+  }, [url])
+
+  return <div ref={mapRef} className="w-full h-[70vh]" />
+}
+
+export default KmzPreview

--- a/package.json
+++ b/package.json
@@ -68,12 +68,15 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "latest",
     "zod": "^3.24.1",
-    "swr": "^2.2.0"
+    "swr": "^2.2.0",
+    "@mapbox/togeojson": "^0.16.0",
+    "leaflet": "^1.9.4"
   },
   "devDependencies": {
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/leaflet": "^1.9.7",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
     "ts-node": "^10.9.2",

--- a/types/index.ts
+++ b/types/index.ts
@@ -291,7 +291,7 @@ export interface UploadedFile {
   id: string
   name: string
   size: number
-  type: "image" | "pdf" | "doc" | "video" | "other"
+  type: "image" | "pdf" | "doc" | "video" | "kmz" | "other"
   uploadedAt: string // ISO timestamp when the file was uploaded
   url: string
   cloudUrl?: string

--- a/types/togeojson.d.ts
+++ b/types/togeojson.d.ts
@@ -1,0 +1,3 @@
+declare module "@mapbox/togeojson" {
+  export function kml(doc: Document): any
+}


### PR DESCRIPTION
## Summary
- add KmzPreview component to render maps from KMZ archives
- support KMZ file type across document previews and claim forms

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0d10f590832c9032bdeff2462a1a