### PR TITLE
feat(email): allow moving or copying attachments to documents

### DIFF
--- a/backend/Controllers/DocumentsController.cs
+++ b/backend/Controllers/DocumentsController.cs
@@ -164,6 +164,26 @@ namespace AutomotiveClaimsApi.Controllers
             }
         }
 
+        [HttpPost("email-attachment/{attachmentId}")]
+        public async Task<ActionResult<DocumentDto>> CreateFromEmailAttachment(Guid attachmentId, [FromBody] CreateDocumentFromAttachmentDto dto)
+        {
+            try
+            {
+                var documentDto = await _documentService.CreateDocumentFromEmailAttachmentAsync(attachmentId, dto);
+                return CreatedAtAction(nameof(GetDocument), new { id = documentDto.Id }, documentDto);
+            }
+            catch (KeyNotFoundException ex)
+            {
+                _logger.LogWarning(ex, "Attachment not found: {Message}", ex.Message);
+                return NotFound(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error creating document from attachment");
+                return StatusCode(500, new { message = "Internal server error", error = ex.Message });
+            }
+        }
+
         [HttpGet("event/{eventId}")]
         public async Task<IActionResult> GetDocumentsForEvent(Guid eventId)
         {

--- a/backend/DTOs/CreateDocumentFromAttachmentDto.cs
+++ b/backend/DTOs/CreateDocumentFromAttachmentDto.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace AutomotiveClaimsApi.DTOs
+{
+    public class CreateDocumentFromAttachmentDto
+    {
+        public Guid? EventId { get; set; }
+        public Guid? DamageId { get; set; }
+        public Guid? RelatedEntityId { get; set; }
+        public string? RelatedEntityType { get; set; }
+        public string? Category { get; set; }
+        public string? Description { get; set; }
+        public string? UploadedBy { get; set; }
+        /// <summary>
+        /// When true the original email attachment will be deleted after creating the document.
+        /// </summary>
+        public bool Move { get; set; }
+    }
+}

--- a/backend/Services/IDocumentService.cs
+++ b/backend/Services/IDocumentService.cs
@@ -31,6 +31,7 @@ namespace AutomotiveClaimsApi.Services
         Task<DocumentDownloadResult?> GetDocumentAsync(string filePath);
         Task<Stream> GetDocumentStreamAsync(string filePath);
         Task<DocumentDto> UploadDocumentAsync(IFormFile file, string category, string entityId);
+        Task<DocumentDto> CreateDocumentFromEmailAttachmentAsync(Guid attachmentId, CreateDocumentFromAttachmentDto createDto);
     }
 
     public class DocumentDownloadResult

--- a/lib/email-service.ts
+++ b/lib/email-service.ts
@@ -1,6 +1,7 @@
 import { EmailFolder } from "@/types/email"
 import { API_BASE_URL } from "./api"
 import { authFetch } from "./auth-fetch"
+import type { DocumentDto } from "./api"
 
 export interface AttachmentDto {
   id: string
@@ -61,6 +62,28 @@ class EmailService {
     const guidRegex =
       /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
     return guidRegex.test(id)
+  }
+
+  async attachmentToDocument(
+    attachmentId: string,
+    eventId: string,
+    move = false,
+  ): Promise<DocumentDto | null> {
+    try {
+      const res = await authFetch(
+        `${API_BASE_URL}/documents/email-attachment/${attachmentId}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ eventId, move }),
+        },
+      )
+      if (!res.ok) throw new Error("Failed to transfer attachment")
+      return (await res.json()) as DocumentDto
+    } catch (error) {
+      console.error("attachmentToDocument failed:", error)
+      return null
+    }
   }
 
   async getAllEmails(): Promise<EmailDto[]> {


### PR DESCRIPTION
## Summary
- allow backend to create documents from email attachments with optional removal of the source
- expose endpoint and frontend service for transferring attachments into claim documents
- enable inbox UI to copy or move attachments to documents via dropdown

## Testing
- `pnpm test`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0b6b0378832c8d361b59a423c1df