### PR TITLE
Handle email attachments in single transaction

### DIFF
--- a/backend/Services/EmailService.cs
+++ b/backend/Services/EmailService.cs
@@ -353,7 +353,6 @@ namespace AutomotiveClaimsApi.Services
                 }
 
                 _context.Emails.Add(email);
-                await _context.SaveChangesAsync();
 
                 if (sendEmailDto.Attachments != null)
                 {
@@ -362,8 +361,9 @@ namespace AutomotiveClaimsApi.Services
                         var attachment = await SaveAttachmentAsync(file, email.Id);
                         email.Attachments.Add(attachment);
                     }
-                    await _context.SaveChangesAsync();
                 }
+
+                await _context.SaveChangesAsync();
 
                 return MapEmailToDto(email);
             }


### PR DESCRIPTION
## Summary
- Save outbound emails and their attachments in a single transaction to avoid extra SaveChanges calls

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb015cd2c832c93fba259a43442e0