### PR TITLE
Add repair type selection to repair details form

### DIFF
--- a/app/api/repair-details/route.ts
+++ b/app/api/repair-details/route.ts
@@ -48,6 +48,7 @@ export async function POST(request: NextRequest) {
       repairEndDate: body.repairEndDate || "",
       otherVehiclesAvailable: body.otherVehiclesAvailable || false,
       otherVehiclesInfo: body.otherVehiclesInfo || "",
+      repairType: body.repairType || "mechanical",
       bodyworkHours: body.bodyworkHours || 0,
       paintingHours: body.paintingHours || 0,
       assemblyHours: body.assemblyHours || 0,

--- a/backend/Controllers/RepairDetailsController.cs
+++ b/backend/Controllers/RepairDetailsController.cs
@@ -53,6 +53,7 @@ namespace AutomotiveClaimsApi.Controllers
                 RepairEndDate = createDto.RepairEndDate,
                 OtherVehiclesAvailable = createDto.OtherVehiclesAvailable,
                 OtherVehiclesInfo = createDto.OtherVehiclesInfo,
+                RepairType = createDto.RepairType,
                 BodyworkHours = createDto.BodyworkHours,
                 PaintingHours = createDto.PaintingHours,
                 AssemblyHours = createDto.AssemblyHours,
@@ -89,6 +90,7 @@ namespace AutomotiveClaimsApi.Controllers
             if (updateDto.RepairEndDate != null) detail.RepairEndDate = updateDto.RepairEndDate;
             if (updateDto.OtherVehiclesAvailable.HasValue) detail.OtherVehiclesAvailable = updateDto.OtherVehiclesAvailable.Value;
             if (updateDto.OtherVehiclesInfo != null) detail.OtherVehiclesInfo = updateDto.OtherVehiclesInfo;
+            if (updateDto.RepairType != null) detail.RepairType = updateDto.RepairType;
             if (updateDto.BodyworkHours.HasValue) detail.BodyworkHours = updateDto.BodyworkHours.Value;
             if (updateDto.PaintingHours.HasValue) detail.PaintingHours = updateDto.PaintingHours.Value;
             if (updateDto.AssemblyHours.HasValue) detail.AssemblyHours = updateDto.AssemblyHours.Value;

--- a/backend/DTOs/CreateRepairDetailDto.cs
+++ b/backend/DTOs/CreateRepairDetailDto.cs
@@ -17,6 +17,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? RepairEndDate { get; set; }
         public bool OtherVehiclesAvailable { get; set; }
         public string? OtherVehiclesInfo { get; set; }
+        public string? RepairType { get; set; }
         public double BodyworkHours { get; set; }
         public double PaintingHours { get; set; }
         public double AssemblyHours { get; set; }

--- a/backend/DTOs/RepairDetailDto.cs
+++ b/backend/DTOs/RepairDetailDto.cs
@@ -19,6 +19,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? RepairEndDate { get; set; }
         public bool OtherVehiclesAvailable { get; set; }
         public string? OtherVehiclesInfo { get; set; }
+        public string? RepairType { get; set; }
         public double BodyworkHours { get; set; }
         public double PaintingHours { get; set; }
         public double AssemblyHours { get; set; }
@@ -48,6 +49,7 @@ namespace AutomotiveClaimsApi.DTOs
                 RepairEndDate = detail.RepairEndDate,
                 OtherVehiclesAvailable = detail.OtherVehiclesAvailable,
                 OtherVehiclesInfo = detail.OtherVehiclesInfo,
+                RepairType = detail.RepairType,
                 BodyworkHours = detail.BodyworkHours,
                 PaintingHours = detail.PaintingHours,
                 AssemblyHours = detail.AssemblyHours,

--- a/backend/DTOs/UpdateRepairDetailDto.cs
+++ b/backend/DTOs/UpdateRepairDetailDto.cs
@@ -17,6 +17,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string? RepairEndDate { get; set; }
         public bool? OtherVehiclesAvailable { get; set; }
         public string? OtherVehiclesInfo { get; set; }
+        public string? RepairType { get; set; }
         public double? BodyworkHours { get; set; }
         public double? PaintingHours { get; set; }
         public double? AssemblyHours { get; set; }

--- a/backend/Models/RepairDetail.cs
+++ b/backend/Models/RepairDetail.cs
@@ -18,6 +18,7 @@ namespace AutomotiveClaimsApi.Models
         public string? RepairEndDate { get; set; }
         public bool OtherVehiclesAvailable { get; set; }
         public string? OtherVehiclesInfo { get; set; }
+        public string? RepairType { get; set; }
         public double BodyworkHours { get; set; }
         public double PaintingHours { get; set; }
         public double AssemblyHours { get; set; }

--- a/components/claim-form/repair-details-section.tsx
+++ b/components/claim-form/repair-details-section.tsx
@@ -57,6 +57,7 @@ const initialFormData: Omit<RepairDetail, "id" | "eventId" | "createdAt" | "upda
   repairEndDate: "",
   otherVehiclesAvailable: false,
   otherVehiclesInfo: "",
+  repairType: "mechanical",
   bodyworkHours: 0,
   paintingHours: 0,
   assemblyHours: 0,
@@ -160,6 +161,7 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({
       repairEndDate: detail.repairEndDate ? detail.repairEndDate.slice(0, 10) : "",
       otherVehiclesAvailable: detail.otherVehiclesAvailable,
       otherVehiclesInfo: detail.otherVehiclesInfo || "",
+      repairType: detail.repairType || "mechanical",
       bodyworkHours: detail.bodyworkHours,
       paintingHours: detail.paintingHours,
       assemblyHours: detail.assemblyHours,
@@ -183,6 +185,15 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({
       console.error("Error deleting repair detail:", error)
       toast({ title: "Błąd", description: "Nie udało się usunąć opisu", variant: "destructive" })
     }
+  }
+
+  const repairTypeLabels: Record<NonNullable<RepairDetail["repairType"]>, string> = {
+    mechanical: "Mechaniczna",
+    bodywork: "Blacharska",
+    painting: "Lakiernicza",
+    electrical: "Elektryczna",
+    assembly: "Montażowa",
+    other: "Inna",
   }
 
   const getStatusBadge = (status: RepairDetail["status"]) => {
@@ -421,6 +432,29 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({
                 </div>
               </div>
 
+              {/* Repair type */}
+              <div className="space-y-4">
+                <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
+                  <Wrench className="h-5 w-5 text-primary" /> Rodzaj naprawy
+                </h3>
+                <Select
+                  value={formData.repairType}
+                  onValueChange={(value) => setFormData((p) => ({ ...p, repairType: value as any }))}
+                >
+                  <SelectTrigger id="repairType" className="rounded-xl border-border">
+                    <SelectValue placeholder="Wybierz rodzaj naprawy" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="mechanical">Mechaniczna</SelectItem>
+                    <SelectItem value="bodywork">Blacharska</SelectItem>
+                    <SelectItem value="painting">Lakiernicza</SelectItem>
+                    <SelectItem value="electrical">Elektryczna</SelectItem>
+                    <SelectItem value="assembly">Montażowa</SelectItem>
+                    <SelectItem value="other">Inna</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
               {/* Work hours */}
               <div className="space-y-4">
                 <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
@@ -624,6 +658,10 @@ export const RepairDetailsSection: React.FC<RepairDetailsSectionProps> = ({
                     <p className="text-xs text-muted-foreground">Zakończenie naprawy</p>
                     <p className="font-medium">{formatDate(detail.repairEndDate)}</p>
                   </div>
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xs text-muted-foreground">Rodzaj naprawy</p>
+                  <p className="font-medium">{repairTypeLabels[detail.repairType ?? "mechanical"]}</p>
                 </div>
                 {detail.damageDescription && (
                   <div className="p-5 bg-muted/50 rounded-2xl">

--- a/lib/api/repair-details.ts
+++ b/lib/api/repair-details.ts
@@ -17,6 +17,17 @@ const repairDetailSchema = z.object({
   repairEndDate: z.string().min(1, "Data zakończenia naprawy jest wymagana"),
   otherVehiclesAvailable: z.boolean(),
   otherVehiclesInfo: z.string().optional().default(""),
+  repairType: z
+    .enum([
+      "mechanical",
+      "bodywork",
+      "painting",
+      "electrical",
+      "assembly",
+      "other",
+    ])
+    .optional()
+    .default("mechanical"),
   bodyworkHours: z.number(),
   paintingHours: z.number(),
   assemblyHours: z.number(),

--- a/lib/repair-details-store.ts
+++ b/lib/repair-details-store.ts
@@ -13,6 +13,7 @@ export interface RepairDetail {
   repairEndDate: string
   otherVehiclesAvailable: boolean
   otherVehiclesInfo: string
+  repairType?: "mechanical" | "bodywork" | "painting" | "electrical" | "assembly" | "other"
   bodyworkHours: number
   paintingHours: number
   assemblyHours: number


### PR DESCRIPTION
## Summary
- add `repairType` field with common repair categories to repair detail schema and backend
- allow selecting repair type in repair details form and display chosen type
- persist repair type through API routes and controller

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba19c3bbd8832c9b3b172a42283d77