### PR TITLE
Increase document preview container height

### DIFF
--- a/components/documents-section.tsx
+++ b/components/documents-section.tsx
@@ -2108,7 +2108,7 @@ export const DocumentsSection = React.forwardRef<
 
               {/* Content area */}
               <div
-                className={`flex justify-center items-center overflow-auto ${previewFullscreen ? "h-[calc(100vh-80px)]" : "max-h-[calc(95vh-80px)]"} bg-gray-100`}
+                className={`flex justify-center items-center overflow-auto ${previewFullscreen ? "h-[calc(100vh-80px)]" : "h-[895px]"} bg-gray-100`}
               >
                 {previewDocument.contentType.startsWith("image/") ? (
                   <div className="flex justify-center items-center w-full h-full p-4">


### PR DESCRIPTION
## Summary
- set document preview area to fixed 895px height when not fullscreen

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0c359db8c832cbd6720b3bac00668