### PR TITLE
fix: handle uppercase kml in kmz preview

### DIFF
--- a/components/kmz-preview.tsx
+++ b/components/kmz-preview.tsx
@@ -21,7 +21,9 @@ export function KmzPreview({ url }: KmzPreviewProps) {
         const response = await fetch(url)
         const arrayBuffer = await response.arrayBuffer()
         const zip = await JSZip.loadAsync(arrayBuffer)
-        const kmlFileName = Object.keys(zip.files).find((n) => n.endsWith(".kml"))
+        const kmlFileName = Object.keys(zip.files).find((n) =>
+          n.toLowerCase().endsWith(".kml")
+        )
         if (!kmlFileName) return
         const kmlText = await zip.files[kmlFileName].async("text")
         const dom = new DOMParser().parseFromString(kmlText, "application/xml")


### PR DESCRIPTION
## Summary
- handle KMZ archives containing uppercase KML files during preview

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1c4cf04c832c9492cde7a7aedf81