### PR TITLE
Fix email content formatting with image preview

### DIFF
--- a/components/email/email-inbox.tsx
+++ b/components/email/email-inbox.tsx
@@ -857,6 +857,13 @@ export default function EmailInbox({ claimId, claimNumber, claimInsuranceNumber 
                               key={attachment.id}
                               className="email-attachment-item bg-white border border-gray-200 rounded-md p-3 hover:shadow-md transition-shadow"
                             >
+                              {attachment.contentType?.startsWith("image/") && (
+                                <img
+                                  src={attachment.url}
+                                  alt={attachment.fileName}
+                                  className="mb-2 max-h-48 w-full object-contain rounded"
+                                />
+                              )}
                               <div className="flex items-center gap-3">
                                 <div className="email-attachment-info flex-1 min-w-0">
                                   <div
@@ -893,12 +900,14 @@ export default function EmailInbox({ claimId, claimNumber, claimInsuranceNumber 
                     </div>
                   )}
                 </div>
-
                 <div className="flex-1 overflow-y-auto mt-6">
-                  <article
-                    className="text-[#334155] prose max-w-none"
-                    dangerouslySetInnerHTML={{ __html: selectedEmail.body }}
-                  />
+                  <div className="text-[#334155] prose max-w-none">
+                    {selectedEmail.htmlBody ? (
+                      <div dangerouslySetInnerHTML={{ __html: selectedEmail.htmlBody }} />
+                    ) : (
+                      <div className="whitespace-pre-wrap">{selectedEmail.body}</div>
+                    )}
+                  </div>
                 </div>
               </div>
             </div>

--- a/components/email/email-view.tsx
+++ b/components/email/email-view.tsx
@@ -219,6 +219,13 @@ export const EmailView = ({
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
                   {email.attachments.map((attachment) => (
                     <Card key={attachment.id} className="p-3">
+                      {attachment.type?.startsWith("image/") && (
+                        <img
+                          src={attachment.url || `${API_BASE_URL}/emails/attachment/${attachment.id}`}
+                          alt={attachment.name}
+                          className="mb-2 max-h-48 w-full object-contain rounded"
+                        />
+                      )}
                       <div className="flex items-center justify-between">
                         <div className="flex items-center space-x-2 min-w-0">
                           <Paperclip className="h-4 w-4 text-gray-400 flex-shrink-0" />

--- a/lib/email-service.ts
+++ b/lib/email-service.ts
@@ -17,6 +17,8 @@ export interface EmailDto {
   to: string
   subject: string
   body: string
+  htmlBody?: string
+  isHtml?: boolean
   /**
    * Date string representing when the email was received or sent.
    * The backend returns "receivedAt" for inbound messages and
@@ -72,6 +74,8 @@ class EmailService {
         to: e.to,
         subject: e.subject,
         body: e.body,
+        htmlBody: e.bodyHtml,
+        isHtml: e.isHtml,
         receivedDate: e.receivedAt || e.sentAt || e.createdAt,
         read: e.isRead,
         claimIds: e.claimIds,
@@ -108,6 +112,8 @@ class EmailService {
         to: e.to,
         subject: e.subject,
         body: e.body,
+        htmlBody: e.bodyHtml,
+        isHtml: e.isHtml,
         receivedDate: e.receivedAt || e.sentAt || e.createdAt,
         read: e.isRead,
         claimIds: e.claimIds,
@@ -203,6 +209,8 @@ class EmailService {
         to: e.to,
         subject: e.subject,
         body: e.body,
+        htmlBody: e.bodyHtml,
+        isHtml: e.isHtml,
         receivedDate: e.receivedAt || e.sentAt || e.createdAt,
         read: e.isRead,
         claimIds: e.claimIds,


### PR DESCRIPTION
## Summary
- include HTML body fields in email DTO mapping
- render HTML bodies or plain text in inbox view
- show image attachments directly in email views

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb7e7d243c832c8b1c11bbd4befb77