### PR TITLE
Integrate repair schedule and details into single section

### DIFF
--- a/components/claim-form/repair-details-section.tsx
+++ b/components/claim-form/repair-details-section.tsx
@@ -557,7 +557,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({
                   <FileText className="h-16 w-16 text-primary" />
                 </div>
               <p className="text-xl font-semibold text-foreground">Brak opisów naprawy</p>
-              <p className="text-muted-foreground">Dodaj pierwszy opis, aby rozpocząć</p>
+              <p className="text-muted-foreground">Dodaj pierwszy opis, aby rozpocząć. Utwórz formularz.</p>
             </div>
           </CardContent>
         </Card>

--- a/components/claim-form/repair-plan-section.tsx
+++ b/components/claim-form/repair-plan-section.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import React from "react"
+import { RepairScheduleSection } from "./repair-schedule-section"
+import { RepairDetailsSection } from "./repair-details-section"
+
+interface RepairPlanSectionProps {
+  eventId: string
+  autoShowRepairForm?: boolean
+  onAutoShowRepairFormHandled?: () => void
+}
+
+export const RepairPlanSection: React.FC<RepairPlanSectionProps> = ({
+  eventId,
+  autoShowRepairForm,
+  onAutoShowRepairFormHandled,
+}) => {
+  return (
+    <div className="space-y-8">
+      <RepairScheduleSection eventId={eventId} />
+      <RepairDetailsSection
+        eventId={eventId}
+        autoShowForm={autoShowRepairForm}
+        onAutoShowFormHandled={onAutoShowRepairFormHandled}
+      />
+    </div>
+  )
+}
+
+export default RepairPlanSection


### PR DESCRIPTION
## Summary
- Combine repair schedule and repair detail forms into new `RepairPlanSection`
- Use unified schedule/repairs card in claim main content
- Clarify empty-state message for repair details

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba13cc42e4832c9e424fccd8345706