### PR TITLE
Ensure assigning email to claim records event and marks as received

### DIFF
--- a/backend/Services/EmailService.cs
+++ b/backend/Services/EmailService.cs
@@ -522,10 +522,22 @@ namespace AutomotiveClaimsApi.Services
                     });
                 }
 
-                if (email.EventId == null)
-                {
-                    email.EventId = claim.EventId;
-                }
+                // Always associate the email with the event of the claim
+                // so it moves out of the unassigned folder and into "Odebrane".
+                // This also ensures that subsequent reassignments update the
+                // event reference.
+                email.EventId = claim.EventId;
+            }
+
+            // Mark the email as received once it's linked to a claim
+            if (email.Status != "Received")
+            {
+                email.Status = "Received";
+            }
+
+            if (!email.ReceivedAt.HasValue)
+            {
+                email.ReceivedAt = DateTime.UtcNow;
             }
 
             await _context.SaveChangesAsync();


### PR DESCRIPTION
## Summary
- Always tie assigned emails to the claim's event
- Mark emails as received when linked to a claim and set received timestamp

## Testing
- `pnpm test`
- `dotnet test` *(fail: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba194f6058832ca4e699f998ba74e8