### PR TITLE
Fix email assignment API route to handle multiple claim IDs

### DIFF
--- a/app/api/emails/assign-to-claim/route.ts
+++ b/app/api/emails/assign-to-claim/route.ts
@@ -4,18 +4,22 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5200/a
 
 export async function POST(request: NextRequest) {
   try {
-    const { emailId, claimId } = await request.json()
+    const { emailId, claimIds } = await request.json()
     const auth = request.headers.get("authorization") ?? ""
 
     const response = await fetch(`${API_BASE_URL}/emails/assign-to-claim`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: auth },
-      body: JSON.stringify({ emailId, claimId }),
+      body: JSON.stringify({ emailId, claimIds }),
     })
 
     if (!response.ok) {
       const errorText = await response.text()
       return NextResponse.json({ error: errorText }, { status: response.status })
+    }
+
+    if (response.status === 204) {
+      return new NextResponse(null, { status: 204 })
     }
 
     const data = await response.json()


### PR DESCRIPTION
## Summary
- Forward claim IDs array when assigning unassigned emails to a claim
- Return proper response when backend sends no content

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7de8107c832caa4943ebcb298b63