### PR TITLE
feat: add object type filter for claims

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -78,6 +78,7 @@ namespace AutomotiveClaimsApi.Controllers
             [FromQuery] string? clientId = null,
             [FromQuery] string? status = null,
             [FromQuery] string? riskType = null,
+            [FromQuery] int? claimObjectTypeId = null,
             [FromQuery] string? policyNumber = null,
             [FromQuery] int? caseHandlerId = null,
             [FromQuery] string? registeredById = null,
@@ -157,6 +158,11 @@ namespace AutomotiveClaimsApi.Controllers
                 if (!string.IsNullOrEmpty(riskType))
                 {
                     query = query.Where(e => e.RiskType == riskType);
+                }
+
+                if (claimObjectTypeId.HasValue)
+                {
+                    query = query.Where(e => e.ObjectTypeId == claimObjectTypeId.Value);
                 }
 
                 if (!string.IsNullOrEmpty(policyNumber))

--- a/components/claims-list-desktop.tsx
+++ b/components/claims-list-desktop.tsx
@@ -96,6 +96,9 @@ export function ClaimsListDesktop({
     { id: number; code: string; name: string; color?: string }[]
   >([])
   const [filterRisks, setFilterRisks] = useState<string[]>([])
+  const [filterObjectTypeId, setFilterObjectTypeId] = useState(
+    claimObjectTypeId || "all",
+  )
   const [riskTypes, setRiskTypes] = useState<
     { id: number; code: string; name: string; claimObjectTypeId?: number }[]
   >([])
@@ -127,6 +130,7 @@ export function ClaimsListDesktop({
     () =>
       Boolean(
         searchInput ||
+        filterObjectTypeId !== "all" ||
         filterStatuses.length ||
         filterRisks.length ||
         filterRegistration ||
@@ -137,6 +141,7 @@ export function ClaimsListDesktop({
       ),
     [
       searchInput,
+      filterObjectTypeId,
       filterStatuses,
       filterRisks,
       filterRegistration,
@@ -152,6 +157,7 @@ export function ClaimsListDesktop({
     setSearchTerm("")
     setFilterStatuses([])
     setFilterRisks([])
+    setFilterObjectTypeId("all")
     setFilterRegistration("")
     setFilterHandlerId("")
     setDateFilters([])
@@ -190,6 +196,7 @@ export function ClaimsListDesktop({
         setSearchInput(parsed.searchTerm || "")
         setFilterStatuses(parsed.filterStatuses || [])
         setFilterRisks(parsed.filterRisks || [])
+        setFilterObjectTypeId(parsed.filterObjectTypeId || "all")
         setFilterRegistration(parsed.filterRegistration || "")
         setFilterHandlerId(parsed.filterHandlerId || "")
         setDateFilters(parsed.dateFilters || [])
@@ -211,6 +218,7 @@ export function ClaimsListDesktop({
       searchTerm,
       filterStatuses,
       filterRisks,
+      filterObjectTypeId,
       filterRegistration,
       filterHandlerId,
       dateFilters,
@@ -226,6 +234,7 @@ export function ClaimsListDesktop({
     searchTerm,
     filterStatuses,
     filterRisks,
+    filterObjectTypeId,
     filterRegistration,
     filterHandlerId,
     dateFilters,
@@ -405,7 +414,8 @@ export function ClaimsListDesktop({
             : undefined,
           registeredById:
             showMyClaims && !user?.caseHandlerId ? user?.id : undefined,
-          claimObjectTypeId,
+          claimObjectTypeId:
+            filterObjectTypeId !== "all" ? filterObjectTypeId : undefined,
           sortBy,
           sortOrder,
           reportFromDate: reportFilter?.from || undefined,
@@ -442,7 +452,7 @@ export function ClaimsListDesktop({
     user?.caseHandlerId,
     user?.id,
     dateFilters,
-    claimObjectTypeId,
+    filterObjectTypeId,
     sortBy,
     sortOrder,
     initialClaims,
@@ -559,7 +569,8 @@ export function ClaimsListDesktop({
             : undefined,
           registeredById:
             showMyClaims && !user?.caseHandlerId ? user?.id : undefined,
-          claimObjectTypeId,
+          claimObjectTypeId:
+            filterObjectTypeId !== "all" ? filterObjectTypeId : undefined,
           sortBy,
           sortOrder,
           reportFromDate: reportFilter?.from || undefined,
@@ -706,6 +717,23 @@ export function ClaimsListDesktop({
             )}
           </div>
           <div className="flex gap-2">
+            <Select
+              value={filterObjectTypeId}
+              onValueChange={(value) => {
+                setFilterObjectTypeId(value)
+                setPage(1)
+              }}
+            >
+              <SelectTrigger className="h-9 text-sm bg-white w-[160px]">
+                <SelectValue placeholder="Typ szkody" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Wszystkie typy</SelectItem>
+                <SelectItem value="1">Komunikacyjna</SelectItem>
+                <SelectItem value="2">Majątkowa</SelectItem>
+                <SelectItem value="3">Transportowa</SelectItem>
+              </SelectContent>
+            </Select>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -1169,16 +1197,25 @@ export function ClaimsListDesktop({
                   <Search className="h-8 w-8 text-gray-400" />
                 </div>
                 <h3 className="text-sm font-medium text-gray-900 mb-1">
-                  {searchTerm || filterStatuses.length > 0 || filterRisks.length > 0
+                  {searchTerm ||
+                  filterObjectTypeId !== "all" ||
+                  filterStatuses.length > 0 ||
+                  filterRisks.length > 0
                     ? "Brak szkód spełniających kryteria"
                     : "Brak szkód w systemie"}
                 </h3>
                 <p className="text-sm text-gray-500 mb-4">
-                  {searchTerm || filterStatuses.length > 0 || filterRisks.length > 0
+                  {searchTerm ||
+                  filterObjectTypeId !== "all" ||
+                  filterStatuses.length > 0 ||
+                  filterRisks.length > 0
                     ? "Spróbuj zmienić kryteria wyszukiwania"
                     : "Dodaj pierwszą szkodę, aby rozpocząć"}
                 </p>
-                {!searchTerm && filterStatuses.length === 0 && filterRisks.length === 0 && (
+                {!searchTerm &&
+                filterObjectTypeId === "all" &&
+                filterStatuses.length === 0 &&
+                filterRisks.length === 0 && (
                   <Button className="bg-[#1a3a6c] hover:bg-[#1a3a6c]/90" onClick={onNewClaim || handleNewClaimDirect}>
                     <Plus className="h-4 w-4 mr-2" />
                     Dodaj pierwszą szkodę

--- a/components/mobile/claims-list.tsx
+++ b/components/mobile/claims-list.tsx
@@ -82,6 +82,7 @@ export function ClaimsListMobile({
     { id: number; code: string; name: string; color?: string }[]
   >([])
   const [filterRisk, setFilterRisk] = useState("all")
+  const [filterType, setFilterType] = useState(claimObjectTypeId || "all")
   const [riskTypes, setRiskTypes] = useState<
     { id: number; code: string; name: string; claimObjectTypeId?: number }[]
   >([])
@@ -113,6 +114,7 @@ export function ClaimsListMobile({
         searchInput ||
         filterStatus !== "all" ||
         filterRisk !== "all" ||
+        filterType !== "all" ||
         filterRegistration ||
         filterHandlerId ||
         dateFilters.length ||
@@ -123,6 +125,7 @@ export function ClaimsListMobile({
       searchInput,
       filterStatus,
       filterRisk,
+      filterType,
       filterRegistration,
       filterHandlerId,
       dateFilters,
@@ -136,6 +139,7 @@ export function ClaimsListMobile({
     setSearchTerm("")
     setFilterStatus("all")
     setFilterRisk("all")
+    setFilterType("all")
     setFilterRegistration("")
     setFilterHandlerId("")
     setDateFilters([])
@@ -158,6 +162,7 @@ export function ClaimsListMobile({
         setSearchInput(parsed.searchTerm || "")
         setFilterStatus(parsed.filterStatus || "all")
         setFilterRisk(parsed.filterRisk || "all")
+        setFilterType(parsed.filterType || "all")
         setFilterRegistration(parsed.filterRegistration || "")
         setFilterHandlerId(parsed.filterHandlerId || "")
         setDateFilters(parsed.dateFilters || [])
@@ -179,6 +184,7 @@ export function ClaimsListMobile({
       searchTerm,
       filterStatus,
       filterRisk,
+      filterType,
       filterRegistration,
       filterHandlerId,
       dateFilters,
@@ -194,6 +200,7 @@ export function ClaimsListMobile({
     searchTerm,
     filterStatus,
     filterRisk,
+    filterType,
     filterRegistration,
     filterHandlerId,
     dateFilters,
@@ -367,7 +374,8 @@ export function ClaimsListMobile({
             : undefined,
           registeredById:
             showMyClaims && !user?.caseHandlerId ? user?.id : undefined,
-          claimObjectTypeId,
+          claimObjectTypeId:
+            filterType !== "all" ? filterType : undefined,
           sortBy,
           sortOrder,
           reportFromDate: reportFilter?.from || undefined,
@@ -404,7 +412,7 @@ export function ClaimsListMobile({
     user?.caseHandlerId,
     user?.id,
     dateFilters,
-    claimObjectTypeId,
+    filterType,
     sortBy,
     sortOrder,
     initialClaims,
@@ -517,7 +525,8 @@ export function ClaimsListMobile({
             : undefined,
           registeredById:
             showMyClaims && !user?.caseHandlerId ? user?.id : undefined,
-          claimObjectTypeId,
+          claimObjectTypeId:
+            filterType !== "all" ? filterType : undefined,
           sortBy,
           sortOrder,
           reportFromDate: reportFilter?.from || undefined,
@@ -664,6 +673,19 @@ export function ClaimsListMobile({
             )}
           </div>
           <div className="flex gap-2">
+            <select
+              value={filterType}
+              onChange={(e) => {
+                setFilterType(e.target.value)
+                setPage(1)
+              }}
+              className="px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#1a3a6c] focus:border-[#1a3a6c] bg-white"
+            >
+              <option value="all">Wszystkie typy</option>
+              <option value="1">Komunikacyjna</option>
+              <option value="2">Majątkowa</option>
+              <option value="3">Transportowa</option>
+            </select>
             <select
               value={filterStatus}
               onChange={(e) => setFilterStatus(e.target.value)}
@@ -1000,16 +1022,16 @@ export function ClaimsListMobile({
                   <Search className="h-8 w-8 text-gray-400" />
                 </div>
                 <h3 className="text-sm font-medium text-gray-900 mb-1">
-                  {searchTerm || filterStatus !== "all" || filterRisk !== "all"
+                  {searchTerm || filterStatus !== "all" || filterRisk !== "all" || filterType !== "all"
                     ? "Brak szkód spełniających kryteria"
                     : "Brak szkód w systemie"}
                 </h3>
                 <p className="text-sm text-gray-500 mb-4">
-                  {searchTerm || filterStatus !== "all" || filterRisk !== "all"
+                  {searchTerm || filterStatus !== "all" || filterRisk !== "all" || filterType !== "all"
                     ? "Spróbuj zmienić kryteria wyszukiwania"
                     : "Dodaj pierwszą szkodę, aby rozpocząć"}
                 </p>
-                {!searchTerm && filterStatus === "all" && filterRisk === "all" && (
+                {!searchTerm && filterStatus === "all" && filterRisk === "all" && filterType === "all" && (
                   <Button className="bg-[#1a3a6c] hover:bg-[#1a3a6c]/90" onClick={onNewClaim || handleNewClaimDirect}>
                     <Plus className="h-4 w-4 mr-2" />
                     Dodaj pierwszą szkodę


### PR DESCRIPTION
## Summary
- add optional claim object type filter to claims API
- allow selecting claim type in desktop and mobile lists

## Testing
- `pnpm test`
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bff27dd2d8832cb09e8ad5afb6f88a