### PR TITLE
Make document names open preview

### DIFF
--- a/components/claim-form/appeals-section.tsx
+++ b/components/claim-form/appeals-section.tsx
@@ -634,12 +634,14 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
                         >
                           <div className="flex items-center gap-2">
                             <FileText className="h-4 w-4 text-[#1a3a6c]" />
-                            <span
-                              className="text-sm font-medium truncate max-w-60"
+                            <button
+                              type="button"
+                              onClick={() => previewFile(currentAppeal, doc)}
+                              className="text-sm font-medium truncate max-w-60 text-blue-600 hover:underline text-left"
                               title={doc.originalFileName || doc.fileName}
                             >
                               {doc.originalFileName || doc.fileName}
-                            </span>
+                            </button>
                           </div>
                           <div className="flex gap-1">
                             {isPreviewable(doc.originalFileName || doc.fileName) && (
@@ -935,12 +937,14 @@ export const AppealsSection = ({ claimId }: AppealsSectionProps) => {
                             const doc = appeal.documents[0]
                             return (
                               <div key={doc.id} className="flex items-center gap-2">
-                                <span
-                                  className="text-gray-700 truncate max-w-32"
+                                <button
+                                  type="button"
+                                  onClick={() => previewFile(appeal, doc)}
+                                  className="text-gray-700 truncate max-w-32 text-blue-600 hover:underline text-left"
                                   title={doc.originalFileName || doc.fileName}
                                 >
                                   {doc.originalFileName || doc.fileName}
-                                </span>
+                                </button>
                                 <div className="flex gap-1">
                                   {isPreviewable(doc.originalFileName || doc.fileName) && (
                                     <Button

--- a/components/claim-form/client-claims-section.tsx
+++ b/components/claim-form/client-claims-section.tsx
@@ -734,9 +734,13 @@ export function ClientClaimsSection({ clientClaims, onClientClaimsChange, claimI
                         >
                           <div className="flex items-center space-x-2">
                             <FileText className="h-4 w-4 text-blue-600" />
-                            <span className="text-sm font-medium">
+                            <button
+                              type="button"
+                              onClick={() => previewFile(editingClaim, doc)}
+                              className="text-sm font-medium text-blue-600 hover:underline"
+                            >
                               {doc.originalFileName || doc.fileName}
-                            </span>
+                            </button>
                           </div>
                           <div className="flex gap-1">
                             {isPreviewable(doc.originalFileName || doc.fileName || "") && (

--- a/components/claim-form/decisions-section.tsx
+++ b/components/claim-form/decisions-section.tsx
@@ -703,9 +703,13 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
                         >
                           <div className="flex items-center gap-2">
                             <FileText className="h-4 w-4 text-primary" />
-                            <span className="text-sm font-medium">
+                            <button
+                              type="button"
+                              onClick={() => previewFile(currentDecision, doc)}
+                              className="text-sm font-medium text-blue-600 hover:underline"
+                            >
                               {doc.originalFileName || doc.fileName}
-                            </span>
+                            </button>
                           </div>
                           <div className="flex gap-1">
                             {isPreviewable(doc.originalFileName || doc.fileName || "") && (
@@ -733,9 +737,13 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
                       <div className="p-3 bg-muted rounded-lg border flex items-center justify-between">
                         <div className="flex items-center gap-2">
                           <FileText className="h-4 w-4 text-primary" />
-                          <span className="text-sm font-medium">
+                          <button
+                            type="button"
+                            onClick={() => previewFile(currentDecision)}
+                            className="text-sm font-medium text-blue-600 hover:underline"
+                          >
                             {getDisplayFileName(currentDecision)}
-                          </span>
+                          </button>
                         </div>
                         <div className="flex gap-1">
                           {isPreviewable(getDisplayFileName(currentDecision)) && (
@@ -986,9 +994,13 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
                           return (
                             <div className="flex items-center gap-2">
                               <FileText className="h-4 w-4 text-primary" />
-                              <span className="text-sm font-medium">
+                              <button
+                                type="button"
+                                onClick={() => previewFile(decision, doc)}
+                                className="text-sm font-medium text-blue-600 hover:underline"
+                              >
                                 {doc.originalFileName || doc.fileName}
-                              </span>
+                              </button>
                               <div className="flex gap-1">
                                 {isPreviewable(doc.originalFileName || doc.fileName || "") && (
                                   <Button
@@ -1018,7 +1030,13 @@ export function DecisionsSection({ claimId, onChange }: DecisionsSectionProps) {
                           return (
                             <div className="flex items-center gap-2">
                               <FileText className="h-4 w-4 text-primary" />
-                              <span className="text-sm font-medium">{name}</span>
+                              <button
+                                type="button"
+                                onClick={() => previewFile(decision)}
+                                className="text-sm font-medium text-blue-600 hover:underline"
+                              >
+                                {name}
+                              </button>
                               <div className="flex gap-1">
                                 {isPreviewable(name) && (
                                   <Button

--- a/components/claim-form/recourse-section.tsx
+++ b/components/claim-form/recourse-section.tsx
@@ -679,9 +679,13 @@ export function RecourseSection({ eventId }: RecourseSectionProps) {
                       >
                         <div className="flex items-center gap-2">
                           <FileText className="h-4 w-4 text-[#1a3a6c]" />
-                          <span className="text-sm font-medium">
+                          <button
+                            type="button"
+                            onClick={() => previewFile(currentRecourse, doc)}
+                            className="text-sm font-medium text-blue-600 hover:underline"
+                          >
                             {doc.originalFileName || doc.fileName}
-                          </span>
+                          </button>
                         </div>
                         <div className="flex gap-1">
                           {isPreviewable(doc.originalFileName || doc.fileName || "") && (

--- a/components/claim-form/settlements-section.tsx
+++ b/components/claim-form/settlements-section.tsx
@@ -669,9 +669,13 @@ export const SettlementsSection: React.FC<SettlementsSectionProps> = ({ eventId 
                         >
                           <div className="flex items-center gap-2">
                             <FileText className="text-[#1a3a6c] h-4 w-4" />
-                            <span className="text-sm font-medium">
+                            <button
+                              type="button"
+                              onClick={() => previewFile(currentSettlement, doc)}
+                              className="text-sm font-medium text-blue-600 hover:underline"
+                            >
                               {doc.originalFileName || doc.fileName}
-                            </span>
+                            </button>
                           </div>
                           <div className="flex gap-1">
                             {isPreviewable(doc.originalFileName || doc.fileName || "") && (

--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -1406,9 +1406,14 @@ export const DocumentsSection = React.forwardRef<
           />
         ) : (
           <div className="flex items-center gap-2 mb-1">
-            <span className="text-sm truncate" title={doc.originalFileName}>
+            <button
+              type="button"
+              onClick={() => void handlePreview(doc)}
+              className="text-sm truncate text-blue-600 hover:underline"
+              title={doc.originalFileName}
+            >
               {doc.originalFileName}
-            </span>
+            </button>
             <Button
               variant="ghost"
               size="sm"
@@ -1742,7 +1747,15 @@ export const DocumentsSection = React.forwardRef<
                                 <td className="p-3 font-medium flex items-center gap-2">
                                   {getFileIcon(doc.contentType)}
                                   {doc.isEmailAttachment ? (
-                                    <span className="truncate">{doc.originalFileName}</span>
+                                    <button
+                                      type="button"
+                                      onClick={() =>
+                                        void handlePreview(doc, documentsForCategory)
+                                      }
+                                      className="truncate text-blue-600 hover:underline"
+                                    >
+                                      {doc.originalFileName}
+                                    </button>
                                   ) : editingDocId === doc.id ? (
                                     <Input
                                       value={doc.originalFileName}
@@ -1762,9 +1775,15 @@ export const DocumentsSection = React.forwardRef<
                                     />
                                   ) : (
                                     <div className="flex items-center gap-2">
-                                      <span className="truncate">
+                                      <button
+                                        type="button"
+                                        onClick={() =>
+                                          void handlePreview(doc, documentsForCategory)
+                                        }
+                                        className="truncate text-blue-600 hover:underline"
+                                      >
                                         {doc.originalFileName}
-                                      </span>
+                                      </button>
                                       <Button
                                         variant="ghost"
                                         size="icon"


### PR DESCRIPTION
## Summary
- Render document names as clickable links that open the document preview across claim sections, including the general documents area

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c054f045d4832c8f91da9ad558dbae