### PR TITLE
feat: move email attachments to documents

### DIFF
--- a/components/claim-form/claim-main-content.tsx
+++ b/components/claim-form/claim-main-content.tsx
@@ -1558,6 +1558,8 @@ export const ClaimMainContent = ({
                 setUploadedFiles={setUploadedFiles}
                 requiredDocuments={requiredDocuments}
                 setRequiredDocuments={setRequiredDocuments}
+                pendingFiles={pendingFiles}
+                setPendingFiles={setPendingFiles}
               />
             </CardContent>
           </Card>

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -9,8 +9,6 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { renameDocument, notifyClient } from "@/lib/api/documents"
 import { authFetch } from "@/lib/auth-fetch"
 import { generateId } from "@/lib/constants"
-import { emailService } from "@/lib/email-service"
-import { EmailFolder } from "@/types/email"
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -368,38 +366,6 @@ export const DocumentsSection = React.forwardRef<
           }`,
           isEmailAttachment: false,
         }))
-
-        // Load received email attachments assigned to this claim/event
-        try {
-          const emails = await emailService.getEmailsByEventId(
-            eventId,
-            EmailFolder.Inbox,
-          )
-          const emailDocs: Document[] = emails.flatMap((email) =>
-            email.attachments.map((a) => ({
-              id: a.id,
-              eventId,
-              fileName: a.fileName,
-              originalFileName: a.fileName,
-              contentType: a.contentType,
-              fileSize: a.size,
-              filePath: a.url,
-              uploadedBy: email.from,
-              createdAt: email.receivedDate || new Date().toISOString(),
-              updatedAt: email.receivedDate || new Date().toISOString(),
-              status: "",
-              canPreview: true,
-              previewUrl: `${a.url}${token ? `?token=${token}` : ""}`,
-              downloadUrl: `${a.url}${token ? `?token=${token}` : ""}`,
-              documentType: "E-mail",
-              categoryCode: "email",
-              isEmailAttachment: true,
-            }))
-          )
-          mappedDocs = mappedDocs.concat(emailDocs)
-        } catch (err) {
-          console.error("Failed to load email attachments", err)
-        }
 
         setDocuments(mappedDocs)
         setUploadedFiles(

--- a/components/email/email-section-compact.tsx
+++ b/components/email/email-section-compact.tsx
@@ -39,6 +39,8 @@ interface EmailSectionProps {
   setUploadedFiles?: Dispatch<SetStateAction<UploadedFile[]>>
   requiredDocuments?: RequiredDocument[]
   setRequiredDocuments?: Dispatch<SetStateAction<RequiredDocument[]>>
+  pendingFiles?: UploadedFile[]
+  setPendingFiles?: Dispatch<SetStateAction<UploadedFile[]>>
 }
 
 export const EmailSection = ({
@@ -48,6 +50,8 @@ export const EmailSection = ({
   setUploadedFiles,
   requiredDocuments,
   setRequiredDocuments,
+  pendingFiles,
+  setPendingFiles,
 }: EmailSectionProps) => {
   const { toast } = useToast()
   const [emails, setEmails] = useState<Email[]>([])
@@ -136,6 +140,8 @@ export const EmailSection = ({
   const [internalRequiredDocs, setInternalRequiredDocs] = useState<RequiredDocument[]>([])
   const docs = requiredDocuments ?? internalRequiredDocs
   const updateRequiredDocs = setRequiredDocuments ?? setInternalRequiredDocs
+  const [internalPendingFiles, setInternalPendingFiles] = useState<UploadedFile[]>([])
+  const updatePendingFiles = setPendingFiles ?? setInternalPendingFiles
 
   const mapAttachmentType = (type: string): UploadedFile["type"] => {
     if (type.includes("pdf")) return "pdf"
@@ -333,6 +339,7 @@ export const EmailSection = ({
       categoryCode: doc?.category,
     }
     updateDocuments((prev) => [...prev, newFile])
+    updatePendingFiles((prev) => [...prev, newFile])
     updateRequiredDocs((prev) => prev.map((d) => (d.id === documentId ? { ...d, uploaded: true } : d)))
     toast({
       title: "Załącznik przypisany",

--- a/components/email/email-section.tsx
+++ b/components/email/email-section.tsx
@@ -19,6 +19,8 @@ interface EmailSectionProps {
   setUploadedFiles?: Dispatch<SetStateAction<UploadedFile[]>>
   requiredDocuments?: RequiredDocument[]
   setRequiredDocuments?: Dispatch<SetStateAction<RequiredDocument[]>>
+  pendingFiles?: UploadedFile[]
+  setPendingFiles?: Dispatch<SetStateAction<UploadedFile[]>>
 }
 
 export const EmailSection = ({
@@ -28,6 +30,8 @@ export const EmailSection = ({
   setUploadedFiles,
   requiredDocuments,
   setRequiredDocuments,
+  pendingFiles,
+  setPendingFiles,
 }: EmailSectionProps) => {
   const { toast } = useToast()
   const [emails, setEmails] = useState<Email[]>(sampleEmails)
@@ -83,6 +87,9 @@ export const EmailSection = ({
   ])
   const reqDocuments = requiredDocuments ?? internalRequiredDocs
   const updateRequiredDocs = setRequiredDocuments ?? setInternalRequiredDocs
+
+  const [internalPendingFiles, setInternalPendingFiles] = useState<UploadedFile[]>([])
+  const updatePendingFiles = setPendingFiles ?? setInternalPendingFiles
 
   const mapAttachmentType = (type: string): UploadedFile["type"] => {
     if (type.includes("pdf")) return "pdf"
@@ -176,6 +183,7 @@ export const EmailSection = ({
       categoryCode: doc?.category,
     }
     updateDocuments((prev) => [...prev, newFile])
+    updatePendingFiles((prev) => [...prev, newFile])
     updateRequiredDocs((prev) => prev.map((d) => (d.id === documentId ? { ...d, uploaded: true } : d)))
     toast({
       title: "Załącznik przypisany",

--- a/components/email/email-view.tsx
+++ b/components/email/email-view.tsx
@@ -57,7 +57,7 @@ export const EmailView = ({
   onAssignAttachment,
 }: EmailViewProps) => {
   const [showFullHeaders, setShowFullHeaders] = useState(false)
-  const availableDocs = requiredDocuments.filter((d) => d.required && !d.uploaded)
+  const availableDocs = requiredDocuments
   const [imageUrls, setImageUrls] = useState<Record<string, string>>({})
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- stop auto-loading email attachments into documents
- allow moving email attachments to chosen document type
- pass pending files state to email module for document updates

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm add -D eslint` *(fails: GET https://registry.npmjs.org/... 403)*
- `pnpm test`
- `pnpm exec tsc -p tsconfig.json --noEmit` *(fails: type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf300693c832cad9467733bba51ba