### PR TITLE
Fix unassigned email status update

### DIFF
--- a/backend/Services/EmailService.cs
+++ b/backend/Services/EmailService.cs
@@ -561,16 +561,21 @@ namespace AutomotiveClaimsApi.Services
                 email.EventId = claim.EventId;
             }
 
-            // Mark the email as received once it's linked to a claim
+            // Mark the email as received once it's linked to a claim and
+            // ensure it appears in the standard inbox
+            if (string.IsNullOrWhiteSpace(email.Direction))
+            {
+                email.Direction = "Inbound";
+            }
             if (email.Status != "Received")
             {
                 email.Status = "Received";
             }
-
             if (!email.ReceivedAt.HasValue)
             {
                 email.ReceivedAt = DateTime.UtcNow;
             }
+            email.UpdatedAt = DateTime.UtcNow;
 
             await _context.SaveChangesAsync();
             return true;


### PR DESCRIPTION
## Summary
- ensure assigning an email to a claim updates its inbox status and timestamps

## Testing
- `pnpm test`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0a116a1c832c92685e67e8262c72