### PR TITLE
Fix assigning emails to claims when claim ID missing

### DIFF
--- a/backend/Services/EmailService.cs
+++ b/backend/Services/EmailService.cs
@@ -499,14 +499,32 @@ namespace AutomotiveClaimsApi.Services
 
         public async Task<bool> AssignEmailToClaimAsync(Guid emailId, IEnumerable<Guid> claimIds)
         {
-            var email = await _context.Emails.Include(e => e.EmailClaims).FirstOrDefaultAsync(e => e.Id == emailId);
+            var email = await _context.Emails
+                .Include(e => e.EmailClaims)
+                .FirstOrDefaultAsync(e => e.Id == emailId);
             if (email == null) return false;
 
             foreach (var claimId in claimIds)
             {
+                var claim = await _context.ClientClaims
+                    .FirstOrDefaultAsync(c => c.Id == claimId);
+                if (claim == null)
+                {
+                    continue;
+                }
+
                 if (!email.EmailClaims.Any(ec => ec.ClaimId == claimId))
                 {
-                    email.EmailClaims.Add(new EmailClaim { EmailId = emailId, ClaimId = claimId });
+                    email.EmailClaims.Add(new EmailClaim
+                    {
+                        EmailId = emailId,
+                        ClaimId = claimId
+                    });
+                }
+
+                if (email.EventId == null)
+                {
+                    email.EventId = claim.EventId;
                 }
             }
 


### PR DESCRIPTION
## Summary
- Safely link emails to claims by checking if each claim exists
- Populate email's EventId from linked claim

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba177e8400832cb5db742d1f7d6659