### PR TITLE
feat: add no status and no risk filters

### DIFF
--- a/backend/Controllers/ClaimsController.cs
+++ b/backend/Controllers/ClaimsController.cs
@@ -149,14 +149,53 @@ namespace AutomotiveClaimsApi.Controllers
                     query = query.Where(e => e.ClientId == clientIdValue);
                 }
 
-                if (!string.IsNullOrEmpty(status) && int.TryParse(status, out var statusId))
+                if (!string.IsNullOrEmpty(status))
                 {
-                    query = query.Where(e => e.ClaimStatusId == statusId);
+                    var parts = status.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                    var includeNull = parts.Any(p => p.Equals("null", StringComparison.OrdinalIgnoreCase));
+                    var ids = parts
+                        .Where(p => int.TryParse(p, out _))
+                        .Select(int.Parse)
+                        .ToList();
+
+                    if (ids.Any() && includeNull)
+                    {
+                        query = query.Where(e =>
+                            (e.ClaimStatusId != null && ids.Contains(e.ClaimStatusId.Value)) ||
+                            e.ClaimStatusId == null);
+                    }
+                    else if (ids.Any())
+                    {
+                        query = query.Where(e => e.ClaimStatusId != null && ids.Contains(e.ClaimStatusId.Value));
+                    }
+                    else if (includeNull)
+                    {
+                        query = query.Where(e => e.ClaimStatusId == null);
+                    }
                 }
 
                 if (!string.IsNullOrEmpty(riskType))
                 {
-                    query = query.Where(e => e.RiskType == riskType);
+                    var parts = riskType.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                    var includeNull = parts.Any(p => p.Equals("null", StringComparison.OrdinalIgnoreCase));
+                    var types = parts
+                        .Where(p => !p.Equals("null", StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+
+                    if (types.Any() && includeNull)
+                    {
+                        query = query.Where(e =>
+                            (e.RiskType != null && types.Contains(e.RiskType)) ||
+                            e.RiskType == null);
+                    }
+                    else if (types.Any())
+                    {
+                        query = query.Where(e => e.RiskType != null && types.Contains(e.RiskType));
+                    }
+                    else if (includeNull)
+                    {
+                        query = query.Where(e => e.RiskType == null);
+                    }
                 }
 
                 if (!string.IsNullOrEmpty(policyNumber))

--- a/components/claims-list-desktop.tsx
+++ b/components/claims-list-desktop.tsx
@@ -717,11 +717,24 @@ export function ClaimsListDesktop({
                     ? claimStatuses
                         .filter((s) => filterStatuses.includes(s.id.toString()))
                         .map((s) => s.name)
+                        .concat(
+                          filterStatuses.includes("null")
+                            ? ["Brak statusu"]
+                            : [],
+                        )
                         .join(", ")
                     : "Wszystkie statusy"}
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent className="max-h-64 overflow-y-auto">
+                <DropdownMenuCheckboxItem
+                  key="null-status"
+                  checked={filterStatuses.includes("null")}
+                  onCheckedChange={() => toggleStatus("null")}
+                >
+                  Brak statusu
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuSeparator />
                 {claimStatuses.map((status) => (
                   <DropdownMenuCheckboxItem
                     key={status.id}
@@ -746,11 +759,22 @@ export function ClaimsListDesktop({
                     ? riskTypes
                         .filter((r) => filterRisks.includes(r.id.toString()))
                         .map((r) => r.name)
+                        .concat(
+                          filterRisks.includes("null") ? ["Brak ryzyka"] : [],
+                        )
                         .join(", ")
                     : "Wszystkie ryzyka"}
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent className="max-h-64 overflow-y-auto">
+                <DropdownMenuCheckboxItem
+                  key="null-risk"
+                  checked={filterRisks.includes("null")}
+                  onCheckedChange={() => toggleRisk("null")}
+                >
+                  Brak ryzyka
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuSeparator />
                 {[1, 2, 3].map((type) => {
                   const grouped = riskTypes.filter(
                     (r) => r.claimObjectTypeId === type,

--- a/components/mobile/claims-list.tsx
+++ b/components/mobile/claims-list.tsx
@@ -670,6 +670,7 @@ export function ClaimsListMobile({
               className="px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#1a3a6c] focus:border-[#1a3a6c] bg-white"
             >
               <option value="all">Wszystkie statusy</option>
+              <option value="null">Brak statusu</option>
               {claimStatuses.map((status) => (
                 <option key={status.id} value={status.id.toString()}>
                   {status.name}
@@ -682,6 +683,7 @@ export function ClaimsListMobile({
               className="px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#1a3a6c] focus:border-[#1a3a6c] bg-white"
             >
               <option value="all">Wszystkie ryzyka</option>
+              <option value="null">Brak ryzyka</option>
               {[1, 2, 3].map((type) => {
                 const grouped = riskTypes.filter(
                   (r) => r.claimObjectTypeId === type,


### PR DESCRIPTION
## Summary
- allow filtering claims without a status or risk on desktop and mobile lists
- handle multiple and `null` status/risk filters in Claims API

## Testing
- `npm test`
- `dotnet test` *(fails: command not found)*
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bff43c424c832cad96c7c1e536bcfe