### PR TITLE
Allow preview navigation across document sections

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -1844,7 +1844,7 @@ export const DocumentsSection = React.forwardRef<
                                       variant="ghost"
                                       size="icon"
                                       className="h-7 w-7"
-                                      onClick={() => void handlePreview(doc, documentsForCategory)}
+                                      onClick={() => void handlePreview(doc)}
                                     >
                                       <Eye className="h-4 w-4" />
                                     </Button>


### PR DESCRIPTION
## Summary
- allow document preview to navigate through all visible files instead of just current section

## Testing
- `pnpm test`
- `pnpm lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0587a8bc8832c9f269d2cedd6aca7