### PR TITLE
Fix document preview navigation across categories

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -1844,7 +1844,7 @@ export const DocumentsSection = React.forwardRef<
                                       variant="ghost"
                                       size="icon"
                                       className="h-7 w-7"
-                                      onClick={() => void handlePreview(doc, documentsForCategory)}
+                                      onClick={() => void handlePreview(doc)}
                                     >
                                       <Eye className="h-4 w-4" />
                                     </Button>


### PR DESCRIPTION
## Summary
- Allow previewing all uploaded documents instead of limiting to current category

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint must be installed: pnpm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68c0590298a0832cbb9a7396efc63591