### PR TITLE
Save email attachments to cloud and document tables

### DIFF
--- a/backend/DTOs/EmailAttachmentDto.cs
+++ b/backend/DTOs/EmailAttachmentDto.cs
@@ -10,6 +10,7 @@ namespace AutomotiveClaimsApi.DTOs
         public string ContentType { get; set; } = string.Empty;
         public long FileSize { get; set; }
         public string FilePath { get; set; } = string.Empty;
+        public string? CloudUrl { get; set; }
         public string? ContentId { get; set; }
         public bool IsInline { get; set; }
         public DateTime CreatedAt { get; set; }

--- a/backend/Services/EmailService.cs
+++ b/backend/Services/EmailService.cs
@@ -247,6 +247,7 @@ namespace AutomotiveClaimsApi.Services
                     ContentType = a.ContentType ?? string.Empty,
                     FileSize = a.FileSize,
                     FilePath = a.FilePath ?? string.Empty,
+                    CloudUrl = a.CloudUrl,
                     CreatedAt = a.CreatedAt,
                 }).ToList()
             };
@@ -268,6 +269,26 @@ namespace AutomotiveClaimsApi.Services
             }
 
             var relativePath = Path.Combine("uploads", "email", uniqueFileName).Replace("\\", "/");
+
+            var email = _context.Emails.Local.FirstOrDefault(e => e.Id == emailId);
+            _context.Documents.Add(new Document
+            {
+                Id = Guid.NewGuid(),
+                EventId = email?.EventId,
+                RelatedEntityId = emailId,
+                RelatedEntityType = "Email",
+                FileName = uniqueFileName,
+                OriginalFileName = file.FileName,
+                FilePath = relativePath,
+                CloudUrl = cloudUrl,
+                FileSize = file.Length,
+                ContentType = file.ContentType,
+                DocumentType = "email",
+                UploadedBy = email?.From ?? "System",
+                Status = "ACTIVE",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            });
 
             return new EmailAttachment
             {
@@ -571,6 +592,7 @@ namespace AutomotiveClaimsApi.Services
                 ContentType = attachment.ContentType ?? string.Empty,
                 FileSize = attachment.FileSize,
                 FilePath = attachment.FilePath ?? string.Empty,
+                CloudUrl = attachment.CloudUrl,
                 CreatedAt = attachment.CreatedAt,
             };
         }
@@ -587,6 +609,7 @@ namespace AutomotiveClaimsApi.Services
                 ContentType = attachment.ContentType ?? string.Empty,
                 FileSize = attachment.FileSize,
                 FilePath = attachment.FilePath ?? string.Empty,
+                CloudUrl = attachment.CloudUrl,
                 CreatedAt = attachment.CreatedAt,
             };
         }

--- a/emailservice/DTOs/EmailAttachmentDto.cs
+++ b/emailservice/DTOs/EmailAttachmentDto.cs
@@ -10,6 +10,7 @@ namespace EmailService.DTOs
         public string ContentType { get; set; } = string.Empty;
         public long FileSize { get; set; }
         public string FilePath { get; set; } = string.Empty;
+        public string? CloudUrl { get; set; }
         public string? ContentId { get; set; }
         public bool IsInline { get; set; }
         public DateTime CreatedAt { get; set; }

--- a/emailservice/Data/EmailDbContext.cs
+++ b/emailservice/Data/EmailDbContext.cs
@@ -10,4 +10,5 @@ public class EmailDbContext : DbContext
     public DbSet<Email> Emails { get; set; } = null!;
     public DbSet<EmailAttachment> EmailAttachments { get; set; } = null!;
     public DbSet<Event> Events { get; set; } = null!;
+    public DbSet<Document> Documents { get; set; } = null!;
 }

--- a/emailservice/EmailClient.cs
+++ b/emailservice/EmailClient.cs
@@ -183,6 +183,25 @@ public class EmailClient
                         CreatedAt = DateTime.UtcNow,
                         UpdatedAt = DateTime.UtcNow
                     });
+
+                    _db.Documents.Add(new Document
+                    {
+                        Id = Guid.NewGuid(),
+                        EventId = evt?.Id,
+                        RelatedEntityId = emailEntity.Id,
+                        RelatedEntityType = "Email",
+                        FileName = Path.GetFileName(data.FilePath),
+                        OriginalFileName = data.FileName,
+                        FilePath = data.FilePath,
+                        CloudUrl = data.CloudUrl,
+                        FileSize = data.FileSize,
+                        ContentType = data.ContentType,
+                        DocumentType = "email",
+                        UploadedBy = emailEntity.From,
+                        Status = "ACTIVE",
+                        CreatedAt = DateTime.UtcNow,
+                        UpdatedAt = DateTime.UtcNow
+                    });
                 }
 
                 _db.Emails.Add(emailEntity);

--- a/emailservice/EmailClient.cs
+++ b/emailservice/EmailClient.cs
@@ -149,6 +149,8 @@ public class EmailClient
             {
                 var emailEntity = new Email
                 {
+                    // Ensure the email has an ID so related documents can reference it
+                    Id = Guid.NewGuid(),
                     Subject = baseEmail.Subject,
                     Body = baseEmail.Body,
                     BodyHtml = baseEmail.BodyHtml,

--- a/emailservice/Models/Document.cs
+++ b/emailservice/Models/Document.cs
@@ -1,0 +1,51 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace EmailService.Models
+{
+    public class Document
+    {
+        [Key]
+        public Guid Id { get; set; }
+
+        public Guid? EventId { get; set; }
+        public Event? Event { get; set; }
+
+        public Guid? RelatedEntityId { get; set; }
+        public string? RelatedEntityType { get; set; }
+
+        [Required]
+        [MaxLength(255)]
+        public string FileName { get; set; } = string.Empty;
+
+        [MaxLength(255)]
+        public string? OriginalFileName { get; set; }
+
+        [Required]
+        [MaxLength(1000)]
+        public string FilePath { get; set; } = string.Empty;
+
+        [MaxLength(1000)]
+        public string? CloudUrl { get; set; }
+
+        public long FileSize { get; set; }
+
+        [MaxLength(100)]
+        public string ContentType { get; set; } = string.Empty;
+
+        [MaxLength(100)]
+        public string? DocumentType { get; set; } = "Other";
+
+        [MaxLength(500)]
+        public string? Description { get; set; }
+
+        [MaxLength(200)]
+        public string UploadedBy { get; set; } = string.Empty;
+
+        public bool IsDeleted { get; set; } = false;
+        public string? Status { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/lib/email-service.ts
+++ b/lib/email-service.ts
@@ -9,6 +9,7 @@ export interface AttachmentDto {
   size: number
   /** Fully qualified URL to download the attachment */
   url: string
+  cloudUrl?: string
 }
 
 export interface EmailDto {
@@ -86,13 +87,17 @@ class EmailService {
         isImportant: e.isImportant,
         isStarred: e.isStarred,
         attachments:
-          e.attachments?.map((a: any) => ({
-            id: a.id,
-            fileName: a.fileName,
-            contentType: a.contentType,
-            size: a.fileSize,
-            url: `${API_BASE_URL}/emails/attachment/${a.id}`,
-          })) || [],
+          e.attachments?.map((a: any) => {
+            const url = a.cloudUrl || `${API_BASE_URL}/emails/attachment/${a.id}`
+            return {
+              id: a.id,
+              fileName: a.fileName,
+              contentType: a.contentType,
+              size: a.fileSize,
+              url,
+              cloudUrl: a.cloudUrl || undefined,
+            }
+          }) || [],
       }))
     } catch (error) {
       console.error("getAllEmails failed:", error)
@@ -125,13 +130,17 @@ class EmailService {
         isImportant: e.isImportant,
         isStarred: e.isStarred,
         attachments:
-          e.attachments?.map((a: any) => ({
-            id: a.id,
-            fileName: a.fileName,
-            contentType: a.contentType,
-            size: a.fileSize,
-            url: `${API_BASE_URL}/emails/attachment/${a.id}`,
-          })) || [],
+          e.attachments?.map((a: any) => {
+            const url = a.cloudUrl || `${API_BASE_URL}/emails/attachment/${a.id}`
+            return {
+              id: a.id,
+              fileName: a.fileName,
+              contentType: a.contentType,
+              size: a.fileSize,
+              url,
+              cloudUrl: a.cloudUrl || undefined,
+            }
+          }) || [],
       }
     } catch (error) {
       console.error(`getEmailById id=${id} failed:`, error)
@@ -223,13 +232,17 @@ class EmailService {
         isImportant: e.isImportant,
         isStarred: e.isStarred,
         attachments:
-          e.attachments?.map((a: any) => ({
-            id: a.id,
-            fileName: a.fileName,
-            contentType: a.contentType,
-            size: a.fileSize,
-            url: `${API_BASE_URL}/emails/attachment/${a.id}`,
-          })) || [],
+          e.attachments?.map((a: any) => {
+            const url = a.cloudUrl || `${API_BASE_URL}/emails/attachment/${a.id}`
+            return {
+              id: a.id,
+              fileName: a.fileName,
+              contentType: a.contentType,
+              size: a.fileSize,
+              url,
+              cloudUrl: a.cloudUrl || undefined,
+            }
+          }) || [],
       }))
     } catch (error) {
       console.error(`getEmailsByEventId eventId=${eventId} failed:`, error)

--- a/types/email.ts
+++ b/types/email.ts
@@ -23,6 +23,7 @@ export interface EmailAttachment {
   size: number
   type: string
   url: string
+  cloudUrl?: string
   file?: File
 }
 


### PR DESCRIPTION
## Summary
- return `cloudUrl` in email attachment DTOs and frontend services
- save email attachments as documents linked to emails
- persist documents for attachments fetched by EmailClient

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`
- `dotnet test backend/AutomotiveClaimsApi.Tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde6de37ac832c8a8f6388e094495b