### PR TITLE
Preserve cloud URL when assigning email attachments

### DIFF
--- a/components/email/email-section-compact.tsx
+++ b/components/email/email-section-compact.tsx
@@ -320,13 +320,15 @@ export const EmailSection = ({
 
   const handleAssignAttachment = (attachment: EmailAttachment, documentId: string) => {
     const doc = docs.find((d) => d.id === documentId)
+    const url = attachment.url
     const newFile: UploadedFile = {
       id: attachment.id,
       name: attachment.name,
       size: attachment.size,
       type: mapAttachmentType(attachment.type),
       uploadedAt: new Date().toISOString(),
-      url: attachment.url,
+      url,
+      cloudUrl: url,
       category: doc?.name,
       categoryCode: doc?.category,
     }

--- a/components/email/email-section.tsx
+++ b/components/email/email-section.tsx
@@ -171,6 +171,7 @@ export const EmailSection = ({
       type: mapAttachmentType(type),
       uploadedAt: new Date().toISOString(),
       url,
+      cloudUrl: url,
       category: doc?.name,
       categoryCode: doc?.category,
     }


### PR DESCRIPTION
## Summary
- maintain a document's cloud URL when assigning email attachments
- populate cloud URL for attachments in compact email section

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8b2f95fc832caf0d85f775c052df