### PR TITLE
Allow email text to wrap in claim forms

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -120,7 +120,7 @@ const InfoCard = ({
       {icon && <div className="text-gray-400">{icon}</div>}
       <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">{label}</span>
     </div>
-    <p className="text-sm font-medium text-gray-900 truncate">{value || "Nie określono"}</p>
+    <p className="text-sm font-medium text-gray-900 break-words">{value || "Nie określono"}</p>
   </div>
 )
 

--- a/components/claim-form/transport-claim-summary.tsx
+++ b/components/claim-form/transport-claim-summary.tsx
@@ -32,7 +32,7 @@ const InfoCard = ({ icon, label, value }: { icon?: React.ReactNode; label: strin
       {icon && <div className="text-gray-400">{icon}</div>}
       <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">{label}</span>
     </div>
-    <p className="text-sm font-medium text-gray-900">{value || "Nie określono"}</p>
+    <p className="text-sm font-medium text-gray-900 break-words">{value || "Nie określono"}</p>
   </div>
 )
 


### PR DESCRIPTION
## Summary
- Prevent truncation of email addresses in claim form info cards by allowing text wrapping
- Ensure transport claim summary info cards wrap long values such as email addresses

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba195f5afc832c8665ebc33671249f