### PR TITLE
feat: remember claim list filters

### DIFF
--- a/app/claims/[id]/edit/page.tsx
+++ b/app/claims/[id]/edit/page.tsx
@@ -147,7 +147,7 @@ export default function EditClaimPage() {
   }
 
   const handleClose = () => {
-    router.push("/claims")
+    router.back()
   }
 
   if (isLoading) {


### PR DESCRIPTION
## Summary
- persist claim list filters in localStorage and restore on mount
- clear stored filters on reset
- use router.back from edit form to return to list

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfe74bbf2c832cb6db595ae86c3718