### PR TITLE
feat: use env API URL for mobile client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-# Base URL for backend API used by both the server and browser
+# Base URL for backend API used by both the server and browser.
+# When building with Docker this value is passed as a build argument.
 NEXT_PUBLIC_API_URL=http://localhost:5200/api
 
 # Optional: number of times to retry requests to the backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Multi-stage Dockerfile for Next.js application
+FROM node:20-alpine AS deps
+WORKDIR /app
+# Enable corepack to use pnpm
+RUN corepack enable
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+RUN corepack enable
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+RUN pnpm build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+RUN corepack enable
+ENV NODE_ENV=production
+COPY --from=builder /app .
+EXPOSE 3000
+CMD ["pnpm","start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.9"
+services:
+  api:
+    build: ./backend
+    ports:
+      - "5200:5200"
+  frontend:
+    build:
+      context: .
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:5200/api}
+    environment:
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:5200/api}
+    ports:
+      - "3000:3000"
+    depends_on:
+      - api

--- a/mobile/main.tsx
+++ b/mobile/main.tsx
@@ -16,6 +16,9 @@ function urlBase64ToUint8Array(base64String: string) {
 }
 
 function getApiBaseUrl() {
+  if (process.env.NEXT_PUBLIC_API_URL) {
+    return process.env.NEXT_PUBLIC_API_URL;
+  }
   if (typeof window === "undefined") return "/api";
   return window.location.origin.includes("localhost")
     ? "http://localhost:5200/api"

--- a/public/mobile-sw.js
+++ b/public/mobile-sw.js
@@ -4,9 +4,13 @@ const seenIds = new Set();
 // Determine the API base URL. When developing locally the API runs on
 // a different port, while in production it is served from the same
 // origin under the `/api` path.
-const API_BASE_URL = self.location.origin.includes("localhost")
-  ? "http://localhost:5200/api"
-  : "/api";
+const API_BASE_URL =
+  (typeof process !== "undefined" &&
+    process.env &&
+    process.env.NEXT_PUBLIC_API_URL) ||
+  (self.location.origin.includes("localhost")
+    ? "http://localhost:5200/api"
+    : "/api");
 
 async function broadcast(notification) {
   const clients = await self.clients.matchAll({


### PR DESCRIPTION
## Summary
- allow mobile frontend to use NEXT_PUBLIC_API_URL
- check environment variable in mobile service worker
- add Dockerfile and compose config passing NEXT_PUBLIC_API_URL
- document Docker build arg in .env.example

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a603f578832ca093c6fc30b980d1