### PR TITLE
feat: filter my claims by handler or user

### DIFF
--- a/components/claims-list-desktop.tsx
+++ b/components/claims-list-desktop.tsx
@@ -385,6 +385,16 @@ export function ClaimsListDesktop({
         const insurerReportFilter = dateFilters.find(
           (f) => f.type === "insurerReportDate",
         )
+        const handlerParams = showMyClaims
+          ? user?.caseHandlerId
+            ? { caseHandlerId: user.caseHandlerId }
+            : { registeredById: user?.id }
+          : selectedSubstituteId
+          ? { caseHandlerId: parseInt(selectedSubstituteId, 10) }
+          : filterHandlerId
+          ? { caseHandlerId: parseInt(filterHandlerId, 10) }
+          : {}
+
         await fetchClaims({
           page,
           pageSize,
@@ -396,15 +406,7 @@ export function ClaimsListDesktop({
             ? filterRisks.join(",")
             : undefined,
           brand: filterRegistration || undefined,
-          caseHandlerId: showMyClaims
-            ? user?.caseHandlerId
-            : selectedSubstituteId
-            ? parseInt(selectedSubstituteId, 10)
-            : filterHandlerId
-            ? parseInt(filterHandlerId, 10)
-            : undefined,
-          registeredById:
-            showMyClaims && !user?.caseHandlerId ? user?.id : undefined,
+          ...handlerParams,
           claimObjectTypeId,
           sortBy,
           sortOrder,
@@ -538,6 +540,16 @@ export function ClaimsListDesktop({
       const insurerReportFilter = dateFilters.find(
         (f) => f.type === "insurerReportDate",
       )
+      const handlerParams = showMyClaims
+        ? user?.caseHandlerId
+          ? { caseHandlerId: user.caseHandlerId }
+          : { registeredById: user?.id }
+        : selectedSubstituteId
+        ? { caseHandlerId: parseInt(selectedSubstituteId, 10) }
+        : filterHandlerId
+        ? { caseHandlerId: parseInt(filterHandlerId, 10) }
+        : {}
+
       await fetchClaims(
         {
           page: 1,
@@ -550,15 +562,7 @@ export function ClaimsListDesktop({
             ? filterRisks.join(",")
             : undefined,
           brand: filterRegistration || undefined,
-          caseHandlerId: showMyClaims
-            ? user?.caseHandlerId
-            : selectedSubstituteId
-            ? parseInt(selectedSubstituteId, 10)
-            : filterHandlerId
-            ? parseInt(filterHandlerId, 10)
-            : undefined,
-          registeredById:
-            showMyClaims && !user?.caseHandlerId ? user?.id : undefined,
+          ...handlerParams,
           claimObjectTypeId,
           sortBy,
           sortOrder,

--- a/components/mobile/claims-list.tsx
+++ b/components/mobile/claims-list.tsx
@@ -351,6 +351,16 @@ export function ClaimsListMobile({
         const insurerReportFilter = dateFilters.find(
           (f) => f.type === "insurerReportDate",
         )
+        const handlerParams = showMyClaims
+          ? user?.caseHandlerId
+            ? { caseHandlerId: user.caseHandlerId }
+            : { registeredById: user?.id }
+          : selectedSubstituteId
+          ? { caseHandlerId: parseInt(selectedSubstituteId, 10) }
+          : filterHandlerId
+          ? { caseHandlerId: parseInt(filterHandlerId, 10) }
+          : {}
+
         await fetchClaims({
           page,
           pageSize,
@@ -358,15 +368,7 @@ export function ClaimsListMobile({
           status: filterStatus !== "all" ? filterStatus : undefined,
           riskType: filterRisk !== "all" ? filterRisk : undefined,
           brand: filterRegistration || undefined,
-          caseHandlerId: showMyClaims
-            ? user?.caseHandlerId
-            : selectedSubstituteId
-            ? parseInt(selectedSubstituteId, 10)
-            : filterHandlerId
-            ? parseInt(filterHandlerId, 10)
-            : undefined,
-          registeredById:
-            showMyClaims && !user?.caseHandlerId ? user?.id : undefined,
+          ...handlerParams,
           claimObjectTypeId,
           sortBy,
           sortOrder,
@@ -500,6 +502,16 @@ export function ClaimsListMobile({
       const insurerReportFilter = dateFilters.find(
         (f) => f.type === "insurerReportDate",
       )
+      const handlerParams = showMyClaims
+        ? user?.caseHandlerId
+          ? { caseHandlerId: user.caseHandlerId }
+          : { registeredById: user?.id }
+        : selectedSubstituteId
+        ? { caseHandlerId: parseInt(selectedSubstituteId, 10) }
+        : filterHandlerId
+        ? { caseHandlerId: parseInt(filterHandlerId, 10) }
+        : {}
+
       await fetchClaims(
         {
           page: 1,
@@ -508,15 +520,7 @@ export function ClaimsListMobile({
           status: filterStatus !== "all" ? filterStatus : undefined,
           riskType: filterRisk !== "all" ? filterRisk : undefined,
           brand: filterRegistration || undefined,
-          caseHandlerId: showMyClaims
-            ? user?.caseHandlerId
-            : selectedSubstituteId
-            ? parseInt(selectedSubstituteId, 10)
-            : filterHandlerId
-            ? parseInt(filterHandlerId, 10)
-            : undefined,
-          registeredById:
-            showMyClaims && !user?.caseHandlerId ? user?.id : undefined,
+          ...handlerParams,
           claimObjectTypeId,
           sortBy,
           sortOrder,


### PR DESCRIPTION
## Summary
- show "Moje szkody" by case handler when assigned
- fall back to registeredBy user when no case handler

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint must be installed; pnpm add -D eslint fails: ERR_PNPM_FETCH_403)*

------
https://chatgpt.com/codex/tasks/task_e_68bff3614b5c832cb3245cdd3599e7e8